### PR TITLE
GH-113: Consolidate benchmarks and reduce setup overhead

### DIFF
--- a/crates/icegate-query/benches/common/harness.rs
+++ b/crates/icegate-query/benches/common/harness.rs
@@ -232,6 +232,8 @@ pub async fn write_benchmark_logs(
         .with_values_field(value_field);
 
     for _ in 0..count {
+        attributes_builder.keys().append_value("dataset");
+        attributes_builder.values().append_value("baseline");
         attributes_builder.keys().append_value("env");
         attributes_builder.values().append_value("prod");
         attributes_builder.append(true)?;
@@ -359,6 +361,8 @@ pub async fn write_benchmark_logs_with_numeric_attrs(
         .with_values_field(value_field);
 
     for (latency, request_time, response_size) in &random_values {
+        attributes_builder.keys().append_value("dataset");
+        attributes_builder.values().append_value("numeric");
         attributes_builder.keys().append_value("latency");
         attributes_builder.values().append_value(latency.to_string());
         attributes_builder.keys().append_value("request_time");
@@ -482,6 +486,8 @@ pub async fn write_benchmark_logs_with_varied_labels(
         let namespace = namespaces[i % namespaces.len()];
         let pod = pods[i % pods.len()];
 
+        attributes_builder.keys().append_value("dataset");
+        attributes_builder.values().append_value("varied");
         attributes_builder.keys().append_value("namespace");
         attributes_builder.values().append_value(namespace);
         attributes_builder.keys().append_value("pod");

--- a/crates/icegate-query/benches/common/harness.rs
+++ b/crates/icegate-query/benches/common/harness.rs
@@ -86,7 +86,15 @@ impl TestServer {
         // which is correct for benchmarks that only write to Iceberg.
         let wal_store: Arc<dyn object_store::ObjectStore> = Arc::new(object_store::memory::InMemory::new());
         let wal_reader = Arc::new(icegate_queue::ParquetQueueReader::new("", Arc::clone(&wal_store), 8192).unwrap());
-        let engine_config = QueryEngineConfig::default();
+        // Use very long refresh interval to prevent the background refresh task
+        // from firing during benchmarks. The rebuild_lock contention between
+        // background refresh and get_provider causes deadlocks with
+        // criterion's block_on loop.
+        let engine_config = QueryEngineConfig {
+            refresh_interval_secs: 86400,
+            max_age_secs: 86400,
+            ..QueryEngineConfig::default()
+        };
         let query_engine = Arc::new(QueryEngine::new(
             Arc::clone(&catalog),
             engine_config,

--- a/crates/icegate-query/benches/loki_queries.rs
+++ b/crates/icegate-query/benches/loki_queries.rs
@@ -4,6 +4,9 @@
 //! 1. Log stream queries (label selectors, line filters)
 //! 2. Range aggregations (`count_over_time`, rate, unwrap operations)
 //! 3. Vector aggregations (sum, avg with grouping)
+//!
+//! A single TestServer is shared across all benchmark groups, with all data
+//! variants written once during setup to avoid repeated server startup overhead.
 
 #![allow(
     clippy::unwrap_used,
@@ -23,14 +26,14 @@ use common::harness::{
     TestServer, write_benchmark_logs, write_benchmark_logs_with_numeric_attrs, write_benchmark_logs_with_varied_labels,
 };
 
-/// Benchmark Group 1: Log Stream Queries
-fn log_stream_queries(c: &mut Criterion) {
-    let mut group = c.benchmark_group("log_stream_queries");
-    group.sample_size(10);
-
+/// All Loki query benchmarks sharing a single TestServer.
+///
+/// Writing all data variants once and reusing the server across groups avoids
+/// 3 extra server startups + data writes, saving ~30-60 seconds.
+fn loki_benchmarks(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    // Setup: Create server and populate data
+    // Setup: single server with all data variants
     let (server, catalog) = rt.block_on(async { TestServer::start().await.unwrap() });
 
     let table = rt.block_on(async {
@@ -41,373 +44,319 @@ fn log_stream_queries(c: &mut Criterion) {
     });
 
     rt.block_on(async {
+        // Write all data variants to the same table
         write_benchmark_logs(&table, &catalog, 500).await.unwrap();
-    });
-
-    // Benchmark 1: Simple label selector
-    group.bench_function("simple_selector", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[("query", "{service_name=\"api\"}")])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    // Benchmark 2: Multiple matchers with negation
-    group.bench_function("multiple_matchers", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[("query", "{service_name=\"api\", severity_text!=\"ERROR\"}")])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    // Benchmark 3: Attribute map access
-    group.bench_function("attribute_access", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[("query", "{env=\"prod\"}")])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    // Benchmark 4: Line filter (contains)
-    group.bench_function("line_filter_contains", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[("query", "{service_name=\"api\"} |= \"processed\"")])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    // Benchmark 5: Line filter (regex)
-    group.bench_function("line_filter_regex", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[("query", "{service_name=\"api\"} |~ \"processed.*\"")])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    drop(group);
-
-    // Cleanup
-    rt.block_on(async {
-        server.shutdown().await;
-    });
-}
-
-/// Benchmark Group 2: Range Aggregations
-fn range_aggregations(c: &mut Criterion) {
-    let mut group = c.benchmark_group("range_aggregations");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(15));
-
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
-    // Setup: Create server and populate data
-    let (server, catalog) = rt.block_on(async { TestServer::start().await.unwrap() });
-
-    let table = rt.block_on(async {
-        catalog
-            .load_table(&iceberg::TableIdent::from_strs([ICEGATE_NAMESPACE, LOGS_TABLE]).unwrap())
-            .await
-            .unwrap()
-    });
-
-    rt.block_on(async {
-        write_benchmark_logs(&table, &catalog, 500).await.unwrap();
-    });
-
-    // Benchmark 6: count_over_time
-    group.bench_function("count_over_time", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[
-                        ("query", "count_over_time({service_name=\"api\"}[5m])"),
-                        ("step", "60s"),
-                    ])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    // Benchmark 7: rate
-    group.bench_function("rate", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[("query", "rate({service_name=\"api\"}[5m])"), ("step", "60s")])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    // Benchmark 8: bytes_over_time
-    group.bench_function("bytes_over_time", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[
-                        ("query", "bytes_over_time({service_name=\"api\"}[5m])"),
-                        ("step", "60s"),
-                    ])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    drop(group);
-
-    // Cleanup
-    rt.block_on(async {
-        server.shutdown().await;
-    });
-}
-
-/// Benchmark Group 3: Range Aggregations with Unwrap
-fn range_aggregations_unwrap(c: &mut Criterion) {
-    let mut group = c.benchmark_group("range_aggregations_unwrap");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(20));
-
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
-    // Setup: Create server and populate data with numeric attributes
-    let (server, catalog) = rt.block_on(async { TestServer::start().await.unwrap() });
-
-    let table = rt.block_on(async {
-        catalog
-            .load_table(&iceberg::TableIdent::from_strs([ICEGATE_NAMESPACE, LOGS_TABLE]).unwrap())
-            .await
-            .unwrap()
-    });
-
-    rt.block_on(async {
         write_benchmark_logs_with_numeric_attrs(&table, &catalog, 500).await.unwrap();
-    });
-
-    // Benchmark 9: sum_over_time with unwrap (direct attribute access)
-    group.bench_function("sum_over_time_unwrap", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[
-                        (
-                            "query",
-                            "sum_over_time({service_name=\"api\"} | unwrap request_time [5m])",
-                        ),
-                        ("step", "60s"),
-                    ])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    // Benchmark 10: avg_over_time with direct unwrap
-    group.bench_function("avg_over_time_unwrap", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[
-                        ("query", "avg_over_time({service_name=\"api\"} | unwrap latency [5m])"),
-                        ("step", "60s"),
-                    ])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    // Benchmark 11: quantile_over_time
-    group.bench_function("quantile_over_time", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[
-                        (
-                            "query",
-                            "quantile_over_time(0.95, {service_name=\"api\"} | unwrap latency [5m])",
-                        ),
-                        ("step", "60s"),
-                    ])
-                    .send()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    drop(group);
-
-    // Cleanup
-    rt.block_on(async {
-        server.shutdown().await;
-    });
-}
-
-/// Benchmark Group 4: Vector Aggregations
-fn vector_aggregations(c: &mut Criterion) {
-    let mut group = c.benchmark_group("vector_aggregations");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(20));
-
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
-    // Setup: Create server and populate data with varied labels
-    let (server, catalog) = rt.block_on(async { TestServer::start().await.unwrap() });
-
-    let table = rt.block_on(async {
-        catalog
-            .load_table(&iceberg::TableIdent::from_strs([ICEGATE_NAMESPACE, LOGS_TABLE]).unwrap())
-            .await
-            .unwrap()
-    });
-
-    rt.block_on(async {
         write_benchmark_logs_with_varied_labels(&table, &catalog, 500).await.unwrap();
     });
 
-    // Benchmark 12: Simple sum (no grouping)
-    group.bench_function("sum_no_grouping", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[("query", "sum(rate({service_name=\"api\"}[5m]))"), ("step", "60s")])
-                    .send()
-                    .await
-                    .unwrap();
+    // --- Group 1: Log Stream Queries ---
+    {
+        let mut group = c.benchmark_group("log_stream_queries");
+        group.sample_size(10);
+
+        // Benchmark 1: Simple label selector
+        group.bench_function("simple_selector", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[("query", "{service_name=\"api\"}")])
+                        .send()
+                        .await
+                        .unwrap();
+                });
             });
         });
-    });
 
-    // Benchmark 13: sum by (single label)
-    group.bench_function("sum_by_single_label", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[
-                        ("query", "sum by (pod) (rate({service_name=\"api\"}[5m]))"),
-                        ("step", "60s"),
-                    ])
-                    .send()
-                    .await
-                    .unwrap();
+        // Benchmark 2: Multiple matchers with negation
+        group.bench_function("multiple_matchers", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[("query", "{service_name=\"api\", severity_text!=\"ERROR\"}")])
+                        .send()
+                        .await
+                        .unwrap();
+                });
             });
         });
-    });
 
-    // Benchmark 14: avg by (multiple labels)
-    group.bench_function("avg_by_multiple_labels", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[
-                        (
-                            "query",
-                            "avg by (namespace, pod) (count_over_time({service_name=\"api\"}[5m]))",
-                        ),
-                        ("step", "60s"),
-                    ])
-                    .send()
-                    .await
-                    .unwrap();
+        // Benchmark 3: Attribute map access
+        group.bench_function("attribute_access", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[("query", "{env=\"prod\"}")])
+                        .send()
+                        .await
+                        .unwrap();
+                });
             });
         });
-    });
 
-    // Benchmark 15: sum without
-    group.bench_function("sum_without", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let _ = server
-                    .client
-                    .get(format!("{}/loki/api/v1/query_range", server.base_url))
-                    .header("X-Scope-OrgID", "test-tenant")
-                    .query(&[
-                        ("query", "sum without (pod) (rate({service_name=\"api\"}[5m]))"),
-                        ("step", "60s"),
-                    ])
-                    .send()
-                    .await
-                    .unwrap();
+        // Benchmark 4: Line filter (contains)
+        group.bench_function("line_filter_contains", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[("query", "{service_name=\"api\"} |= \"processed\"")])
+                        .send()
+                        .await
+                        .unwrap();
+                });
             });
         });
-    });
 
-    drop(group);
+        // Benchmark 5: Line filter (regex)
+        group.bench_function("line_filter_regex", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[("query", "{service_name=\"api\"} |~ \"processed.*\"")])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        drop(group);
+    }
+
+    // --- Group 2: Range Aggregations ---
+    {
+        let mut group = c.benchmark_group("range_aggregations");
+        group.sample_size(10);
+        group.measurement_time(Duration::from_secs(15));
+
+        // Benchmark 6: count_over_time
+        group.bench_function("count_over_time", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[
+                            ("query", "count_over_time({service_name=\"api\"}[5m])"),
+                            ("step", "60s"),
+                        ])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        // Benchmark 7: rate
+        group.bench_function("rate", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[("query", "rate({service_name=\"api\"}[5m])"), ("step", "60s")])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        // Benchmark 8: bytes_over_time
+        group.bench_function("bytes_over_time", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[
+                            ("query", "bytes_over_time({service_name=\"api\"}[5m])"),
+                            ("step", "60s"),
+                        ])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        drop(group);
+    }
+
+    // --- Group 3: Range Aggregations with Unwrap ---
+    {
+        let mut group = c.benchmark_group("range_aggregations_unwrap");
+        group.sample_size(10);
+        group.measurement_time(Duration::from_secs(20));
+
+        // Benchmark 9: sum_over_time with unwrap (direct attribute access)
+        group.bench_function("sum_over_time_unwrap", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[
+                            (
+                                "query",
+                                "sum_over_time({service_name=\"api\"} | unwrap request_time [5m])",
+                            ),
+                            ("step", "60s"),
+                        ])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        // Benchmark 10: avg_over_time with direct unwrap
+        group.bench_function("avg_over_time_unwrap", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[
+                            ("query", "avg_over_time({service_name=\"api\"} | unwrap latency [5m])"),
+                            ("step", "60s"),
+                        ])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        // Benchmark 11: quantile_over_time
+        group.bench_function("quantile_over_time", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[
+                            (
+                                "query",
+                                "quantile_over_time(0.95, {service_name=\"api\"} | unwrap latency [5m])",
+                            ),
+                            ("step", "60s"),
+                        ])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        drop(group);
+    }
+
+    // --- Group 4: Vector Aggregations ---
+    {
+        let mut group = c.benchmark_group("vector_aggregations");
+        group.sample_size(10);
+        group.measurement_time(Duration::from_secs(20));
+
+        // Benchmark 12: Simple sum (no grouping)
+        group.bench_function("sum_no_grouping", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[("query", "sum(rate({service_name=\"api\"}[5m]))"), ("step", "60s")])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        // Benchmark 13: sum by (single label)
+        group.bench_function("sum_by_single_label", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[
+                            ("query", "sum by (pod) (rate({service_name=\"api\"}[5m]))"),
+                            ("step", "60s"),
+                        ])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        // Benchmark 14: avg by (multiple labels)
+        group.bench_function("avg_by_multiple_labels", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[
+                            (
+                                "query",
+                                "avg by (namespace, pod) (count_over_time({service_name=\"api\"}[5m]))",
+                            ),
+                            ("step", "60s"),
+                        ])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        // Benchmark 15: sum without
+        group.bench_function("sum_without", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = server
+                        .client
+                        .get(format!("{}/loki/api/v1/query_range", server.base_url))
+                        .header("X-Scope-OrgID", "test-tenant")
+                        .query(&[
+                            ("query", "sum without (pod) (rate({service_name=\"api\"}[5m]))"),
+                            ("step", "60s"),
+                        ])
+                        .send()
+                        .await
+                        .unwrap();
+                });
+            });
+        });
+
+        drop(group);
+    }
 
     // Cleanup
     rt.block_on(async {
@@ -415,11 +364,5 @@ fn vector_aggregations(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    benches,
-    log_stream_queries,
-    range_aggregations,
-    range_aggregations_unwrap,
-    vector_aggregations
-);
+criterion_group!(benches, loki_benchmarks);
 criterion_main!(benches);

--- a/crates/icegate-query/benches/loki_queries.rs
+++ b/crates/icegate-query/benches/loki_queries.rs
@@ -5,8 +5,10 @@
 //! 2. Range aggregations (`count_over_time`, rate, unwrap operations)
 //! 3. Vector aggregations (sum, avg with grouping)
 //!
-//! A single TestServer is shared across all benchmark groups, with all data
+//! A single `TestServer` is shared across all benchmark groups, with all data
 //! variants written once during setup to avoid repeated server startup overhead.
+//! Each dataset is tagged with a `dataset` attribute so queries only hit the
+//! intended 500-row corpus.
 
 #![allow(
     clippy::unwrap_used,
@@ -26,10 +28,11 @@ use common::harness::{
     TestServer, write_benchmark_logs, write_benchmark_logs_with_numeric_attrs, write_benchmark_logs_with_varied_labels,
 };
 
-/// All Loki query benchmarks sharing a single TestServer.
+/// All Loki query benchmarks sharing a single `TestServer`.
 ///
 /// Writing all data variants once and reusing the server across groups avoids
 /// 3 extra server startups + data writes, saving ~30-60 seconds.
+#[allow(clippy::too_many_lines)]
 fn loki_benchmarks(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
@@ -44,13 +47,15 @@ fn loki_benchmarks(c: &mut Criterion) {
     });
 
     rt.block_on(async {
-        // Write all data variants to the same table
+        // Write all data variants to the same table.
+        // Each helper tags rows with dataset="baseline"/"numeric"/"varied"
+        // so queries only hit the intended 500-row corpus.
         write_benchmark_logs(&table, &catalog, 500).await.unwrap();
         write_benchmark_logs_with_numeric_attrs(&table, &catalog, 500).await.unwrap();
         write_benchmark_logs_with_varied_labels(&table, &catalog, 500).await.unwrap();
     });
 
-    // --- Group 1: Log Stream Queries ---
+    // --- Group 1: Log Stream Queries (dataset=baseline) ---
     {
         let mut group = c.benchmark_group("log_stream_queries");
         group.sample_size(10);
@@ -63,7 +68,7 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .client
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
-                        .query(&[("query", "{service_name=\"api\"}")])
+                        .query(&[("query", "{service_name=\"api\", dataset=\"baseline\"}")])
                         .send()
                         .await
                         .unwrap();
@@ -79,7 +84,10 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .client
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
-                        .query(&[("query", "{service_name=\"api\", severity_text!=\"ERROR\"}")])
+                        .query(&[(
+                            "query",
+                            "{service_name=\"api\", dataset=\"baseline\", severity_text!=\"ERROR\"}",
+                        )])
                         .send()
                         .await
                         .unwrap();
@@ -95,7 +103,7 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .client
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
-                        .query(&[("query", "{env=\"prod\"}")])
+                        .query(&[("query", "{dataset=\"baseline\", env=\"prod\"}")])
                         .send()
                         .await
                         .unwrap();
@@ -111,7 +119,7 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .client
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
-                        .query(&[("query", "{service_name=\"api\"} |= \"processed\"")])
+                        .query(&[("query", "{service_name=\"api\", dataset=\"baseline\"} |= \"processed\"")])
                         .send()
                         .await
                         .unwrap();
@@ -127,7 +135,10 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .client
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
-                        .query(&[("query", "{service_name=\"api\"} |~ \"processed.*\"")])
+                        .query(&[(
+                            "query",
+                            "{service_name=\"api\", dataset=\"baseline\"} |~ \"processed.*\"",
+                        )])
                         .send()
                         .await
                         .unwrap();
@@ -138,7 +149,7 @@ fn loki_benchmarks(c: &mut Criterion) {
         drop(group);
     }
 
-    // --- Group 2: Range Aggregations ---
+    // --- Group 2: Range Aggregations (dataset=baseline) ---
     {
         let mut group = c.benchmark_group("range_aggregations");
         group.sample_size(10);
@@ -153,7 +164,10 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
                         .query(&[
-                            ("query", "count_over_time({service_name=\"api\"}[5m])"),
+                            (
+                                "query",
+                                "count_over_time({service_name=\"api\", dataset=\"baseline\"}[5m])",
+                            ),
                             ("step", "60s"),
                         ])
                         .send()
@@ -171,7 +185,10 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .client
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
-                        .query(&[("query", "rate({service_name=\"api\"}[5m])"), ("step", "60s")])
+                        .query(&[
+                            ("query", "rate({service_name=\"api\", dataset=\"baseline\"}[5m])"),
+                            ("step", "60s"),
+                        ])
                         .send()
                         .await
                         .unwrap();
@@ -188,7 +205,10 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
                         .query(&[
-                            ("query", "bytes_over_time({service_name=\"api\"}[5m])"),
+                            (
+                                "query",
+                                "bytes_over_time({service_name=\"api\", dataset=\"baseline\"}[5m])",
+                            ),
                             ("step", "60s"),
                         ])
                         .send()
@@ -201,7 +221,7 @@ fn loki_benchmarks(c: &mut Criterion) {
         drop(group);
     }
 
-    // --- Group 3: Range Aggregations with Unwrap ---
+    // --- Group 3: Range Aggregations with Unwrap (dataset=numeric) ---
     {
         let mut group = c.benchmark_group("range_aggregations_unwrap");
         group.sample_size(10);
@@ -218,7 +238,7 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .query(&[
                             (
                                 "query",
-                                "sum_over_time({service_name=\"api\"} | unwrap request_time [5m])",
+                                "sum_over_time({service_name=\"api\", dataset=\"numeric\"} | unwrap request_time [5m])",
                             ),
                             ("step", "60s"),
                         ])
@@ -238,7 +258,10 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
                         .query(&[
-                            ("query", "avg_over_time({service_name=\"api\"} | unwrap latency [5m])"),
+                            (
+                                "query",
+                                "avg_over_time({service_name=\"api\", dataset=\"numeric\"} | unwrap latency [5m])",
+                            ),
                             ("step", "60s"),
                         ])
                         .send()
@@ -259,7 +282,7 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .query(&[
                             (
                                 "query",
-                                "quantile_over_time(0.95, {service_name=\"api\"} | unwrap latency [5m])",
+                                "quantile_over_time(0.95, {service_name=\"api\", dataset=\"numeric\"} | unwrap latency [5m])",
                             ),
                             ("step", "60s"),
                         ])
@@ -273,7 +296,7 @@ fn loki_benchmarks(c: &mut Criterion) {
         drop(group);
     }
 
-    // --- Group 4: Vector Aggregations ---
+    // --- Group 4: Vector Aggregations (dataset=varied) ---
     {
         let mut group = c.benchmark_group("vector_aggregations");
         group.sample_size(10);
@@ -287,7 +310,10 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .client
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
-                        .query(&[("query", "sum(rate({service_name=\"api\"}[5m]))"), ("step", "60s")])
+                        .query(&[
+                            ("query", "sum(rate({service_name=\"api\", dataset=\"varied\"}[5m]))"),
+                            ("step", "60s"),
+                        ])
                         .send()
                         .await
                         .unwrap();
@@ -304,7 +330,10 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
                         .query(&[
-                            ("query", "sum by (pod) (rate({service_name=\"api\"}[5m]))"),
+                            (
+                                "query",
+                                "sum by (pod) (rate({service_name=\"api\", dataset=\"varied\"}[5m]))",
+                            ),
                             ("step", "60s"),
                         ])
                         .send()
@@ -325,7 +354,7 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .query(&[
                             (
                                 "query",
-                                "avg by (namespace, pod) (count_over_time({service_name=\"api\"}[5m]))",
+                                "avg by (namespace, pod) (count_over_time({service_name=\"api\", dataset=\"varied\"}[5m]))",
                             ),
                             ("step", "60s"),
                         ])
@@ -345,7 +374,10 @@ fn loki_benchmarks(c: &mut Criterion) {
                         .get(format!("{}/loki/api/v1/query_range", server.base_url))
                         .header("X-Scope-OrgID", "test-tenant")
                         .query(&[
-                            ("query", "sum without (pod) (rate({service_name=\"api\"}[5m]))"),
+                            (
+                                "query",
+                                "sum without (pod) (rate({service_name=\"api\", dataset=\"varied\"}[5m]))",
+                            ),
                             ("step", "60s"),
                         ])
                         .send()

--- a/crates/icegate-queue/benches/queue_s3_bench.rs
+++ b/crates/icegate-queue/benches/queue_s3_bench.rs
@@ -5,11 +5,12 @@
 //! 2. Read performance (list segments, read single segment, plan segments)
 //! 3. End-to-end (write then read)
 //!
-//! A single MinIO container is shared across all benchmark groups to avoid
+//! A single `MinIO` container is shared across all benchmark groups to avoid
 //! repeated container startup overhead.
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout, missing_docs)]
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{sync::Arc, time::Duration};
 
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -60,8 +61,11 @@ async fn write_batch(tx: &icegate_queue::WriteChannel, topic: &str, batch: arrow
     response_rx.await.expect("Failed to receive write result");
 }
 
-/// All queue benchmarks sharing a single MinIO container.
+/// All queue benchmarks sharing a single `MinIO` container.
 fn queue_benchmarks(c: &mut Criterion) {
+    /// Counter for unique e2e topic names across iterations.
+    static E2E_COUNTER: AtomicU64 = AtomicU64::new(0);
+
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     // Single MinIO container for all benchmark groups
@@ -193,31 +197,32 @@ fn queue_benchmarks(c: &mut Criterion) {
         group.sample_size(10);
         group.measurement_time(Duration::from_secs(30));
 
-        // Benchmark 7: Write then read - write 5 batches, read back via plan+read
+        // Benchmark 7: Write then read - write 5 batches, read back via plan+read.
+        // Each iteration uses a unique topic to avoid accumulating segments
+        // across iterations, which would make later iterations progressively slower.
         group.bench_function("write_then_read", |b| {
             b.iter(|| {
+                let topic = format!("e2e_{}", E2E_COUNTER.fetch_add(1, Ordering::Relaxed));
                 rt.block_on(async {
                     // Write phase
                     let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
                     let batches = generate_batches_with_grouping(5, 100, 5);
                     for batch in batches {
-                        write_batch(&tx, "e2e", batch).await;
+                        write_batch(&tx, &topic, batch).await;
                     }
                     drop(tx);
                     writer_handle.await.unwrap().unwrap();
 
                     // Read phase
-                    let reader =
-                        ParquetQueueReader::new("queue".to_string(), Arc::clone(&store), 8192).unwrap();
+                    let reader = ParquetQueueReader::new("queue".to_string(), Arc::clone(&store), 8192).unwrap();
                     let cancel = CancellationToken::new();
-                    let topic_e2e = "e2e".to_string();
 
                     // List and read segments directly
-                    let segments = reader.list_segments(&topic_e2e, 0, &cancel).await.unwrap();
+                    let segments = reader.list_segments(&topic, 0, &cancel).await.unwrap();
                     for segment in segments {
                         // Read first row group from each segment
                         let _ = reader
-                            .read_segment(&topic_e2e, segment.id.offset, &[0], &cancel)
+                            .read_segment(&topic, segment.id.offset, &[0], &cancel)
                             .await
                             .unwrap()
                             .try_collect::<Vec<_>>()

--- a/crates/icegate-queue/benches/queue_s3_bench.rs
+++ b/crates/icegate-queue/benches/queue_s3_bench.rs
@@ -2,9 +2,11 @@
 //!
 //! Benchmarks cover:
 //! 1. Write performance (small batches, large batches, concurrent topics)
-//! 2. Write performance with multi-tenant batches
-//! 3. Read performance (list segments, read single segment, plan segments)
-//! 4. End-to-end (write then read)
+//! 2. Read performance (list segments, read single segment, plan segments)
+//! 3. End-to-end (write then read)
+//!
+//! A single MinIO container is shared across all benchmark groups to avoid
+//! repeated container startup overhead.
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stdout, missing_docs)]
 
@@ -58,199 +60,182 @@ async fn write_batch(tx: &icegate_queue::WriteChannel, topic: &str, batch: arrow
     response_rx.await.expect("Failed to receive write result");
 }
 
-/// Benchmark Group 1: Write Performance
-fn write_performance(c: &mut Criterion) {
-    let mut group = c.benchmark_group("write_performance");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(400));
-
+/// All queue benchmarks sharing a single MinIO container.
+fn queue_benchmarks(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
-    // Setup: Shared MinIO for all benchmarks in this group
-    let (minio, store) = rt.block_on(async { setup_minio_and_bucket("write-perf").await });
+    // Single MinIO container for all benchmark groups
+    let (minio, store) = rt.block_on(async { setup_minio_and_bucket("bench").await });
 
-    // Benchmark 1: Small batches - 10 batches × 100 records
-    group.bench_function("small_batches", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
-                let batches = generate_batches_for_throughput(10, 100);
-                for batch in batches {
-                    write_batch(&tx, "small", batch).await;
-                }
-                drop(tx);
-                writer_handle.await.unwrap().unwrap();
+    // --- Group 1: Write Performance ---
+    {
+        let mut group = c.benchmark_group("write_performance");
+        group.sample_size(10);
+        group.measurement_time(Duration::from_secs(30));
+
+        // Benchmark 1: Small batches - 10 batches x 100 records
+        group.bench_function("small_batches", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
+                    let batches = generate_batches_for_throughput(10, 100);
+                    for batch in batches {
+                        write_batch(&tx, "small", batch).await;
+                    }
+                    drop(tx);
+                    writer_handle.await.unwrap().unwrap();
+                });
             });
         });
-    });
 
-    // Benchmark 2: Large batches - 10 batches × 10,000 records
-    group.bench_function("large_batches", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
-                let batches = generate_batches_for_throughput(10, 10_000);
-                for batch in batches {
-                    write_batch(&tx, "large", batch).await;
-                }
-                drop(tx);
-                writer_handle.await.unwrap().unwrap();
+        // Benchmark 2: Large batches - 10 batches x 10,000 records
+        group.bench_function("large_batches", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
+                    let batches = generate_batches_for_throughput(10, 10_000);
+                    for batch in batches {
+                        write_batch(&tx, "large", batch).await;
+                    }
+                    drop(tx);
+                    writer_handle.await.unwrap().unwrap();
+                });
             });
         });
-    });
 
-    // Benchmark 3: Concurrent topics - 3 topics in parallel
-    group.bench_function("concurrent_topics", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
-                let batches_topic1 = generate_batches_for_throughput(10, 100);
-                let batches_topic2 = generate_batches_for_throughput(10, 100);
-                let batches_topic3 = generate_batches_for_throughput(10, 100);
+        // Benchmark 3: Concurrent topics - 3 topics in parallel
+        group.bench_function("concurrent_topics", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
+                    let batches_topic1 = generate_batches_for_throughput(10, 100);
+                    let batches_topic2 = generate_batches_for_throughput(10, 100);
+                    let batches_topic3 = generate_batches_for_throughput(10, 100);
 
-                // Interleave writes from 3 topics
-                for i in 0..10 {
-                    write_batch(&tx, "topic1", batches_topic1[i].clone()).await;
-                    write_batch(&tx, "topic2", batches_topic2[i].clone()).await;
-                    write_batch(&tx, "topic3", batches_topic3[i].clone()).await;
-                }
-                drop(tx);
-                writer_handle.await.unwrap().unwrap();
+                    // Interleave writes from 3 topics
+                    for i in 0..10 {
+                        write_batch(&tx, "topic1", batches_topic1[i].clone()).await;
+                        write_batch(&tx, "topic2", batches_topic2[i].clone()).await;
+                        write_batch(&tx, "topic3", batches_topic3[i].clone()).await;
+                    }
+                    drop(tx);
+                    writer_handle.await.unwrap().unwrap();
+                });
             });
         });
-    });
 
-    drop(group);
-    // Explicitly drop MinIO within the runtime context
-    rt.block_on(async {
-        drop(minio);
-    });
-}
+        drop(group);
+    }
 
-/// Benchmark Group 2: Read Performance
-fn read_performance(c: &mut Criterion) {
-    let mut group = c.benchmark_group("read_performance");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(110));
+    // --- Group 2: Read Performance ---
+    {
+        // Pre-write segments for read benchmarks
+        rt.block_on(async {
+            let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
+            let batches = generate_batches_for_throughput(10, 100);
+            for batch in batches {
+                write_batch(&tx, "reads", batch).await;
+            }
+            drop(tx);
+            writer_handle.await.unwrap().unwrap();
+        });
 
-    let rt = tokio::runtime::Runtime::new().unwrap();
+        let reader = ParquetQueueReader::new("queue".to_string(), Arc::clone(&store), 8192).unwrap();
+        let topic = "reads".to_string();
 
-    // Setup: Create MinIO and pre-write segments
-    let (minio, store) = rt.block_on(async {
-        let (minio, store) = setup_minio_and_bucket("read-perf").await;
-        let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
+        let mut group = c.benchmark_group("read_performance");
+        group.sample_size(10);
+        group.measurement_time(Duration::from_secs(15));
 
-        // Pre-write 10 segments for listing test (without grouping)
-        let batches = generate_batches_for_throughput(10, 100);
-        for batch in batches {
-            write_batch(&tx, "reads", batch).await;
-        }
-        drop(tx);
-        writer_handle.await.unwrap().unwrap();
-
-        (minio, store)
-    });
-
-    let reader = ParquetQueueReader::new("queue".to_string(), Arc::clone(&store), 8192).unwrap();
-    let topic = "reads".to_string();
-
-    // Benchmark 6: List segments - list 10 pre-written segments
-    group.bench_function("list_segments", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let cancel = CancellationToken::new();
-                let _ = reader.list_segments(&topic, 0, &cancel).await.unwrap();
+        // Benchmark 4: List segments
+        group.bench_function("list_segments", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let cancel = CancellationToken::new();
+                    let _ = reader.list_segments(&topic, 0, &cancel).await.unwrap();
+                });
             });
         });
-    });
 
-    // Benchmark 7: Read single segment - read 1 segment with row groups
-    group.bench_function("read_single_segment", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let cancel = CancellationToken::new();
-                // Read row group 0 from segment 0
-                let _ = reader
-                    .read_segment(&topic, 0, &[0], &cancel)
-                    .await
-                    .unwrap()
-                    .try_collect::<Vec<_>>()
-                    .await
-                    .unwrap();
-            });
-        });
-    });
-
-    // Benchmark 8: List and count segments
-    group.bench_function("list_segments_count", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                let cancel = CancellationToken::new();
-                // Note: Planning without grouping since pre-written data isn't grouped
-                let segments = reader.list_segments(&topic, 0, &cancel).await.unwrap();
-                let _ = segments.len();
-            });
-        });
-    });
-
-    drop(group);
-    // Explicitly drop MinIO within the runtime context
-    rt.block_on(async {
-        drop(minio);
-    });
-}
-
-/// Benchmark Group 4: End-to-End
-fn end_to_end(c: &mut Criterion) {
-    let mut group = c.benchmark_group("end_to_end");
-    group.sample_size(10);
-    group.measurement_time(Duration::from_secs(120));
-
-    let rt = tokio::runtime::Runtime::new().unwrap();
-
-    // Setup: Shared MinIO for all benchmarks in this group
-    let (minio, store) = rt.block_on(async { setup_minio_and_bucket("e2e").await });
-
-    // Benchmark 9: Write then read - write 5 batches, read back via plan+read
-    group.bench_function("write_then_read", |b| {
-        b.iter(|| {
-            rt.block_on(async {
-                // Write phase
-                let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
-                let batches = generate_batches_with_grouping(5, 100, 5);
-                for batch in batches {
-                    write_batch(&tx, "e2e", batch).await;
-                }
-                drop(tx);
-                writer_handle.await.unwrap().unwrap();
-
-                // Read phase
-                let reader = ParquetQueueReader::new("queue".to_string(), Arc::clone(&store), 8192).unwrap();
-                let cancel = CancellationToken::new();
-                let topic_e2e = "e2e".to_string();
-
-                // List and read segments directly
-                let segments = reader.list_segments(&topic_e2e, 0, &cancel).await.unwrap();
-                for segment in segments {
-                    // Read first row group from each segment
+        // Benchmark 5: Read single segment
+        group.bench_function("read_single_segment", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let cancel = CancellationToken::new();
                     let _ = reader
-                        .read_segment(&topic_e2e, segment.id.offset, &[0], &cancel)
+                        .read_segment(&topic, 0, &[0], &cancel)
                         .await
                         .unwrap()
                         .try_collect::<Vec<_>>()
                         .await
                         .unwrap();
-                }
+                });
             });
         });
-    });
 
-    drop(group);
-    // Explicitly drop MinIO within the runtime context
+        // Benchmark 6: List and count segments
+        group.bench_function("list_segments_count", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    let cancel = CancellationToken::new();
+                    let segments = reader.list_segments(&topic, 0, &cancel).await.unwrap();
+                    let _ = segments.len();
+                });
+            });
+        });
+
+        drop(group);
+    }
+
+    // --- Group 3: End-to-End ---
+    {
+        let mut group = c.benchmark_group("end_to_end");
+        group.sample_size(10);
+        group.measurement_time(Duration::from_secs(30));
+
+        // Benchmark 7: Write then read - write 5 batches, read back via plan+read
+        group.bench_function("write_then_read", |b| {
+            b.iter(|| {
+                rt.block_on(async {
+                    // Write phase
+                    let (writer_handle, tx) = start_writer(Arc::clone(&store), "queue");
+                    let batches = generate_batches_with_grouping(5, 100, 5);
+                    for batch in batches {
+                        write_batch(&tx, "e2e", batch).await;
+                    }
+                    drop(tx);
+                    writer_handle.await.unwrap().unwrap();
+
+                    // Read phase
+                    let reader =
+                        ParquetQueueReader::new("queue".to_string(), Arc::clone(&store), 8192).unwrap();
+                    let cancel = CancellationToken::new();
+                    let topic_e2e = "e2e".to_string();
+
+                    // List and read segments directly
+                    let segments = reader.list_segments(&topic_e2e, 0, &cancel).await.unwrap();
+                    for segment in segments {
+                        // Read first row group from each segment
+                        let _ = reader
+                            .read_segment(&topic_e2e, segment.id.offset, &[0], &cancel)
+                            .await
+                            .unwrap()
+                            .try_collect::<Vec<_>>()
+                            .await
+                            .unwrap();
+                    }
+                });
+            });
+        });
+
+        drop(group);
+    }
+
+    // Cleanup: drop MinIO within the runtime context
     rt.block_on(async {
         drop(minio);
     });
 }
 
-criterion_group!(benches, write_performance, read_performance, end_to_end);
+criterion_group!(benches, queue_benchmarks);
 criterion_main!(benches);


### PR DESCRIPTION
All 22 benchmarks pass. ~8 minutes total, down from ~1 hour.
- loki_queries.rs - shared single TestServer across 4 groups
- queue_s3_bench.rs - reduced measurement_time, shared single MinIO container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated benchmark suite organization for query and queue components to improve test infrastructure efficiency.

* **Chores**
  * Refactored benchmark test configurations to use shared server and resource setup across multiple benchmark groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->