### PR TITLE
GH-25: Update dependency versions in Cargo.toml and Cargo.lock; bump Iceberg to latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=6946f3197bc3958d38af275933c188b957920a88#6946f3197bc3958d38af275933c188b957920a88"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=8d3338aa9130996f6de0b5106458fb263d7e2b3e#8d3338aa9130996f6de0b5106458fb263d7e2b3e"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -3581,7 +3581,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=6946f3197bc3958d38af275933c188b957920a88#6946f3197bc3958d38af275933c188b957920a88"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=8d3338aa9130996f6de0b5106458fb263d7e2b3e#8d3338aa9130996f6de0b5106458fb263d7e2b3e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3601,7 +3601,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=6946f3197bc3958d38af275933c188b957920a88#6946f3197bc3958d38af275933c188b957920a88"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=8d3338aa9130996f6de0b5106458fb263d7e2b3e#8d3338aa9130996f6de0b5106458fb263d7e2b3e"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ icegate-common = { path = "crates/icegate-common" }
 icegate-queue = { path = "crates/icegate-queue" }
 
 # Arrow ecosystem (must match iceberg's version)
-arrow = { version = "57", default-features = false, features = ["prettyprint"] }
-parquet = { version = "57", default-features = false, features = ["arrow", "object_store", "zstd"] }
+arrow = { version = "57.0", default-features = false, features = ["prettyprint"] }
+parquet = { version = "57.0", default-features = false, features = ["arrow", "object_store", "zstd"] }
 object_store = { version = "0.12", features = ["aws"] }
 
 # Error handling
@@ -73,12 +73,12 @@ antlr4rust = "0.5"
 # Patches: DataFusion 51 + Arrow 57 compat (upstream PR #1830 closed), memory catalog enhancements
 # Upstream plan: Switch back when DataFusion 51 officially supported upstream
 # Maintenance: develop branch rebased on upstream main; run `make ci` after each sync
-iceberg = { git = "https://github.com/icegatetech/iceberg-rust", rev = "6946f3197bc3958d38af275933c188b957920a88" }
-iceberg-catalog-rest = { git = "https://github.com/icegatetech/iceberg-rust", rev = "6946f3197bc3958d38af275933c188b957920a88" }
-iceberg-datafusion = { git = "https://github.com/icegatetech/iceberg-rust", rev = "6946f3197bc3958d38af275933c188b957920a88" }
+iceberg = { git = "https://github.com/icegatetech/iceberg-rust", rev = "8d3338aa9130996f6de0b5106458fb263d7e2b3e" }
+iceberg-catalog-rest = { git = "https://github.com/icegatetech/iceberg-rust", rev = "8d3338aa9130996f6de0b5106458fb263d7e2b3e" }
+iceberg-datafusion = { git = "https://github.com/icegatetech/iceberg-rust", rev = "8d3338aa9130996f6de0b5106458fb263d7e2b3e" }
 
 # DataFusion
-datafusion = "51"
+datafusion = "51.0"
 
 # Async runtime
 tokio = { version = "1.48.0", features = ["full"] }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions for Arrow, Parquet, and DataFusion.
  * Updated Iceberg components to newer revisions for improved table and catalog handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->