### PR TITLE
GH-44: Refactor tests and planner logic to streamline trace/span ID handling and unify `cloud_account_id` usage.

### DIFF
--- a/config/docker/log.sql
+++ b/config/docker/log.sql
@@ -10,182 +10,152 @@ INSERT INTO icegate.logs (
     ingested_timestamp,
     trace_id,
     span_id,
-    severity_number,
     severity_text,
     body,
-    attributes,
-    flags,
-    dropped_attributes_count
+    attributes
 ) VALUES
 -- Row 1: NOW - 9 minutes (oldest)
 (
-    'anonymous',
+    'default',
     'account-001',
     'api-gateway',
     current_timestamp - INTERVAL '9' MINUTE,
     current_timestamp - INTERVAL '9' MINUTE,
     current_timestamp - INTERVAL '9' MINUTE,
-    from_hex('0123456789abcdef0123456789abcdef'),
-    from_hex('0123456789abcdef'),
-    9,
+    '0123456789abcdef0123456789abcdef',
+    '0123456789abcdef',
     'INFO',
     '{"method": "GET", "path": "/api/v1/users", "status": 200, "latency_ms": 45}',
-    MAP(ARRAY['http_method', 'http_status_code', 'http_url', 'environment'], ARRAY['GET', '200', '/api/v1/users', 'production']),
-    0,
-    0
+    MAP(ARRAY['http_method', 'http_status_code', 'http_url', 'environment', 'cloud_account_id', 'service_name', 'trace_id', 'span_id', 'severity_text', 'level'], ARRAY['GET', '200', '/api/v1/users', 'production', 'account-001', 'api-gateway', '0123456789abcdef0123456789abcdef', '0123456789abcdef', 'INFO', 'INFO'])
 ),
 -- Row 2: NOW - 8 minutes
 (
-    'anonymous',
+    'default',
     'account-001',
     'user-service',
     current_timestamp - INTERVAL '8' MINUTE,
     current_timestamp - INTERVAL '8' MINUTE,
     current_timestamp - INTERVAL '8' MINUTE,
-    from_hex('fedcba9876543210fedcba9876543210'),
-    from_hex('fedcba9876543210'),
-    13,
+    'fedcba9876543210fedcba9876543210',
+    'fedcba9876543210',
     'WARN',
     '{"message": "Database connection pool running low", "available": 2, "max": 10}',
-    MAP(ARRAY['db_system', 'db_name', 'pool_available', 'environment'], ARRAY['postgresql', 'users', '2', 'production']),
-    0,
-    0
+    MAP(ARRAY['db_system', 'db_name', 'pool_available', 'environment', 'cloud_account_id', 'service_name', 'trace_id', 'span_id', 'severity_text', 'level'], ARRAY['postgresql', 'users', '2', 'production', 'account-001', 'user-service', 'fedcba9876543210fedcba9876543210', 'fedcba9876543210', 'WARN', 'WARN'])
 ),
 -- Row 3: NOW - 7 minutes
 (
-    'anonymous',
+    'default',
     'account-002',
     'payment-service',
     current_timestamp - INTERVAL '7' MINUTE,
     current_timestamp - INTERVAL '7' MINUTE,
     current_timestamp - INTERVAL '7' MINUTE,
-    from_hex('abcdef0123456789abcdef0123456789'),
-    from_hex('abcdef01234567ab'),
-    17,
+    'abcdef0123456789abcdef0123456789',
+    'abcdef01234567ab',
     'ERROR',
     '{"error": "Payment gateway timeout", "transaction_id": "txn-12345", "retry_count": 3}',
-    MAP(ARRAY['payment_gateway', 'payment_amount', 'payment_currency', 'environment'], ARRAY['stripe', '99.99', 'USD', 'production']),
-    0,
-    0
+    MAP(ARRAY['payment_gateway', 'payment_amount', 'payment_currency', 'environment', 'cloud_account_id', 'service_name', 'trace_id', 'span_id', 'severity_text', 'level'], ARRAY['stripe', '99.99', 'USD', 'production', 'account-002', 'payment-service', 'abcdef0123456789abcdef0123456789', 'abcdef01234567ab', 'ERROR', 'ERROR'])
 ),
 -- Row 4: NOW - 6 minutes
 (
-    'anonymous',
+    'default',
     'account-001',
     'api-gateway',
     current_timestamp - INTERVAL '6' MINUTE,
     current_timestamp - INTERVAL '6' MINUTE,
     current_timestamp - INTERVAL '6' MINUTE,
-    from_hex('1111111111111111aaaaaaaaaaaaaaaa'),
-    from_hex('1111111111111111'),
-    9,
+    '1111111111111111aaaaaaaaaaaaaaaa',
+    '1111111111111111',
     'INFO',
     '{"method": "POST", "path": "/api/v1/orders", "status": 201, "latency_ms": 120}',
-    MAP(ARRAY['http_method', 'http_status_code', 'http_url', 'environment'], ARRAY['POST', '201', '/api/v1/orders', 'production']),
-    0,
-    0
+    MAP(ARRAY['http_method', 'http_status_code', 'http_url', 'environment', 'cloud_account_id', 'service_name', 'trace_id', 'span_id', 'severity_text', 'level'], ARRAY['POST', '201', '/api/v1/orders', 'production', 'account-001', 'api-gateway', '1111111111111111aaaaaaaaaaaaaaaa', '1111111111111111', 'INFO', 'INFO'])
 ),
 -- Row 5: NOW - 5 minutes
 (
-    'anonymous',
+    'default',
     'account-003',
     'inventory-service',
     current_timestamp - INTERVAL '5' MINUTE,
     current_timestamp - INTERVAL '5' MINUTE,
     current_timestamp - INTERVAL '5' MINUTE,
-    from_hex('2222222222222222bbbbbbbbbbbbbbbb'),
-    from_hex('2222222222222222'),
-    5,
+    '2222222222222222bbbbbbbbbbbbbbbb',
+    '2222222222222222',
     'DEBUG',
     '{"action": "stock_check", "product_id": "SKU-789", "quantity": 150}',
-    MAP(ARRAY['inventory_sku', 'inventory_warehouse', 'environment'], ARRAY['SKU-789', 'WH-01', 'staging']),
-    0,
-    0
+    MAP(ARRAY['inventory_sku', 'inventory_warehouse', 'environment', 'cloud_account_id', 'service_name', 'trace_id', 'span_id', 'severity_text', 'level'], ARRAY['SKU-789', 'WH-01', 'staging', 'account-003', 'inventory-service', '2222222222222222bbbbbbbbbbbbbbbb', '2222222222222222', 'DEBUG', 'DEBUG'])
 ),
 -- Row 6: NOW - 4 minutes
 (
-    'anonymous',
+    'default',
     'account-001',
     'notification-service',
     current_timestamp - INTERVAL '4' MINUTE,
     current_timestamp - INTERVAL '4' MINUTE,
     current_timestamp - INTERVAL '4' MINUTE,
-    from_hex('3333333333333333cccccccccccccccc'),
-    from_hex('3333333333333333'),
-    9,
+    '3333333333333333cccccccccccccccc',
+    '3333333333333333',
     'INFO',
     '{"type": "email", "recipient": "user@example.com", "template": "order_confirmation", "sent": true}',
-    MAP(ARRAY['notification_type', 'notification_status', 'environment'], ARRAY['email', 'sent', 'production']),
-    0,
-    0
+    MAP(ARRAY['notification_type', 'notification_status', 'environment', 'cloud_account_id', 'service_name', 'trace_id', 'span_id', 'severity_text', 'level'], ARRAY['email', 'sent', 'production', 'account-001', 'notification-service', '3333333333333333cccccccccccccccc', '3333333333333333', 'INFO', 'INFO'])
 ),
 -- Row 7: NOW - 3 minutes
 (
-    'anonymous',
+    'default',
     'account-003',
     'auth-service',
     current_timestamp - INTERVAL '3' MINUTE,
     current_timestamp - INTERVAL '3' MINUTE,
     current_timestamp - INTERVAL '3' MINUTE,
-    from_hex('4444444444444444dddddddddddddddd'),
-    from_hex('4444444444444444'),
-    13,
+    '4444444444444444dddddddddddddddd',
+    '4444444444444444',
     'WARN',
     '{"event": "failed_login", "user_id": "user-456", "ip": "192.168.1.100", "attempts": 3}',
-    MAP(ARRAY['auth_event', 'auth_ip', 'auth_user_agent', 'environment'], ARRAY['failed_login', '192.168.1.100', 'Mozilla/5.0', 'production']),
-    0,
-    0
+    MAP(ARRAY['auth_event', 'auth_ip', 'auth_user_agent', 'environment', 'cloud_account_id', 'service_name', 'trace_id', 'span_id', 'severity_text', 'level'], ARRAY['failed_login', '192.168.1.100', 'Mozilla/5.0', 'production', 'account-003', 'auth-service', '4444444444444444dddddddddddddddd', '4444444444444444', 'WARN', 'WARN'])
 ),
 -- Row 8: NOW - 2 minutes
 (
-    'anonymous',
+    'default',
     'account-002',
     'search-service',
     current_timestamp - INTERVAL '2' MINUTE,
     current_timestamp - INTERVAL '2' MINUTE,
     current_timestamp - INTERVAL '2' MINUTE,
-    from_hex('5555555555555555eeeeeeeeeeeeeeee'),
-    from_hex('5555555555555555'),
-    9,
+    '5555555555555555eeeeeeeeeeeeeeee',
+    '5555555555555555',
     'INFO',
     '{"query": "laptop", "results": 245, "took_ms": 32, "filters": ["category:electronics"]}',
-    MAP(ARRAY['search_query', 'search_results_count', 'search_index', 'environment'], ARRAY['laptop', '245', 'products', 'production']),
-    0,
-    0
+    MAP(ARRAY['search_query', 'search_results_count', 'search_index', 'environment', 'cloud_account_id', 'service_name', 'trace_id', 'span_id', 'severity_text', 'level'], ARRAY['laptop', '245', 'products', 'production', 'account-002', 'search-service', '5555555555555555eeeeeeeeeeeeeeee', '5555555555555555', 'INFO', 'INFO'])
 ),
 -- Row 9: NOW - 1 minute
 (
-    'anonymous',
+    'default',
     'account-001',
     'api-gateway',
     current_timestamp - INTERVAL '1' MINUTE,
     current_timestamp - INTERVAL '1' MINUTE,
     current_timestamp - INTERVAL '1' MINUTE,
-    from_hex('6666666666666666ffffffffffffffff'),
-    from_hex('6666666666666666'),
-    17,
+    '6666666666666666ffffffffffffffff',
+    '6666666666666666',
     'ERROR',
     '{"method": "GET", "path": "/api/v1/products/999", "status": 500, "error": "Internal server error"}',
-    MAP(ARRAY['http_method', 'http_status_code', 'http_url', 'error_type', 'environment'], ARRAY['GET', '500', '/api/v1/products/999', 'InternalServerError', 'production']),
-    0,
-    0
+    MAP(ARRAY['http_method', 'http_status_code', 'http_url', 'error_type', 'environment', 'cloud_account_id', 'service_name', 'trace_id', 'span_id', 'severity_text', 'level'], ARRAY['GET', '500', '/api/v1/products/999', 'InternalServerError', 'production', 'account-001', 'api-gateway', '6666666666666666ffffffffffffffff', '6666666666666666', 'ERROR', 'ERROR'])
 ),
 -- Row 10: NOW (most recent)
 (
-    'anonymous',
+    'default',
     'account-004',
     'billing-service',
     current_timestamp,
     current_timestamp,
     current_timestamp,
-    from_hex('7777777777777777000000000000000a'),
-    from_hex('7777777777777777'),
-    9,
+    '7777777777777777000000000000000a',
+    '7777777777777777',
     'INFO',
     '{"action": "invoice_generated", "invoice_id": "INV-2024-001", "amount": 1250.00, "customer_id": "cust-789"}',
-    MAP(ARRAY['billing_invoice_id', 'billing_amount', 'billing_currency', 'environment'], ARRAY['INV-2024-001', '1250.00', 'USD', 'production']),
-    0,
-    0
+    MAP(ARRAY['billing_invoice_id', 'billing_amount', 'billing_currency', 'environment', 'cloud_account_id', 'service_name', 'trace_id', 'span_id', 'severity_text', 'level'], ARRAY['INV-2024-001', '1250.00', 'USD', 'production', 'account-004', 'billing-service', '7777777777777777000000000000000a', '7777777777777777', 'INFO', 'INFO'])
 );
 
 SELECT * FROM icegate.logs;
+
+-- DELETE FROM icegate.logs WHERE 1=1;  -- Commented out to preserve sample data
+

--- a/crates/icegate-common/src/lib.rs
+++ b/crates/icegate-common/src/lib.rs
@@ -27,10 +27,6 @@ pub const METRICS_TABLE_FQN: &str = "iceberg.icegate.metrics";
 /// Default tenant ID when not provided in request metadata.
 pub const DEFAULT_TENANT_ID: &str = "default";
 
-/// Default account ID when not provided in resource attributes.
-/// Required because `cloud_account_id` is a partition column.
-pub const DEFAULT_ACCOUNT_ID: &str = "default";
-
 /// Topic name for logs in the WAL queue.
 pub const LOGS_TOPIC: &str = "logs";
 

--- a/crates/icegate-ingest/src/otlp_grpc/services.rs
+++ b/crates/icegate-ingest/src/otlp_grpc/services.rs
@@ -50,7 +50,9 @@ impl LogsService for OtlpGrpcService {
         let tenant_id = None; // Will use default
 
         // Transform OTLP logs to Arrow RecordBatch
-        let Some(batch) = transform::logs_to_record_batch(&export_request, tenant_id) else {
+        let Some(batch) = transform::logs_to_record_batch(&export_request, tenant_id)
+            .map_err(|e| Status::internal(format!("Failed to transform logs: {e}")))?
+        else {
             // No records to process - return success with 0 rejected
             return Ok(Response::new(ExportLogsServiceResponse { partial_success: None }));
         };

--- a/crates/icegate-ingest/src/otlp_http/handlers.rs
+++ b/crates/icegate-ingest/src/otlp_http/handlers.rs
@@ -56,7 +56,7 @@ pub async fn ingest_logs(
     let tenant_id = None;
 
     // Transform OTLP logs to Arrow RecordBatch
-    let Some(batch) = transform::logs_to_record_batch(&export_request, tenant_id) else {
+    let Some(batch) = transform::logs_to_record_batch(&export_request, tenant_id)? else {
         // No records to process - return success with 0 rejected
         return Ok(Json(ExportLogsResponse::default()));
     };

--- a/crates/icegate-ingest/src/transform.rs
+++ b/crates/icegate-ingest/src/transform.rs
@@ -6,14 +6,11 @@
 use std::sync::Arc;
 
 use arrow::{
-    array::{
-        ArrayRef, FixedSizeBinaryBuilder, Int32Builder, MapBuilder, MapFieldNames, RecordBatch, StringBuilder,
-        TimestampMicrosecondArray,
-    },
+    array::{ArrayRef, MapBuilder, MapFieldNames, RecordBatch, StringBuilder, TimestampMicrosecondArray},
     datatypes::{DataType, Schema},
 };
 use iceberg::arrow::schema_to_arrow_schema;
-use icegate_common::{DEFAULT_ACCOUNT_ID, DEFAULT_TENANT_ID};
+use icegate_common::DEFAULT_TENANT_ID;
 use opentelemetry_proto::tonic::{
     collector::logs::v1::ExportLogsServiceRequest,
     common::v1::{AnyValue, any_value::Value},
@@ -48,12 +45,21 @@ pub fn logs_arrow_schema() -> Schema {
 ///
 /// # Returns
 ///
-/// Arrow `RecordBatch` matching the logs schema, or None if no records.
+/// Arrow `RecordBatch` matching the logs schema wrapped in `Ok(Some(_))`,
+/// or `Ok(None)` if no records are present.
+///
+/// # Errors
+///
+/// Returns `IngestError` if:
+/// - Schema validation fails
+/// - `RecordBatch` creation fails
 #[allow(clippy::cast_possible_wrap)]
 #[allow(clippy::cast_possible_truncation)] // Timestamp fits in i64 for practical purposes
 #[allow(clippy::expect_used)] // Byte lengths are validated before append
-#[allow(clippy::too_many_lines)] // Linear transform function
-pub fn logs_to_record_batch(request: &ExportLogsServiceRequest, tenant_id: Option<&str>) -> Option<RecordBatch> {
+pub fn logs_to_record_batch(
+    request: &ExportLogsServiceRequest,
+    tenant_id: Option<&str>,
+) -> crate::error::Result<Option<RecordBatch>> {
     let ingested_timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("time went backwards")
@@ -68,21 +74,12 @@ pub fn logs_to_record_batch(request: &ExportLogsServiceRequest, tenant_id: Optio
         .sum();
 
     if total_records == 0 {
-        return None;
+        return Ok(None);
     }
 
     // Get the Arrow schema to extract correct field types for map builder
     let schema = logs_arrow_schema();
-    let attributes_field = schema.field(11); // attributes is field index 11
-
-    // Extract map field information from schema
-    let (key_field, value_field) = match attributes_field.data_type() {
-        DataType::Map(entries_field, _) => match entries_field.data_type() {
-            DataType::Struct(fields) => (fields[0].clone(), fields[1].clone()),
-            _ => panic!("Expected Struct type for map entries"),
-        },
-        _ => panic!("Expected Map type for attributes field"),
-    };
+    let (key_field, value_field) = extract_map_fields_from_schema(&schema)?;
 
     // Initialize builders
     let mut tenant_id_builder = StringBuilder::with_capacity(total_records, total_records * 16);
@@ -91,9 +88,8 @@ pub fn logs_to_record_batch(request: &ExportLogsServiceRequest, tenant_id: Optio
     let mut timestamp_builder = Vec::with_capacity(total_records);
     let mut observed_timestamp_builder = Vec::with_capacity(total_records);
     let mut ingested_timestamp_builder = Vec::with_capacity(total_records);
-    let mut trace_id_builder = FixedSizeBinaryBuilder::with_capacity(total_records, 16);
-    let mut span_id_builder = FixedSizeBinaryBuilder::with_capacity(total_records, 8);
-    let mut severity_number_builder = Int32Builder::with_capacity(total_records);
+    let mut trace_id_builder = StringBuilder::with_capacity(total_records, total_records * 32);
+    let mut span_id_builder = StringBuilder::with_capacity(total_records, total_records * 16);
     let mut severity_text_builder = StringBuilder::with_capacity(total_records, total_records * 8);
     let mut body_builder = StringBuilder::with_capacity(total_records, total_records * 256);
 
@@ -106,9 +102,6 @@ pub fn logs_to_record_batch(request: &ExportLogsServiceRequest, tenant_id: Optio
     let mut attributes_builder = MapBuilder::new(Some(field_names), StringBuilder::new(), StringBuilder::new())
         .with_keys_field(key_field)
         .with_values_field(value_field);
-
-    let mut flags_builder = Int32Builder::with_capacity(total_records);
-    let mut dropped_attrs_builder = Int32Builder::with_capacity(total_records);
 
     let tenant = tenant_id.unwrap_or(DEFAULT_TENANT_ID);
 
@@ -124,7 +117,7 @@ pub fn logs_to_record_batch(request: &ExportLogsServiceRequest, tenant_id: Optio
             .iter()
             .find(|kv| kv.key == "service.name")
             .and_then(|kv| extract_string_value(kv.value.as_ref()));
-        let account_id = resource_attrs
+        let cloud_account_id = resource_attrs
             .iter()
             .find(|kv| kv.key == "cloud.account.id")
             .and_then(|kv| extract_string_value(kv.value.as_ref()));
@@ -136,9 +129,12 @@ pub fn logs_to_record_batch(request: &ExportLogsServiceRequest, tenant_id: Optio
                 // tenant_id
                 tenant_id_builder.append_value(tenant);
 
-                // cloud_account_id (use default if not provided - required by schema)
-                let acc = account_id.as_deref().unwrap_or(DEFAULT_ACCOUNT_ID);
-                account_id_builder.append_value(acc);
+                // account_id (optional - null if not provided)
+                if let Some(ref acc) = cloud_account_id {
+                    account_id_builder.append_value(acc);
+                } else {
+                    account_id_builder.append_null();
+                }
 
                 // service_name
                 if let Some(ref svc) = service_name {
@@ -166,28 +162,9 @@ pub fn logs_to_record_batch(request: &ExportLogsServiceRequest, tenant_id: Optio
                 // ingested_timestamp
                 ingested_timestamp_builder.push(ingested_timestamp);
 
-                // trace_id (16 bytes)
-                if log_record.trace_id.len() == 16 && !is_zero_bytes(&log_record.trace_id) {
-                    trace_id_builder
-                        .append_value(&log_record.trace_id)
-                        .expect("trace_id is 16 bytes");
-                } else {
-                    trace_id_builder.append_null();
-                }
-
-                // span_id (8 bytes)
-                if log_record.span_id.len() == 8 && !is_zero_bytes(&log_record.span_id) {
-                    span_id_builder.append_value(&log_record.span_id).expect("span_id is 8 bytes");
-                } else {
-                    span_id_builder.append_null();
-                }
-
-                // severity_number
-                if log_record.severity_number != 0 {
-                    severity_number_builder.append_value(log_record.severity_number);
-                } else {
-                    severity_number_builder.append_null();
-                }
+                // trace_id and span_id
+                let (trace_id_hex, span_id_hex) =
+                    process_trace_span_ids(log_record, &mut trace_id_builder, &mut span_id_builder);
 
                 // severity_text
                 if log_record.severity_text.is_empty() {
@@ -196,51 +173,29 @@ pub fn logs_to_record_batch(request: &ExportLogsServiceRequest, tenant_id: Optio
                     severity_text_builder.append_value(&log_record.severity_text);
                 }
 
-                // body
-                if let Some(body_str) = extract_any_value_string(log_record.body.as_ref()) {
+                // body (JSON-serialized for Loki compatibility)
+                if let Some(body_str) = serialize_any_value_to_json(log_record.body.as_ref()) {
                     body_builder.append_value(body_str);
                 } else {
                     body_builder.append_null();
                 }
 
                 // attributes (merged from resource, scope, and log record)
-                let dropped_count = log_record.dropped_attributes_count;
+                // Add resource, scope, and log record attributes (flatten nested, normalize keys)
+                add_flattened_attributes(resource_attrs, &mut attributes_builder);
+                add_flattened_attributes(scope_attrs, &mut attributes_builder);
+                add_flattened_attributes(&log_record.attributes, &mut attributes_builder);
 
-                // Add resource attributes (normalize keys: dots -> underscores)
-                for kv in resource_attrs {
-                    if let Some(v) = extract_string_value(kv.value.as_ref()) {
-                        attributes_builder.keys().append_value(normalize_attribute_key(&kv.key));
-                        attributes_builder.values().append_value(v);
-                    }
-                }
-
-                // Add scope attributes (normalize keys: dots -> underscores)
-                for kv in scope_attrs {
-                    if let Some(v) = extract_string_value(kv.value.as_ref()) {
-                        attributes_builder.keys().append_value(normalize_attribute_key(&kv.key));
-                        attributes_builder.values().append_value(v);
-                    }
-                }
-
-                // Add log record attributes (normalize keys: dots -> underscores)
-                for kv in &log_record.attributes {
-                    if let Some(v) = extract_string_value(kv.value.as_ref()) {
-                        attributes_builder.keys().append_value(normalize_attribute_key(&kv.key));
-                        attributes_builder.values().append_value(v);
-                    }
-                }
+                // Duplicate indexed columns into attributes map for query layer
+                add_indexed_columns_to_attributes(
+                    &mut attributes_builder,
+                    trace_id_hex.as_ref(),
+                    span_id_hex.as_ref(),
+                    &log_record.severity_text,
+                    cloud_account_id.as_ref(),
+                );
 
                 attributes_builder.append(true).expect("append map entry");
-
-                // flags
-                if log_record.flags != 0 {
-                    flags_builder.append_value(log_record.flags as i32);
-                } else {
-                    flags_builder.append_null();
-                }
-
-                // dropped_attributes_count
-                dropped_attrs_builder.append_value(dropped_count as i32);
             }
         }
     }
@@ -256,21 +211,15 @@ pub fn logs_to_record_batch(request: &ExportLogsServiceRequest, tenant_id: Optio
         Arc::new(TimestampMicrosecondArray::from(ingested_timestamp_builder)),
         Arc::new(trace_id_builder.finish()),
         Arc::new(span_id_builder.finish()),
-        Arc::new(severity_number_builder.finish()),
         Arc::new(severity_text_builder.finish()),
         Arc::new(body_builder.finish()),
         Arc::new(attributes_builder.finish()),
-        Arc::new(flags_builder.finish()),
-        Arc::new(dropped_attrs_builder.finish()),
     ];
 
-    match RecordBatch::try_new(schema, columns) {
-        Ok(batch) => Some(batch),
-        Err(e) => {
-            tracing::error!("Failed to create RecordBatch: {e}");
-            None
-        }
-    }
+    RecordBatch::try_new(schema, columns).map(Some).map_err(|e| {
+        tracing::error!("Failed to create RecordBatch: {e}");
+        crate::error::IngestError::Validation(format!("Failed to create RecordBatch: {e}"))
+    })
 }
 
 /// Extracts a string value from an OTLP `AnyValue` reference.
@@ -305,9 +254,270 @@ fn extract_string_value(value: Option<&AnyValue>) -> Option<String> {
     extract_any_value_string(value)
 }
 
+/// Serializes an OTLP `AnyValue` to JSON string format.
+///
+/// This is used specifically for the LogRecord.Body field, which should be
+/// JSON-serialized according to Loki requirements.
+///
+/// # Arguments
+///
+/// * `value` - OTLP `AnyValue` to serialize
+///
+/// # Returns
+///
+/// JSON string representation of the value, or None if value is None
+///
+/// # Examples
+///
+/// ```
+/// // StringValue("hello") -> "hello" (no quotes)
+/// // IntValue(42) -> "42"
+/// // ArrayValue([1, 2]) -> "[1,2]"
+/// // KvlistValue({a: 1}) -> "{\"a\":1}"
+/// ```
+fn serialize_any_value_to_json(value: Option<&AnyValue>) -> Option<String> {
+    value.and_then(|v| {
+        v.value.as_ref().and_then(|val| match val {
+            Value::StringValue(s) => Some(s.clone()),
+            Value::IntValue(i) => Some(i.to_string()),
+            Value::DoubleValue(d) => Some(d.to_string()),
+            Value::BoolValue(b) => Some(b.to_string()),
+            Value::BytesValue(b) => Some(hex::encode(b)),
+            Value::ArrayValue(arr) => {
+                let json_array: Vec<serde_json::Value> = arr.values.iter().filter_map(any_value_to_json).collect();
+                serde_json::to_string(&json_array).ok()
+            }
+            Value::KvlistValue(kvs) => {
+                let mut json_object = serde_json::Map::new();
+                for kv in &kvs.values {
+                    if let Some(json_val) = kv.value.as_ref().and_then(any_value_to_json) {
+                        json_object.insert(kv.key.clone(), json_val);
+                    }
+                }
+                serde_json::to_string(&json_object).ok()
+            }
+        })
+    })
+}
+
+/// Helper to convert `AnyValue` to `serde_json::Value` for JSON serialization.
+fn any_value_to_json(value: &AnyValue) -> Option<serde_json::Value> {
+    value.value.as_ref().map(|val| match val {
+        Value::StringValue(s) => serde_json::Value::String(s.clone()),
+        Value::IntValue(i) => serde_json::Value::Number(serde_json::Number::from(*i)),
+        Value::DoubleValue(d) => {
+            serde_json::Number::from_f64(*d).map_or(serde_json::Value::Null, serde_json::Value::Number)
+        }
+        Value::BoolValue(b) => serde_json::Value::Bool(*b),
+        Value::BytesValue(b) => serde_json::Value::String(hex::encode(b)),
+        Value::ArrayValue(arr) => {
+            let items: Vec<serde_json::Value> = arr.values.iter().filter_map(any_value_to_json).collect();
+            serde_json::Value::Array(items)
+        }
+        Value::KvlistValue(kvs) => {
+            let mut map = serde_json::Map::new();
+            for kv in &kvs.values {
+                if let Some(v) = kv.value.as_ref().and_then(any_value_to_json) {
+                    map.insert(kv.key.clone(), v);
+                }
+            }
+            serde_json::Value::Object(map)
+        }
+    })
+}
+
 /// Checks if a byte slice is all zeros.
 fn is_zero_bytes(bytes: &[u8]) -> bool {
     bytes.iter().all(|&b| b == 0)
+}
+
+/// Extracts map field metadata from the Arrow schema for attributes field.
+///
+/// Returns a tuple of (`key_field`, `value_field`) from the schema's map type definition.
+///
+/// # Errors
+///
+/// Returns `IngestError::Validation` if:
+/// - Schema does not contain an 'attributes' field
+/// - The 'attributes' field is not of Map type
+/// - The map entries are not of Struct type
+/// - The struct does not contain at least 2 fields (key and value)
+fn extract_map_fields_from_schema(
+    schema: &Schema,
+) -> crate::error::Result<(arrow::datatypes::FieldRef, arrow::datatypes::FieldRef)> {
+    let attributes_field = schema
+        .field_with_name("attributes")
+        .map_err(|_| crate::error::IngestError::Validation("Schema must contain an 'attributes' field".to_string()))?;
+
+    // Extract map field information from schema
+    match attributes_field.data_type() {
+        DataType::Map(entries_field, _) => match entries_field.data_type() {
+            DataType::Struct(fields) => {
+                if fields.len() < 2 {
+                    return Err(crate::error::IngestError::Validation(format!(
+                        "Expected at least 2 fields in map entries struct, found {}",
+                        fields.len()
+                    )));
+                }
+                Ok((fields[0].clone(), fields[1].clone()))
+            }
+            _ => Err(crate::error::IngestError::Validation(
+                "Expected Struct type for map entries in 'attributes' field".to_string(),
+            )),
+        },
+        _ => Err(crate::error::IngestError::Validation(format!(
+            "Expected Map type for 'attributes' field, found {:?}",
+            attributes_field.data_type()
+        ))),
+    }
+}
+
+/// Adds flattened attributes to the map builder with key normalization.
+///
+/// Flattens nested structures and normalizes attribute keys by replacing dots with underscores.
+fn add_flattened_attributes(
+    attributes: &[opentelemetry_proto::tonic::common::v1::KeyValue],
+    attributes_builder: &mut MapBuilder<StringBuilder, StringBuilder>,
+) {
+    for kv in attributes {
+        let flattened = flatten_any_value(&kv.key, kv.value.as_ref());
+        for (key, value) in flattened {
+            attributes_builder.keys().append_value(normalize_attribute_key(&key));
+            attributes_builder.values().append_value(value);
+        }
+    }
+}
+
+/// Processes trace and span IDs, returning hex-encoded values if valid.
+///
+/// Returns a tuple of (`trace_id_hex`, `span_id_hex`) where each is `Some(String)` if valid,
+/// or `None` if invalid or all zeros.
+fn process_trace_span_ids(
+    log_record: &opentelemetry_proto::tonic::logs::v1::LogRecord,
+    trace_id_builder: &mut StringBuilder,
+    span_id_builder: &mut StringBuilder,
+) -> (Option<String>, Option<String>) {
+    // trace_id (16 bytes → 32 hex chars)
+    let trace_id_hex = if log_record.trace_id.len() == 16 && !is_zero_bytes(&log_record.trace_id) {
+        let hex_string = hex::encode(&log_record.trace_id);
+        trace_id_builder.append_value(hex_string.clone());
+        Some(hex_string)
+    } else {
+        trace_id_builder.append_null();
+        None
+    };
+
+    // span_id (8 bytes → 16 hex chars)
+    let span_id_hex = if log_record.span_id.len() == 8 && !is_zero_bytes(&log_record.span_id) {
+        let hex_string = hex::encode(&log_record.span_id);
+        span_id_builder.append_value(hex_string.clone());
+        Some(hex_string)
+    } else {
+        span_id_builder.append_null();
+        None
+    };
+
+    (trace_id_hex, span_id_hex)
+}
+
+/// Adds indexed columns to the attributes map for query layer compatibility.
+///
+/// Duplicates `trace_id`, `span_id`, `severity_text`, and `account_id` into the attributes map
+/// to allow queries to use indexed columns for filtering then switch to attributes for operations.
+fn add_indexed_columns_to_attributes(
+    attributes_builder: &mut MapBuilder<StringBuilder, StringBuilder>,
+    trace_id_hex: Option<&String>,
+    span_id_hex: Option<&String>,
+    severity_text: &str,
+    cloud_account_id: Option<&String>,
+) {
+    // trace_id
+    if let Some(tid) = trace_id_hex {
+        attributes_builder.keys().append_value("trace_id");
+        attributes_builder.values().append_value(tid);
+    }
+
+    // span_id
+    if let Some(sid) = span_id_hex {
+        attributes_builder.keys().append_value("span_id");
+        attributes_builder.values().append_value(sid);
+    }
+
+    // severity_text
+    if !severity_text.is_empty() {
+        attributes_builder.keys().append_value("severity_text");
+        attributes_builder.values().append_value(severity_text);
+    }
+
+    // level (alias for severity_text for Grafana compatibility)
+    if !severity_text.is_empty() {
+        attributes_builder.keys().append_value("level"); // Loki support
+        attributes_builder.values().append_value(severity_text);
+    }
+
+    // cloud_account_id
+    if let Some(acc) = cloud_account_id {
+        attributes_builder.keys().append_value("cloud_account_id");
+        attributes_builder.values().append_value(acc);
+    }
+}
+
+/// Recursively flattens an OTLP `AnyValue` into key-value pairs.
+///
+/// Nested `KvlistValue` structures are flattened using underscore separator,
+/// matching Loki's behavior with JSON parser.
+///
+/// # Arguments
+///
+/// * `prefix` - Key prefix for nested values (use empty string for root)
+/// * `value` - OTLP `AnyValue` to flatten
+///
+/// # Returns
+///
+/// Vector of (key, value) string pairs representing flattened structure
+///
+/// # Examples
+///
+/// ```
+/// // Input: prefix="http", value=KvlistValue({method: "GET", details: {code: 200}})
+/// // Output: [("http_method", "GET"), ("http_details_code", "200")]
+/// ```
+fn flatten_any_value(prefix: &str, value: Option<&AnyValue>) -> Vec<(String, String)> {
+    let mut result = Vec::new();
+
+    if let Some(v) = value {
+        if let Some(val) = &v.value {
+            match val {
+                Value::KvlistValue(kvs) => {
+                    // Recursively flatten nested key-value lists
+                    for kv in &kvs.values {
+                        let nested_prefix = if prefix.is_empty() {
+                            kv.key.clone()
+                        } else {
+                            format!("{}_{}", prefix, kv.key)
+                        };
+                        let nested_pairs = flatten_any_value(&nested_prefix, kv.value.as_ref());
+                        result.extend(nested_pairs);
+                    }
+                }
+                Value::ArrayValue(arr) => {
+                    // Arrays are stringified, not flattened (no indexable keys)
+                    let items: Vec<String> =
+                        arr.values.iter().filter_map(|v| extract_any_value_string(Some(v))).collect();
+                    let stringified = format!("[{}]", items.join(", "));
+                    result.push((prefix.to_string(), stringified));
+                }
+                _ => {
+                    // Primitive types: stringify and return
+                    if let Some(s) = extract_any_value_string(Some(v)) {
+                        result.push((prefix.to_string(), s));
+                    }
+                }
+            }
+        }
+    }
+
+    result
 }
 
 /// Normalizes an attribute key by replacing dots with underscores.
@@ -332,7 +542,7 @@ mod tests {
     fn test_logs_to_record_batch_empty() {
         let request = ExportLogsServiceRequest { resource_logs: vec![] };
 
-        let batch = logs_to_record_batch(&request, None);
+        let batch = logs_to_record_batch(&request, None).expect("should not error");
         assert!(batch.is_none());
     }
 
@@ -376,12 +586,12 @@ mod tests {
             }],
         };
 
-        let batch = logs_to_record_batch(&request, Some("test-tenant"));
+        let batch = logs_to_record_batch(&request, Some("test-tenant")).expect("should not error");
         assert!(batch.is_some());
 
         let batch = batch.expect("batch should exist");
         assert_eq!(batch.num_rows(), 1);
-        assert_eq!(batch.num_columns(), 14);
+        assert_eq!(batch.num_columns(), 11);
     }
 
     #[test]
@@ -414,5 +624,188 @@ mod tests {
 
         // None
         assert_eq!(extract_string_value(None), None);
+    }
+
+    #[test]
+    fn test_body_json_serialization_primitives() {
+        use opentelemetry_proto::tonic::common::v1::any_value::Value;
+
+        // String - returned as-is
+        let string_val = AnyValue {
+            value: Some(Value::StringValue("hello world".to_string())),
+        };
+        assert_eq!(
+            serialize_any_value_to_json(Some(&string_val)),
+            Some("hello world".to_string())
+        );
+
+        // Int - stringified
+        let int_val = AnyValue {
+            value: Some(Value::IntValue(42)),
+        };
+        assert_eq!(serialize_any_value_to_json(Some(&int_val)), Some("42".to_string()));
+
+        // Bool - stringified
+        let bool_val = AnyValue {
+            value: Some(Value::BoolValue(true)),
+        };
+        assert_eq!(serialize_any_value_to_json(Some(&bool_val)), Some("true".to_string()));
+    }
+
+    #[test]
+    fn test_body_json_serialization_array() {
+        use opentelemetry_proto::tonic::common::v1::{ArrayValue, any_value::Value};
+
+        let array_val = AnyValue {
+            value: Some(Value::ArrayValue(ArrayValue {
+                values: vec![
+                    AnyValue {
+                        value: Some(Value::StringValue("tag1".to_string())),
+                    },
+                    AnyValue {
+                        value: Some(Value::IntValue(123)),
+                    },
+                ],
+            })),
+        };
+
+        let result = serialize_any_value_to_json(Some(&array_val));
+        assert!(result.is_some());
+
+        // Should be valid JSON array
+        let parsed: serde_json::Value =
+            serde_json::from_str(&result.expect("result should exist")).expect("should parse as JSON");
+        assert!(parsed.is_array());
+        assert_eq!(parsed[0], "tag1");
+        assert_eq!(parsed[1], 123);
+    }
+
+    #[test]
+    fn test_body_json_serialization_object() {
+        use opentelemetry_proto::tonic::common::v1::{KeyValueList, any_value::Value};
+
+        let object_val = AnyValue {
+            value: Some(Value::KvlistValue(KeyValueList {
+                values: vec![
+                    KeyValue {
+                        key: "status".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(Value::IntValue(200)),
+                        }),
+                    },
+                    KeyValue {
+                        key: "message".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(Value::StringValue("OK".to_string())),
+                        }),
+                    },
+                ],
+            })),
+        };
+
+        let result = serialize_any_value_to_json(Some(&object_val));
+        assert!(result.is_some());
+
+        // Should be valid JSON object
+        let parsed: serde_json::Value =
+            serde_json::from_str(&result.expect("result should exist")).expect("should parse as JSON");
+        assert!(parsed.is_object());
+        assert_eq!(parsed["status"], 200);
+        assert_eq!(parsed["message"], "OK");
+    }
+
+    #[test]
+    fn test_flatten_nested_attributes() {
+        use std::collections::HashMap;
+
+        use opentelemetry_proto::tonic::common::v1::{KeyValueList, any_value::Value};
+
+        // Test nested KvlistValue flattening
+        let nested_kv = AnyValue {
+            value: Some(Value::KvlistValue(KeyValueList {
+                values: vec![
+                    KeyValue {
+                        key: "method".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(Value::StringValue("POST".to_string())),
+                        }),
+                    },
+                    KeyValue {
+                        key: "details".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(Value::KvlistValue(KeyValueList {
+                                values: vec![
+                                    KeyValue {
+                                        key: "status".to_string(),
+                                        value: Some(AnyValue {
+                                            value: Some(Value::IntValue(200)),
+                                        }),
+                                    },
+                                    KeyValue {
+                                        key: "path".to_string(),
+                                        value: Some(AnyValue {
+                                            value: Some(Value::StringValue("/api/v1".to_string())),
+                                        }),
+                                    },
+                                ],
+                            })),
+                        }),
+                    },
+                ],
+            })),
+        };
+
+        let flattened = flatten_any_value("http", Some(&nested_kv));
+
+        // Should produce 3 flattened entries
+        assert_eq!(flattened.len(), 3);
+
+        // Check flattened keys and values
+        let map: HashMap<String, String> = flattened.into_iter().collect();
+        assert_eq!(map.get("http_method"), Some(&"POST".to_string()));
+        assert_eq!(map.get("http_details_status"), Some(&"200".to_string()));
+        assert_eq!(map.get("http_details_path"), Some(&"/api/v1".to_string()));
+    }
+
+    #[test]
+    fn test_flatten_array_attribute() {
+        use opentelemetry_proto::tonic::common::v1::{ArrayValue, any_value::Value};
+
+        // Arrays should be stringified, not flattened (no meaningful keys)
+        let array_value = AnyValue {
+            value: Some(Value::ArrayValue(ArrayValue {
+                values: vec![
+                    AnyValue {
+                        value: Some(Value::StringValue("tag1".to_string())),
+                    },
+                    AnyValue {
+                        value: Some(Value::StringValue("tag2".to_string())),
+                    },
+                ],
+            })),
+        };
+
+        let flattened = flatten_any_value("tags", Some(&array_value));
+
+        // Should produce single stringified entry
+        assert_eq!(flattened.len(), 1);
+        assert_eq!(flattened[0].0, "tags");
+        assert_eq!(flattened[0].1, "[tag1, tag2]");
+    }
+
+    #[test]
+    fn test_flatten_primitive_attribute() {
+        use opentelemetry_proto::tonic::common::v1::any_value::Value;
+
+        // Primitive values should work as before
+        let string_value = AnyValue {
+            value: Some(Value::StringValue("simple".to_string())),
+        };
+
+        let flattened = flatten_any_value("key", Some(&string_value));
+
+        assert_eq!(flattened.len(), 1);
+        assert_eq!(flattened[0].0, "key");
+        assert_eq!(flattened[0].1, "simple");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schema v1.2: cloud_account_id replaces account_id; trace/span IDs are now hex string identifiers; added service_name and service_instance_id; attributes map expanded (environment, cloud_account_id, service_name, trace_id, span_id, severity_text, level, body).

* **Bug Fixes**
  * Transformer errors now propagate instead of being swallowed; tenant handling standardized (anonymous → default); removed numeric severity/flags/dropped_attributes_count and aligned severity_text with level.

* **Tests**
  * Test suites and benchmarks updated for the new schema and string-based identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->