### PR TITLE
Add metrics for shift row groups merger

### DIFF
--- a/config/docker/grafana/dashboards/Icegate-Ingest-1769530183590.json
+++ b/config/docker/grafana/dashboards/Icegate-Ingest-1769530183590.json
@@ -603,7 +603,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Wait time for write acknowledgment.",
+      "description": "OTLP transform duration before WAL preparation.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -665,6 +665,234 @@
         "h": 6,
         "w": 6,
         "x": 6,
+        "y": 7
+      },
+      "id": 76,
+      "maxDataPoints": 500,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le, signal, status) (rate(icegate_ingest_otlp_transform_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "{{signal}} - {{status}} - p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, signal, status) (rate(icegate_ingest_otlp_transform_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "{{signal}} - {{status}} - p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, signal, status) (rate(icegate_ingest_otlp_transform_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "{{signal}} - {{status}} - p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Request: transform latency [1m]",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "OTLP WAL sorting duration before enqueue.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 9,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 7
+      },
+      "id": 77,
+      "maxDataPoints": 500,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le, signal, status) (rate(icegate_ingest_otlp_wal_sorting_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "{{signal}} - {{status}} - p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, signal, status) (rate(icegate_ingest_otlp_wal_sorting_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "{{signal}} - {{status}} - p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, signal, status) (rate(icegate_ingest_otlp_wal_sorting_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "{{signal}} - {{status}} - p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Request: WAL sorting latency [1m]",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Wait time for write acknowledgment.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 9,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
         "y": 7
       },
       "id": 26,
@@ -779,8 +1007,8 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 12,
-        "y": 7
+        "x": 0,
+        "y": 13
       },
       "id": 31,
       "maxDataPoints": 500,
@@ -829,192 +1057,6 @@
         }
       ],
       "title": "WAL: flush latency [1m]",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Number of batches in the accumulator",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 7
-      },
-      "id": 28,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "datasource": "Prometheus",
-          "editorMode": "code",
-          "expr": "icegate_ingest_wal_pending_batches{job=\"ingest\"}",
-          "legendFormat": "{{topic}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "WAL: pending batches to flush",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "description": "Number of records in the accumulator",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 0,
-        "y": 13
-      },
-      "id": 29,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "datasource": "Prometheus",
-          "editorMode": "code",
-          "expr": "icegate_ingest_wal_pending_records{job=\"ingest\"}",
-          "legendFormat": "{{topic}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "WAL: pending records to flush",
       "type": "timeseries"
     },
     {
@@ -1113,6 +1155,192 @@
     },
     {
       "datasource": "Prometheus",
+      "description": "Number of records in the accumulator",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 13
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "icegate_ingest_wal_pending_records{job=\"ingest\"}",
+          "legendFormat": "{{topic}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "WAL: pending records to flush",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Number of batches in the accumulator",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 13
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "icegate_ingest_wal_pending_batches{job=\"ingest\"}",
+          "legendFormat": "{{topic}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "WAL: pending batches to flush",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1174,8 +1402,8 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 12,
-        "y": 13
+        "x": 0,
+        "y": 19
       },
       "id": 32,
       "maxDataPoints": 500,
@@ -1224,120 +1452,6 @@
         }
       ],
       "title": "WAL: segment size [1m]",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 9,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 13
-      },
-      "id": 25,
-      "maxDataPoints": 500,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "datasource": "Prometheus",
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, protocol, signal) (rate(icegate_ingest_wal_enqueue_duration_seconds_bucket{job=\"ingest\"}[1m])))",
-          "fromExploreMetrics": false,
-          "legendFormat": "p95",
-          "range": true,
-          "refId": "icegate_ingest_shift_plan_duration_seconds_bucket-p99-histogram_quantile"
-        },
-        {
-          "datasource": "Prometheus",
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by (le, protocol, signal) (rate(icegate_ingest_wal_enqueue_duration_seconds_bucket{job=\"ingest\"}[1m])))",
-          "fromExploreMetrics": false,
-          "hide": false,
-          "legendFormat": "p50",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": "Prometheus",
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by (le, protocol, signal) (rate(icegate_ingest_wal_enqueue_duration_seconds_bucket{job=\"ingest\"}[1m])))",
-          "fromExploreMetrics": false,
-          "legendFormat": "p99",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "WAL: write to WAL latency [1m]",
       "type": "timeseries"
     },
     {
@@ -1402,7 +1516,7 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 0,
+        "x": 6,
         "y": 19
       },
       "id": 33,
@@ -1452,98 +1566,6 @@
         }
       ],
       "title": "WAL: records per segment [1m]",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 19
-      },
-      "id": 27,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "datasource": "Prometheus",
-          "editorMode": "code",
-          "expr": "sum by (protocol, signal) (rate(icegate_ingest_wal_queue_unavailable_total{job=\"ingest\"}[1m]))",
-          "legendFormat": "{{protocol}} - {{signal}} - {{status}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "WAL: write to queue unavailable [1m]",
       "type": "timeseries"
     },
     {
@@ -1754,6 +1776,99 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 25
+      },
+      "id": 72,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (operation) (rate(icegate_ingest_shift_queue_writer_s3_request_duration_seconds_count{job=\"ingest\"}[1m]))",
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Queue writer: requests [1m]",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
             "fillOpacity": 9,
             "gradientMode": "none",
             "hideFrom": {
@@ -1800,7 +1915,7 @@
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 0,
+        "x": 6,
         "y": 25
       },
       "id": 71,
@@ -1838,6 +1953,120 @@
         }
       ],
       "title": "Queue writer: request latency [1m]",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 9,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 25
+      },
+      "id": 25,
+      "maxDataPoints": 500,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, protocol, signal) (rate(icegate_ingest_wal_enqueue_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "icegate_ingest_shift_plan_duration_seconds_bucket-p99-histogram_quantile"
+        },
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, protocol, signal) (rate(icegate_ingest_wal_enqueue_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "hide": false,
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, protocol, signal) (rate(icegate_ingest_wal_enqueue_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "WAL: write to WAL latency [1m]",
       "type": "timeseries"
     },
     {
@@ -1894,18 +2123,17 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "reqps"
+          }
         },
         "overrides": []
       },
       "gridPos": {
         "h": 6,
         "w": 6,
-        "x": 6,
+        "x": 18,
         "y": 25
       },
-      "id": 72,
+      "id": 27,
       "options": {
         "legend": {
           "calcs": [],
@@ -1924,13 +2152,13 @@
         {
           "datasource": "Prometheus",
           "editorMode": "code",
-          "expr": "sum by (operation) (rate(icegate_ingest_shift_queue_writer_s3_request_duration_seconds_count{job=\"ingest\"}[1m]))",
-          "legendFormat": "{{operation}}",
+          "expr": "sum by (protocol, signal) (rate(icegate_ingest_wal_queue_unavailable_total{job=\"ingest\"}[1m]))",
+          "legendFormat": "{{protocol}} - {{signal}} - {{status}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Queue writer: requests [1m]",
+      "title": "WAL: write to queue unavailable [1m]",
       "type": "timeseries"
     },
     {
@@ -5163,6 +5391,209 @@
       "type": "timeseries"
     },
     {
+      "datasource": "Prometheus",
+      "description": "Lifetime of one row group while it stays open in row groups merger",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 63
+      },
+      "id": 73,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, topic) (rate(icegate_ingest_shift_row_groups_merger_row_group_lifetime_duration_seconds_bucket\n{job=\"ingest\"}[1m])))",
+          "legendFormat": "{{topic}} - p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, topic) (rate(icegate_ingest_shift_row_groups_merger_row_group_lifetime_duration_seconds_bucket\n{job=\"ingest\"}[1m])))",
+          "legendFormat": "{{topic}} - p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, topic) (rate(icegate_ingest_shift_row_groups_merger_row_group_lifetime_duration_seconds_bucket\n{job=\"ingest\"}[1m])))",
+          "legendFormat": "{{topic}} - p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Shift task: row groups merger row group lifetime [1m]",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Open row groups and open row group bytes in row groups merger.\nIf value <=1:\n- there are no overlap clusters;\n- there are intersections, but the subsequent ones row group are empty and do not fall into active streams;\n- the intersections are very short.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 63
+      },
+      "id": 74,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "sum by (topic) (icegate_ingest_shift_row_groups_merger_open_row_groups{job=\"ingest\"})",
+          "legendFormat": "{{topic}} - open row groups",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Shift task: row groups merger open state",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -5844,7 +6275,7 @@
         {
           "datasource": "Prometheus",
           "editorMode": "code",
-          "expr": "sum by (operation, http_status) (rate(icegate_jobmanager_storage_s3_latency_seconds_count{http_status!=\"OK\", job=\"ingest\"}[1m]))\n",
+          "expr": "sum by (operation, http_status) (increase(icegate_jobmanager_storage_s3_latency_seconds_count{http_status!=\"OK\", job=\"ingest\"}[1m]))\n",
           "legendFormat": "{{operation}}-{{http_status}}",
           "range": true,
           "refId": "A"
@@ -6224,6 +6655,120 @@
       ],
       "title": "Jobmanager: save conflict retry rate [1m]",
       "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "OTLP request decode duration.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 9,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 82
+      },
+      "id": 75,
+      "maxDataPoints": 500,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le, protocol, signal, status) (rate(icegate_ingest_otlp_decode_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "{{signal}} - {{status}} - p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, protocol, signal, status) (rate(icegate_ingest_otlp_decode_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "{{signal}} - {{status}} - p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "Prometheus",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, protocol, signal, status) (rate(icegate_ingest_otlp_decode_duration_seconds_bucket{job=\"ingest\"}[1m])))",
+          "fromExploreMetrics": false,
+          "legendFormat": "{{signal}} - {{status}} - p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Request: decode latency [1m]",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -6240,5 +6785,5 @@
   "timezone": "browser",
   "title": "Ingest",
   "uid": "g78tk2",
-  "version": 8
+  "version": 13
 }

--- a/config/docker/grafana/dashboards/Icegate-Ingest-1769530183590.json
+++ b/config/docker/grafana/dashboards/Icegate-Ingest-1769530183590.json
@@ -893,7 +893,7 @@
         "h": 6,
         "w": 6,
         "x": 18,
-        "y": 7
+        "y": 82
       },
       "id": 26,
       "maxDataPoints": 500,
@@ -2153,7 +2153,7 @@
           "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "sum by (protocol, signal) (rate(icegate_ingest_wal_queue_unavailable_total{job=\"ingest\"}[1m]))",
-          "legendFormat": "{{protocol}} - {{signal}} - {{status}}",
+          "legendFormat": "{{protocol}} - {{signal}}",
           "range": true,
           "refId": "A"
         }
@@ -5502,7 +5502,7 @@
     },
     {
       "datasource": "Prometheus",
-      "description": "Open row groups and open row group bytes in row groups merger.\nIf value <=1:\n- there are no overlap clusters;\n- there are intersections, but the subsequent ones row group are empty and do not fall into active streams;\n- the intersections are very short.",
+      "description": "Open row groups in row groups merger.\nIf value <=1:\n- there are no overlap clusters;\n- there are intersections, but the subsequent ones row group are empty and do not fall into active streams;\n- the intersections are very short.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -6720,7 +6720,7 @@
         "h": 6,
         "w": 6,
         "x": 18,
-        "y": 82
+        "y": 7
       },
       "id": 75,
       "maxDataPoints": 500,

--- a/crates/icegate-ingest/src/infra/metrics.rs
+++ b/crates/icegate-ingest/src/infra/metrics.rs
@@ -16,7 +16,7 @@ use object_store::{
 };
 use opentelemetry::{
     KeyValue,
-    metrics::{Counter, Gauge, Histogram, Meter, MeterProvider as _},
+    metrics::{Counter, Gauge, Histogram, Meter, MeterProvider as _, UpDownCounter},
 };
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 
@@ -47,6 +47,9 @@ pub struct ShiftMetrics {
     already_committed_total: Counter<u64>,
     task_failures_total: Counter<u64>,
     task_success_total: Counter<u64>,
+    row_groups_merger_open_row_groups: UpDownCounter<i64>,
+    row_groups_merger_open_row_group_bytes: UpDownCounter<i64>,
+    row_groups_merger_row_group_lifetime_duration: Histogram<f64>,
 }
 
 impl ShiftMetrics {
@@ -82,6 +85,15 @@ impl ShiftMetrics {
             already_committed_total: meter.u64_counter("icegate_ingest_shift_already_committed").build(),
             task_failures_total: meter.u64_counter("icegate_ingest_shift_task_failures").build(),
             task_success_total: meter.u64_counter("icegate_ingest_shift_task_success").build(),
+            row_groups_merger_open_row_groups: meter
+                .i64_up_down_counter("icegate_ingest_shift_row_groups_merger_open_row_groups")
+                .build(),
+            row_groups_merger_open_row_group_bytes: meter
+                .i64_up_down_counter("icegate_ingest_shift_row_groups_merger_open_row_group_bytes")
+                .build(),
+            row_groups_merger_row_group_lifetime_duration: meter
+                .f64_histogram("icegate_ingest_shift_row_groups_merger_row_group_lifetime_duration")
+                .build(),
         }
     }
 
@@ -172,6 +184,20 @@ impl ShiftMetrics {
             .u64_counter("icegate_ingest_shift_task_success")
             .with_description("Number of shift task successes")
             .build();
+        let row_groups_merger_open_row_groups = meter
+            .i64_up_down_counter("icegate_ingest_shift_row_groups_merger_open_row_groups")
+            .with_description("Number of row groups currently open in row groups merger")
+            .build();
+        let row_groups_merger_open_row_group_bytes = meter
+            .i64_up_down_counter("icegate_ingest_shift_row_groups_merger_open_row_group_bytes")
+            .with_description("Bytes of row groups currently open in row groups merger")
+            .with_unit("By")
+            .build();
+        let row_groups_merger_row_group_lifetime_duration = meter
+            .f64_histogram("icegate_ingest_shift_row_groups_merger_row_group_lifetime_duration")
+            .with_description("Lifetime of one row group while it stays open in row groups merger")
+            .with_unit("s")
+            .build();
 
         Self {
             enabled: true,
@@ -194,6 +220,9 @@ impl ShiftMetrics {
             already_committed_total,
             task_failures_total,
             task_success_total,
+            row_groups_merger_open_row_groups,
+            row_groups_merger_open_row_group_bytes,
+            row_groups_merger_row_group_lifetime_duration,
         }
     }
 
@@ -415,6 +444,33 @@ impl ShiftMetrics {
                 KeyValue::new("topic", topic.to_string()),
             ],
         );
+    }
+
+    /// Add delta to currently open row groups in merger.
+    pub fn add_row_groups_merger_open_row_groups(&self, delta: i64, topic: &str) {
+        if !self.enabled {
+            return;
+        }
+        self.row_groups_merger_open_row_groups
+            .add(delta, &[KeyValue::new("topic", topic.to_string())]);
+    }
+
+    /// Add delta to currently open row group bytes in merger.
+    pub fn add_row_groups_merger_open_row_group_bytes(&self, delta: i64, topic: &str) {
+        if !self.enabled {
+            return;
+        }
+        self.row_groups_merger_open_row_group_bytes
+            .add(delta, &[KeyValue::new("topic", topic.to_string())]);
+    }
+
+    /// Record lifetime of one row group while it stays open in merger.
+    pub fn record_row_groups_merger_row_group_lifetime_duration(&self, duration: Duration, topic: &str) {
+        if !self.enabled {
+            return;
+        }
+        self.row_groups_merger_row_group_lifetime_duration
+            .record(duration.as_secs_f64(), &[KeyValue::new("topic", topic.to_string())]);
     }
 }
 

--- a/crates/icegate-ingest/src/shift/instrumentation.rs
+++ b/crates/icegate-ingest/src/shift/instrumentation.rs
@@ -122,9 +122,17 @@ impl RowGroupsMergerObserverWithMetrics {
 impl RowGroupsMergerObserver for RowGroupsMergerObserverWithMetrics {
     fn on_row_group_opened(&self, segment_offset: u64, row_group_idx: usize, bytes: u64) {
         let bytes_i64 = i64::try_from(bytes).unwrap_or(i64::MAX);
-        {
-            let mut opened_at = self.opened_at.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-            opened_at.insert((segment_offset, row_group_idx), Instant::now());
+        let previous = self
+            .opened_at
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert((segment_offset, row_group_idx), Instant::now());
+        if previous.is_some() {
+            tracing::error!(
+                segment_offset,
+                row_group_idx,
+                "row group opened twice without close; replacing previous open timestamp"
+            );
         }
         self.metrics.add_row_groups_merger_open_row_groups(1, self.topic.as_str());
         self.metrics
@@ -145,6 +153,12 @@ impl RowGroupsMergerObserver for RowGroupsMergerObserverWithMetrics {
         if let Some(opened_at) = opened_at {
             self.metrics
                 .record_row_groups_merger_row_group_lifetime_duration(opened_at.elapsed(), self.topic.as_str());
+        } else {
+            tracing::error!(
+                segment_offset,
+                row_group_idx,
+                "row group closed without open; skipping lifetime metric"
+            );
         }
     }
 }

--- a/crates/icegate-ingest/src/shift/instrumentation.rs
+++ b/crates/icegate-ingest/src/shift/instrumentation.rs
@@ -1,5 +1,8 @@
-use std::sync::Arc;
 use std::time::Instant;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
 use icegate_jobmanager::{Error, JobManager};
@@ -11,6 +14,7 @@ use super::{
     executor::TaskStatus,
     iceberg_storage::{Storage, WrittenDataFiles},
     plan_runner::{PlanTaskResult, PlanTaskRunner},
+    row_groups_merger::RowGroupsMergerObserver,
     shift_runner::{ShiftTaskFailure, ShiftTaskFailureReason, ShiftTaskResult, ShiftTaskRunner},
 };
 use crate::infra::metrics::ShiftMetrics;
@@ -95,6 +99,54 @@ pub struct ShiftTaskRunnerWithMetrics<R> {
     inner: Arc<R>,
     metrics: ShiftMetrics,
     topic: Topic,
+}
+
+/// Row groups merger observer that records metrics.
+pub struct RowGroupsMergerObserverWithMetrics {
+    metrics: ShiftMetrics,
+    topic: Topic,
+    opened_at: Mutex<HashMap<(u64, usize), Instant>>,
+}
+
+impl RowGroupsMergerObserverWithMetrics {
+    /// Create a new merger observer wrapper.
+    pub fn new(metrics: ShiftMetrics, topic: impl Into<String>) -> Self {
+        Self {
+            metrics,
+            topic: topic.into(),
+            opened_at: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl RowGroupsMergerObserver for RowGroupsMergerObserverWithMetrics {
+    fn on_row_group_opened(&self, segment_offset: u64, row_group_idx: usize, bytes: u64) {
+        let bytes_i64 = i64::try_from(bytes).unwrap_or(i64::MAX);
+        {
+            let mut opened_at = self.opened_at.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            opened_at.insert((segment_offset, row_group_idx), Instant::now());
+        }
+        self.metrics.add_row_groups_merger_open_row_groups(1, self.topic.as_str());
+        self.metrics
+            .add_row_groups_merger_open_row_group_bytes(bytes_i64, self.topic.as_str());
+    }
+
+    fn on_row_group_closed(&self, segment_offset: u64, row_group_idx: usize, bytes: u64) {
+        // Use the same i64::MAX saturation as on_row_group_opened so open/close updates stay symmetric even if bytes does not fit i64.
+        let bytes_i64 = i64::try_from(bytes).unwrap_or(i64::MAX);
+        let opened_at = self
+            .opened_at
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&(segment_offset, row_group_idx));
+        self.metrics.add_row_groups_merger_open_row_groups(-1, self.topic.as_str());
+        self.metrics
+            .add_row_groups_merger_open_row_group_bytes(-bytes_i64, self.topic.as_str());
+        if let Some(opened_at) = opened_at {
+            self.metrics
+                .record_row_groups_merger_row_group_lifetime_duration(opened_at.elapsed(), self.topic.as_str());
+        }
+    }
 }
 
 impl<R> ShiftTaskRunnerWithMetrics<R>

--- a/crates/icegate-ingest/src/shift/mod.rs
+++ b/crates/icegate-ingest/src/shift/mod.rs
@@ -38,8 +38,8 @@ use icegate_jobmanager::{
 };
 use icegate_queue::ParquetQueueReader;
 use instrumentation::{
-    CommitTaskRunnerWithMetrics, PlanTaskRunnerWithMetrics, QueueReaderWithMetrics, ShiftTaskRunnerWithMetrics,
-    StorageWithMetrics,
+    CommitTaskRunnerWithMetrics, PlanTaskRunnerWithMetrics, QueueReaderWithMetrics, RowGroupsMergerObserverWithMetrics,
+    ShiftTaskRunnerWithMetrics, StorageWithMetrics,
 };
 use plan_runner::PlanTaskRunnerImpl;
 use shift_runner::ShiftTaskRunnerImpl;
@@ -94,6 +94,10 @@ impl Shifter {
 
         let shift_storage = Arc::new(StorageWithMetrics::new(storage, shift_metrics.clone(), LOGS_TOPIC));
         let shift_storage_for_runner = Arc::clone(&shift_storage);
+        let row_groups_merger_observer = Arc::new(RowGroupsMergerObserverWithMetrics::new(
+            shift_metrics.clone(),
+            LOGS_TOPIC,
+        ));
         let shift_runner = Arc::new(
             ShiftTaskRunnerImpl::new(
                 queue_reader,
@@ -101,6 +105,7 @@ impl Shifter {
                 LOGS_TOPIC,
                 shift_config.write.row_group_size,
             )?
+            .with_row_groups_merger_observer(row_groups_merger_observer)
             .with_segment_read_parallelism(shift_config.read.shift_segment_read_parallelism)?,
         );
         let shift_runner = Arc::new(ShiftTaskRunnerWithMetrics::new(

--- a/crates/icegate-ingest/src/shift/row_groups_merger.rs
+++ b/crates/icegate-ingest/src/shift/row_groups_merger.rs
@@ -18,6 +18,25 @@ use crate::{
 
 const MERGE_CANCEL_CHECK_INTERVAL_ROWS: usize = 1024;
 
+/// Observer for merger lifecycle events.
+pub(crate) trait RowGroupsMergerObserver: Send + Sync {
+    /// Called when a row group starts participating in an active merge cluster.
+    fn on_row_group_opened(&self, segment_offset: u64, row_group_idx: usize, bytes: u64);
+
+    /// Called when a previously opened row group is fully drained or cleaned up.
+    fn on_row_group_closed(&self, segment_offset: u64, row_group_idx: usize, bytes: u64);
+}
+
+/// No-op merger observer used by default.
+#[derive(Default)]
+pub(crate) struct NoopRowGroupsMergerObserver;
+
+impl RowGroupsMergerObserver for NoopRowGroupsMergerObserver {
+    fn on_row_group_opened(&self, _segment_offset: u64, _row_group_idx: usize, _bytes: u64) {}
+
+    fn on_row_group_closed(&self, _segment_offset: u64, _row_group_idx: usize, _bytes: u64) {}
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct BatchScratch {
     batch_generation: u64,
@@ -105,6 +124,7 @@ struct ActiveClusterState {
     batch_generation: u64,
     cache: Option<SortColumnCache>,
     rows_consumed_total: u64,
+    open_in_observer: bool,
 }
 
 struct RowComparator<'a> {
@@ -294,7 +314,7 @@ pub struct SortedBatchMergerConfig {
 /// The merger only keeps one overlap cluster in memory at a time: it opens the
 /// row groups whose key ranges intersect, performs k-way merge across them, and
 /// then moves to the next cluster.
-pub struct RowGroupsMerger<Q: QueueReader + ?Sized> {
+pub struct RowGroupsMerger<Q: QueueReader + ?Sized + 'static> {
     /// Immutable read/output settings.
     config: SortedBatchMergerConfig,
     /// Immutable logs sort descriptor shared by all per-batch column caches.
@@ -303,6 +323,8 @@ pub struct RowGroupsMerger<Q: QueueReader + ?Sized> {
     schema: SchemaRef,
     /// Queue reader used to open WAL row groups as Arrow streams.
     queue_reader: Arc<Q>,
+    /// Optional observer for merger lifecycle and timings.
+    observer: Arc<dyn RowGroupsMergerObserver>,
     /// Row groups that are not opened yet, ordered by their lower boundary.
     pending_row_groups: BTreeSet<PendingRowGroupWithOrder>,
     /// Streams that belong to the current overlap cluster.
@@ -325,25 +347,32 @@ impl<Q> RowGroupsMerger<Q>
 where
     Q: QueueReader + 'static + ?Sized,
 {
-    /// Build merger state from shift segments by flattening their row groups into
-    /// one validated read plan.
-    pub fn try_new_from_segments(
+    /// Build merger state from shift segments by flattening their row groups into one validated read plan.
+    pub fn new(
         queue_reader: Arc<Q>,
         segments: &[super::SegmentToRead],
         config: SortedBatchMergerConfig,
     ) -> Result<Self> {
         let read_plan = PlannedRowGroupRead::from_segments(segments);
-        Self::try_new_with_plan(queue_reader, read_plan, config)
+        Self::new_with_plan(queue_reader, read_plan, config, Arc::new(NoopRowGroupsMergerObserver))
+    }
+
+    /// Attach merger lifecycle observer.
+    #[must_use]
+    pub fn with_observer(mut self, observer: Arc<dyn RowGroupsMergerObserver>) -> Self {
+        self.observer = observer;
+        self
     }
 
     /// Create a merger from an already flattened read plan.
     ///
     /// At this point no WAL data is opened yet. The method only validates the
     /// plan and initializes the pending set ordered by lower boundary.
-    fn try_new_with_plan(
+    fn new_with_plan(
         queue_reader: Arc<Q>,
         read_plan: Vec<PlannedRowGroupRead>,
         config: SortedBatchMergerConfig,
+        observer: Arc<dyn RowGroupsMergerObserver>,
     ) -> Result<Self> {
         if config.row_group_size == 0 {
             return Err(IngestError::Config(
@@ -363,6 +392,7 @@ where
             sort_descriptor: SortColumnsDescriptor::logs()?, // TODO(high): make a generic solution without binding to logs
             schema: SchemaRef::new(arrow::datatypes::Schema::empty()),
             queue_reader,
+            observer,
             pending_row_groups: read_plan.into_iter().map(PendingRowGroupWithOrder::new).collect(),
             active_cluster_streams: Vec::new(),
             heap: MergeHeap::new(),
@@ -766,6 +796,16 @@ where
     /// Drop all state associated with the current cluster after it has been
     /// fully drained or found empty.
     fn complete_active_cluster(&mut self) {
+        for stream_state in &mut self.active_cluster_streams {
+            if stream_state.open_in_observer {
+                self.observer.on_row_group_closed(
+                    stream_state.source.segment_offset,
+                    stream_state.source.row_group_idx,
+                    stream_state.source.row_group_bytes,
+                );
+                stream_state.open_in_observer = false;
+            }
+        }
         if let Some(stats) = self.active_cluster.take() {
             debug!(
                 cluster_row_groups = stats.row_groups,
@@ -794,6 +834,7 @@ where
     /// Register one opened WAL source in the active cluster and seed the heap
     /// with the first row from its first non-empty batch.
     fn push_opened_source(&mut self, opened: OpenedSource) -> Result<()> {
+        let opened_bytes = opened.source.row_group_bytes;
         if self.schema.fields().is_empty() {
             self.schema = opened.row_group.schema();
         } else if opened.row_group.schema() != self.schema {
@@ -813,6 +854,7 @@ where
             batch_generation: 1,
             cache: Some(cache),
             rows_consumed_total: 0,
+            open_in_observer: false,
         });
         let comparator = RowComparator::new(&self.active_cluster_streams);
         self.heap.push(
@@ -824,6 +866,18 @@ where
             },
             &comparator,
         )?;
+        // Set the flag first so Drop can always balance opened/closed callbacks
+        // even if observer implementation panics.
+        let stream_state = self
+            .active_cluster_streams
+            .get_mut(stream_idx)
+            .ok_or_else(|| IngestError::Shift("cannot access merger stream state after push".to_string()))?;
+        stream_state.open_in_observer = true;
+        self.observer.on_row_group_opened(
+            stream_state.source.segment_offset,
+            stream_state.source.row_group_idx,
+            opened_bytes,
+        );
         Ok(())
     }
 
@@ -883,6 +937,14 @@ where
             )
         })?
         else {
+            if stream_state.open_in_observer {
+                self.observer.on_row_group_closed(
+                    stream_state.source.segment_offset,
+                    stream_state.source.row_group_idx,
+                    stream_state.source.row_group_bytes,
+                );
+                stream_state.open_in_observer = false;
+            }
             stream_state.current_batch = None;
             stream_state.cache = None;
             stream_state.stream = None;
@@ -913,6 +975,15 @@ where
             row_idx: 0,
             segment_row_idx: stream_state.current_batch_start_row,
         }))
+    }
+}
+
+impl<Q> Drop for RowGroupsMerger<Q>
+where
+    Q: QueueReader + ?Sized + 'static,
+{
+    fn drop(&mut self) {
+        self.complete_active_cluster();
     }
 }
 
@@ -982,7 +1053,13 @@ async fn next_non_empty_batch(stream: &mut RecordBatchStream) -> Result<Option<R
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicI64, AtomicUsize, Ordering},
+        },
+    };
 
     use arrow::{
         array::{ArrayRef, Int64Array, StringArray, TimestampMicrosecondArray},
@@ -994,7 +1071,10 @@ mod tests {
     use tokio::time::{Duration, sleep};
     use tokio_util::sync::CancellationToken;
 
-    use super::{PlannedRowGroupRead, RowGroupsMerger, SortedBatchMergerConfig};
+    use super::{
+        NoopRowGroupsMergerObserver, PlannedRowGroupRead, RowGroupsMerger, RowGroupsMergerObserver,
+        SortedBatchMergerConfig,
+    };
     use crate::{
         error::IngestError,
         shift::executor::{PlannedRowGroup, SegmentToRead},
@@ -1004,10 +1084,81 @@ mod tests {
         },
     };
 
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     struct FakeQueueReader {
         batches: HashMap<(u64, usize), Vec<RecordBatch>>,
         open_delays: HashMap<(u64, usize), Duration>,
+        error_after_n_reads: Option<usize>,
+        read_segment_calls: AtomicUsize,
+    }
+
+    #[derive(Default)]
+    struct FakeObserver {
+        open_row_groups: AtomicI64,
+        open_row_group_bytes: AtomicI64,
+        opened_calls: AtomicUsize,
+        closed_calls: AtomicUsize,
+        lifetime_calls: AtomicUsize,
+        opened_at: Mutex<HashMap<(u64, usize), std::time::Instant>>,
+        lifetimes: Mutex<Vec<Duration>>,
+    }
+
+    impl FakeObserver {
+        fn open_row_groups(&self) -> i64 {
+            self.open_row_groups.load(Ordering::SeqCst)
+        }
+
+        fn open_row_group_bytes(&self) -> i64 {
+            self.open_row_group_bytes.load(Ordering::SeqCst)
+        }
+
+        fn lifetime_calls(&self) -> usize {
+            self.lifetime_calls.load(Ordering::SeqCst)
+        }
+
+        fn lifetimes(&self) -> Vec<Duration> {
+            self.lifetimes.lock().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
+        }
+
+        fn opened_calls(&self) -> usize {
+            self.opened_calls.load(Ordering::SeqCst)
+        }
+
+        fn closed_calls(&self) -> usize {
+            self.closed_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl RowGroupsMergerObserver for FakeObserver {
+        fn on_row_group_opened(&self, segment_offset: u64, row_group_idx: usize, bytes: u64) {
+            let bytes = i64::try_from(bytes).unwrap_or(i64::MAX);
+            self.opened_calls.fetch_add(1, Ordering::SeqCst);
+            self.open_row_groups.fetch_add(1, Ordering::SeqCst);
+            self.open_row_group_bytes.fetch_add(bytes, Ordering::SeqCst);
+            self.opened_at
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert((segment_offset, row_group_idx), std::time::Instant::now());
+        }
+
+        fn on_row_group_closed(&self, segment_offset: u64, row_group_idx: usize, bytes: u64) {
+            let bytes = i64::try_from(bytes).unwrap_or(i64::MAX);
+            self.closed_calls.fetch_add(1, Ordering::SeqCst);
+            self.open_row_groups.fetch_sub(1, Ordering::SeqCst);
+            self.open_row_group_bytes.fetch_sub(bytes, Ordering::SeqCst);
+            let opened_at = self
+                .opened_at
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remove(&(segment_offset, row_group_idx));
+            if let Some(opened_at) = opened_at {
+                self.lifetime_calls.fetch_add(1, Ordering::SeqCst);
+                self.lifetimes
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .push(opened_at.elapsed());
+            }
+        }
     }
 
     #[async_trait]
@@ -1026,12 +1177,29 @@ mod tests {
 
         async fn read_segment(
             &self,
-            _topic: &icegate_queue::Topic,
+            topic: &icegate_queue::Topic,
             offset: u64,
             record_batch_idxs: &[usize],
             _cancel_token: &CancellationToken,
         ) -> icegate_queue::Result<icegate_queue::RecordBatchStream> {
-            let row_group_idx = *record_batch_idxs.first().expect("row group idx");
+            let read_segment_call = self.read_segment_calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if self.error_after_n_reads.is_some_and(|limit| read_segment_call >= limit) {
+                return Err(icegate_queue::QueueError::Read {
+                    topic: topic.as_str().to_string(),
+                    offset,
+                    source: Box::new(std::io::Error::other("injected read_segment error in tests")),
+                });
+            }
+            let Some(&row_group_idx) = record_batch_idxs.first() else {
+                return Err(icegate_queue::QueueError::Read {
+                    topic: topic.as_str().to_string(),
+                    offset,
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "record_batch_idxs is empty",
+                    )),
+                });
+            };
             if let Some(delay) = self.open_delays.get(&(offset, row_group_idx)) {
                 sleep(*delay).await;
             }
@@ -1080,11 +1248,20 @@ mod tests {
     }
 
     fn plan(segment_offset: u64, row_group_idx: usize, batch: &RecordBatch) -> SegmentToRead {
+        plan_with_bytes(segment_offset, row_group_idx, batch, 1)
+    }
+
+    fn plan_with_bytes(
+        segment_offset: u64,
+        row_group_idx: usize,
+        batch: &RecordBatch,
+        row_group_bytes: u64,
+    ) -> SegmentToRead {
         SegmentToRead {
             segment_offset,
             row_groups: vec![PlannedRowGroup {
                 row_group_idx,
-                row_group_bytes: 1,
+                row_group_bytes,
                 boundary_range: logs_row_group_boundary_range_from_batch(batch).expect("boundary range"),
             }],
         }
@@ -1134,7 +1311,9 @@ mod tests {
             queue_reader: Arc::new(FakeQueueReader {
                 batches: HashMap::new(),
                 open_delays: HashMap::new(),
+                ..FakeQueueReader::default()
             }),
+            observer: Arc::new(NoopRowGroupsMergerObserver),
             pending_row_groups: PlannedRowGroupRead::from_segments(segments)
                 .into_iter()
                 .map(super::PendingRowGroupWithOrder::new)
@@ -1165,7 +1344,7 @@ mod tests {
         segments: Vec<SegmentToRead>,
         row_group_size: usize,
     ) -> Vec<i64> {
-        let merger = RowGroupsMerger::try_new_from_segments(
+        let merger = RowGroupsMerger::new(
             queue_reader,
             &segments,
             SortedBatchMergerConfig {
@@ -1195,7 +1374,7 @@ mod tests {
         segments: Vec<SegmentToRead>,
         row_group_size: usize,
     ) -> Vec<RecordBatch> {
-        let merger = RowGroupsMerger::try_new_from_segments(
+        let merger = RowGroupsMerger::new(
             queue_reader,
             &segments,
             SortedBatchMergerConfig {
@@ -1210,6 +1389,37 @@ mod tests {
         merger.into_stream().try_collect::<Vec<_>>().await.expect("merged")
     }
 
+    async fn merged_values_with_observer(
+        queue_reader: Arc<FakeQueueReader>,
+        segments: Vec<SegmentToRead>,
+        observer: Arc<dyn RowGroupsMergerObserver>,
+    ) -> Vec<i64> {
+        let merger = RowGroupsMerger::new(
+            queue_reader,
+            &segments,
+            SortedBatchMergerConfig {
+                row_group_size: 8,
+                read_parallelism: 2,
+                topic: "logs".to_string(),
+                cancel_token: CancellationToken::new(),
+            },
+        )
+        .expect("merger")
+        .with_observer(observer);
+
+        merger
+            .into_stream()
+            .try_collect::<Vec<_>>()
+            .await
+            .expect("merged")
+            .into_iter()
+            .flat_map(|batch| {
+                let values = batch.column(3).as_any().downcast_ref::<Int64Array>().expect("values");
+                (0..batch.num_rows()).map(|idx| values.value(idx)).collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
     #[tokio::test]
     async fn merger_preserves_global_order_across_non_overlapping_clusters() {
         let batch_1 = logs_batch(vec![(Some("acc-1"), Some("svc-1"), Some(30), 1)]);
@@ -1222,9 +1432,10 @@ mod tests {
                 ((3, 0), vec![batch_3.clone()]),
             ]),
             open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
         });
         let segments = vec![plan(1, 0, &batch_1), plan(2, 0, &batch_2), plan(3, 0, &batch_3)];
-        let merger = RowGroupsMerger::try_new_from_segments(
+        let merger = RowGroupsMerger::new(
             queue_reader,
             &segments,
             SortedBatchMergerConfig {
@@ -1257,6 +1468,7 @@ mod tests {
         let queue_reader = Arc::new(FakeQueueReader {
             batches: HashMap::from([((1, 0), vec![batch.clone()])]),
             open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
         });
 
         let batches = merged_batches_with_row_group_size(queue_reader, vec![plan(1, 0, &batch)], 2).await;
@@ -1288,6 +1500,7 @@ mod tests {
         let queue_reader = Arc::new(FakeQueueReader {
             batches: HashMap::from([((1, 0), vec![batch_1.clone()]), ((2, 0), vec![batch_2.clone()])]),
             open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
         });
 
         let values =
@@ -1309,11 +1522,12 @@ mod tests {
         let queue_reader = Arc::new(FakeQueueReader {
             batches: HashMap::from([((1, 0), vec![batch_1.clone()]), ((2, 0), vec![batch_2.clone()])]),
             open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
         });
         let batch_1_value_column = Arc::clone(batch_1.column(3));
         let batch_2_value_column = Arc::clone(batch_2.column(3));
 
-        let merger = RowGroupsMerger::try_new_from_segments(
+        let merger = RowGroupsMerger::new(
             queue_reader,
             &[plan(1, 0, &batch_1), plan(2, 0, &batch_2)],
             SortedBatchMergerConfig {
@@ -1351,9 +1565,10 @@ mod tests {
         let queue_reader = Arc::new(FakeQueueReader {
             batches: HashMap::from([((1, 0), vec![batch_1.clone()]), ((2, 0), vec![batch_2.clone()])]),
             open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
         });
         let cancel_token = CancellationToken::new();
-        let merger = RowGroupsMerger::try_new_from_segments(
+        let merger = RowGroupsMerger::new(
             queue_reader,
             &[plan(1, 0, &batch_1), plan(2, 0, &batch_2)],
             SortedBatchMergerConfig {
@@ -1390,10 +1605,11 @@ mod tests {
                 ((3, 0), vec![batch_3.clone()]),
             ]),
             open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
         });
         let segments = vec![plan(1, 0, &batch_1), plan(2, 0, &batch_2), plan(3, 0, &batch_3)];
 
-        let merger = RowGroupsMerger::try_new_from_segments(
+        let merger = RowGroupsMerger::new(
             queue_reader,
             &segments,
             SortedBatchMergerConfig {
@@ -1434,6 +1650,7 @@ mod tests {
                 ((12, 0), vec![batch_3.clone()]),
             ]),
             open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
         });
         let values = merged_values(
             queue_reader,
@@ -1457,6 +1674,7 @@ mod tests {
         let queue_reader = Arc::new(FakeQueueReader {
             batches: HashMap::from([((7, 0), vec![row_group_0.clone()]), ((7, 1), vec![row_group_1.clone()])]),
             open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
         });
         let values = merged_values(queue_reader, vec![plan(7, 0, &row_group_0), plan(7, 1, &row_group_1)]).await;
 
@@ -1479,6 +1697,7 @@ mod tests {
                 ((11, 0), Duration::from_millis(10)),
                 ((12, 0), Duration::from_millis(0)),
             ]),
+            ..FakeQueueReader::default()
         });
         let values = merged_values(
             queue_reader,
@@ -1487,6 +1706,208 @@ mod tests {
         .await;
 
         assert_eq!(values, vec![11, 21, 31]);
+    }
+
+    #[tokio::test]
+    async fn merger_observer_tracks_opened_and_closed_row_groups() {
+        let batch_1 = logs_batch(vec![(Some("acc-1"), Some("svc-1"), Some(40), 1)]);
+        let batch_2 = logs_batch(vec![(Some("acc-1"), Some("svc-1"), Some(30), 2)]);
+        let queue_reader = Arc::new(FakeQueueReader {
+            batches: HashMap::from([((1, 0), vec![batch_1.clone()]), ((2, 0), vec![batch_2.clone()])]),
+            open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
+        });
+        let observer = Arc::new(FakeObserver::default());
+        let merger = RowGroupsMerger::new(
+            queue_reader,
+            &[plan_with_bytes(1, 0, &batch_1, 10), plan_with_bytes(2, 0, &batch_2, 20)],
+            SortedBatchMergerConfig {
+                row_group_size: 1,
+                read_parallelism: 2,
+                topic: "logs".to_string(),
+                cancel_token: CancellationToken::new(),
+            },
+        )
+        .expect("merger")
+        .with_observer(Arc::clone(&observer) as Arc<dyn RowGroupsMergerObserver>);
+        let mut stream = merger.into_stream();
+
+        let _ = stream.try_next().await.expect("first batch").expect("first batch");
+        assert!(observer.opened_calls() >= 1);
+        assert!(observer.closed_calls() <= observer.opened_calls());
+
+        let _remaining = stream.try_collect::<Vec<_>>().await.expect("remaining batches");
+        assert_eq!(observer.opened_calls(), 2);
+        assert_eq!(observer.closed_calls(), 2);
+        assert_eq!(observer.open_row_groups(), 0);
+        assert_eq!(observer.open_row_group_bytes(), 0);
+    }
+
+    #[tokio::test]
+    async fn merger_observer_resets_open_counts_on_cancel() {
+        let batch_1 = logs_batch(vec![
+            (Some("acc-1"), Some("svc-1"), Some(60), 1),
+            (Some("acc-1"), Some("svc-1"), Some(40), 3),
+            (Some("acc-1"), Some("svc-1"), Some(20), 5),
+        ]);
+        let batch_2 = logs_batch(vec![
+            (Some("acc-1"), Some("svc-1"), Some(50), 2),
+            (Some("acc-1"), Some("svc-1"), Some(30), 4),
+            (Some("acc-1"), Some("svc-1"), Some(10), 6),
+        ]);
+        let queue_reader = Arc::new(FakeQueueReader {
+            batches: HashMap::from([((1, 0), vec![batch_1.clone()]), ((2, 0), vec![batch_2.clone()])]),
+            open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
+        });
+        let observer = Arc::new(FakeObserver::default());
+        let cancel_token = CancellationToken::new();
+        let merger = RowGroupsMerger::new(
+            queue_reader,
+            &[plan_with_bytes(1, 0, &batch_1, 10), plan_with_bytes(2, 0, &batch_2, 20)],
+            SortedBatchMergerConfig {
+                row_group_size: 2,
+                read_parallelism: 2,
+                topic: "logs".to_string(),
+                cancel_token: cancel_token.clone(),
+            },
+        )
+        .expect("merger")
+        .with_observer(Arc::clone(&observer) as Arc<dyn RowGroupsMergerObserver>);
+
+        let mut stream = merger.into_stream();
+        let _ = stream.try_next().await.expect("first batch").expect("first batch");
+        assert!(observer.open_row_groups() > 0);
+        cancel_token.cancel();
+        let _ = stream.try_next().await.expect_err("cancelled");
+        drop(stream);
+
+        assert_eq!(observer.open_row_groups(), 0);
+        assert_eq!(observer.open_row_group_bytes(), 0);
+    }
+
+    #[tokio::test]
+    async fn merger_observer_keeps_balanced_counts_when_bootstrap_fails() {
+        let batch = logs_batch(vec![(Some("acc-1"), Some("svc-1"), Some(40), 1)]);
+        let batch_2 = logs_batch(vec![(Some("acc-1"), Some("svc-1"), Some(40), 2)]);
+        let queue_reader = Arc::new(FakeQueueReader {
+            batches: HashMap::from([((1, 0), vec![batch.clone()]), ((2, 0), vec![batch_2.clone()])]),
+            open_delays: HashMap::new(),
+            error_after_n_reads: Some(2),
+            ..FakeQueueReader::default()
+        });
+        let observer = Arc::new(FakeObserver::default());
+        let merger = RowGroupsMerger::new(
+            queue_reader,
+            &[plan_with_bytes(1, 0, &batch, 10), plan_with_bytes(2, 0, &batch_2, 20)],
+            SortedBatchMergerConfig {
+                row_group_size: 1,
+                read_parallelism: 1,
+                topic: "logs".to_string(),
+                cancel_token: CancellationToken::new(),
+            },
+        )
+        .expect("merger")
+        .with_observer(Arc::clone(&observer) as Arc<dyn RowGroupsMergerObserver>);
+
+        let mut stream = merger.into_stream();
+        let err = stream.try_next().await.expect_err("bootstrap must fail");
+        assert!(matches!(err, IngestError::ShiftQueueRead(_)));
+        drop(stream);
+
+        assert_eq!(observer.opened_calls(), 1);
+        assert_eq!(observer.closed_calls(), 1);
+        assert_eq!(observer.open_row_groups(), 0);
+        assert_eq!(observer.open_row_group_bytes(), 0);
+    }
+
+    #[tokio::test]
+    async fn merger_output_is_unchanged_with_observer_enabled() {
+        let batch_1 = logs_batch(vec![
+            (Some("acc-1"), Some("svc-1"), Some(40), 1),
+            (Some("acc-1"), Some("svc-1"), Some(20), 3),
+        ]);
+        let batch_2 = logs_batch(vec![
+            (Some("acc-1"), Some("svc-1"), Some(30), 2),
+            (Some("acc-1"), Some("svc-1"), Some(10), 4),
+        ]);
+        let queue_reader = Arc::new(FakeQueueReader {
+            batches: HashMap::from([((1, 0), vec![batch_1.clone()]), ((2, 0), vec![batch_2.clone()])]),
+            open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
+        });
+        let expected = merged_values(
+            Arc::clone(&queue_reader),
+            vec![plan(1, 0, &batch_1), plan(2, 0, &batch_2)],
+        )
+        .await;
+        let actual = merged_values_with_observer(
+            queue_reader,
+            vec![plan(1, 0, &batch_1), plan(2, 0, &batch_2)],
+            Arc::new(FakeObserver::default()) as Arc<dyn RowGroupsMergerObserver>,
+        )
+        .await;
+
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn merger_observer_records_row_group_lifetime_for_multi_stream_merge() {
+        let batch_1 = logs_batch(vec![
+            (Some("acc-1"), Some("svc-1"), Some(40), 1),
+            (Some("acc-1"), Some("svc-1"), Some(20), 3),
+        ]);
+        let batch_2 = logs_batch(vec![
+            (Some("acc-1"), Some("svc-1"), Some(30), 2),
+            (Some("acc-1"), Some("svc-1"), Some(10), 4),
+        ]);
+        let queue_reader = Arc::new(FakeQueueReader {
+            batches: HashMap::from([((1, 0), vec![batch_1.clone()]), ((2, 0), vec![batch_2.clone()])]),
+            open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
+        });
+        let observer = Arc::new(FakeObserver::default());
+        let _values = merged_values_with_observer(
+            queue_reader,
+            vec![plan(1, 0, &batch_1), plan(2, 0, &batch_2)],
+            Arc::clone(&observer) as Arc<dyn RowGroupsMergerObserver>,
+        )
+        .await;
+
+        assert_eq!(observer.lifetime_calls(), 2);
+        assert_eq!(observer.lifetimes().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn merger_observer_records_row_group_lifetime_for_single_stream_merge() {
+        let batch = logs_batch(vec![
+            (Some("acc-1"), Some("svc-1"), Some(30), 1),
+            (Some("acc-1"), Some("svc-1"), Some(20), 2),
+            (Some("acc-1"), Some("svc-1"), Some(10), 3),
+        ]);
+        let queue_reader = Arc::new(FakeQueueReader {
+            batches: HashMap::from([((1, 0), vec![batch.clone()])]),
+            open_delays: HashMap::new(),
+            ..FakeQueueReader::default()
+        });
+        let observer = Arc::new(FakeObserver::default());
+        let merger = RowGroupsMerger::new(
+            queue_reader,
+            &[plan(1, 0, &batch)],
+            SortedBatchMergerConfig {
+                row_group_size: 1,
+                read_parallelism: 1,
+                topic: "logs".to_string(),
+                cancel_token: CancellationToken::new(),
+            },
+        )
+        .expect("merger")
+        .with_observer(Arc::clone(&observer) as Arc<dyn RowGroupsMergerObserver>);
+
+        let _batches = merger.into_stream().try_collect::<Vec<_>>().await.expect("merged");
+
+        assert_eq!(observer.lifetime_calls(), 1);
+        assert_eq!(observer.lifetimes().len(), 1);
     }
 
     #[test]
@@ -1597,10 +2018,11 @@ mod tests {
             ),
         ]);
 
-        let Err(err) = RowGroupsMerger::try_new_with_plan(
+        let Err(err) = RowGroupsMerger::new_with_plan(
             Arc::new(FakeQueueReader {
                 batches: HashMap::new(),
                 open_delays: HashMap::new(),
+                ..FakeQueueReader::default()
             }),
             plan,
             SortedBatchMergerConfig {
@@ -1609,6 +2031,7 @@ mod tests {
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
             },
+            Arc::new(NoopRowGroupsMergerObserver),
         ) else {
             panic!("incompatible boundary keys must be rejected");
         };
@@ -1633,10 +2056,11 @@ mod tests {
             ),
         ]);
 
-        let Err(err) = RowGroupsMerger::try_new_with_plan(
+        let Err(err) = RowGroupsMerger::new_with_plan(
             Arc::new(FakeQueueReader {
                 batches: HashMap::new(),
                 open_delays: HashMap::new(),
+                ..FakeQueueReader::default()
             }),
             plan,
             SortedBatchMergerConfig {
@@ -1645,6 +2069,7 @@ mod tests {
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
             },
+            Arc::new(NoopRowGroupsMergerObserver),
         ) else {
             panic!("duplicate row groups must be rejected");
         };

--- a/crates/icegate-ingest/src/shift/shift_runner.rs
+++ b/crates/icegate-ingest/src/shift/shift_runner.rs
@@ -14,7 +14,9 @@ use super::{
     SegmentToRead, ShiftInput, ShiftOutput,
     executor::{TaskStatus, parse_task_input},
     iceberg_storage::Storage,
-    row_groups_merger::{RowGroupsMerger, SortedBatchMergerConfig},
+    row_groups_merger::{
+        NoopRowGroupsMergerObserver, RowGroupsMerger, RowGroupsMergerObserver, SortedBatchMergerConfig,
+    },
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -106,6 +108,7 @@ pub struct ShiftTaskRunnerImpl<Q, S> {
     output_batch_size: usize,
     segment_read_parallelism: usize,
     retrier: Retrier,
+    row_groups_merger_observer: Arc<dyn RowGroupsMergerObserver>,
 }
 
 impl<Q, S> ShiftTaskRunnerImpl<Q, S>
@@ -139,6 +142,7 @@ where
             output_batch_size,
             segment_read_parallelism: Self::DEFAULT_SEGMENT_READ_PARALLELISM,
             retrier: Retrier::new(RetrierConfig::default()),
+            row_groups_merger_observer: Arc::new(NoopRowGroupsMergerObserver),
         })
     }
 
@@ -158,6 +162,13 @@ where
         }
         self.segment_read_parallelism = segment_read_parallelism;
         Ok(self)
+    }
+
+    /// Set merger observer for row group lifecycle and merge timing.
+    #[must_use]
+    pub fn with_row_groups_merger_observer(mut self, observer: Arc<dyn RowGroupsMergerObserver>) -> Self {
+        self.row_groups_merger_observer = observer;
+        self
     }
 }
 
@@ -312,7 +323,7 @@ where
         segments: &[SegmentToRead],
         cancel_token: &CancellationToken,
     ) -> Result<crate::shift::iceberg_storage::WrittenDataFiles, ShiftWriteError> {
-        let mut merger = RowGroupsMerger::try_new_from_segments(
+        let mut merger = RowGroupsMerger::new(
             Arc::clone(&self.queue_reader),
             segments,
             SortedBatchMergerConfig {
@@ -322,7 +333,8 @@ where
                 cancel_token: cancel_token.clone(),
             },
         )
-        .map_err(ShiftWriteError::queue_read)?;
+        .map_err(ShiftWriteError::queue_read)?
+        .with_observer(Arc::clone(&self.row_groups_merger_observer));
         merger.prefetch_first_group().await.map_err(ShiftWriteError::queue_read)?;
         let merged_stream = merger.into_stream();
         self.storage


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple Grafana panels for OTLP transform/decode latency, WAL records/segments, WAL flush counts, queue reader/writer request metrics, and task/shift success/error rates.
  * Added observability for row-groups merger (open counts, open bytes, lifetime quantiles) and wired observer metrics into shift processing.

* **Chores**
  * Refreshed dashboard queries, panel layouts, units, and tooltip/sort settings; updated Jobmanager S3 error-rate calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->