### PR TITLE
GH-116: Add tracing support to ingest

### DIFF
--- a/config/kustomize/base/otel-collector/configmap.yaml
+++ b/config/kustomize/base/otel-collector/configmap.yaml
@@ -199,6 +199,7 @@ data:
 
       batch: {}
 
+      # Shared environment/demo labels. Added to both logs and traces.
       resource:
         attributes:
           - key: deployment.environment
@@ -207,14 +208,24 @@ data:
           - key: demo.source
             value: kubernetes
             action: upsert
-          # Align log `service.name` with the value traces carry.
-          # icegate's OTel SDK emits `service.name = icegate-ingest` /
-          # `icegate-query`, which matches the Deployment name k8s_attributes
-          # already extracted. Overriding the label-derived value (`icegate`)
-          # with `k8s.deployment.name` unifies logs and traces under one
-          # service identity. Pods not managed by a Deployment lack
-          # `k8s.deployment.name`; upsert+from_attribute becomes a no-op in
-          # that case so the label fallback survives.
+
+      # Logs-only override: align `service.name` with what traces carry.
+      # k8s_attributes extracts `service.name` from the `app.kubernetes.io/name`
+      # label, which is the coarser "icegate" identity. The Deployment name
+      # (`icegate-ingest`, `icegate-query`) matches what the OTel SDK emits
+      # on traces, so using `k8s.deployment.name` here unifies both signals.
+      #
+      # We explicitly do NOT apply this override on the traces pipeline:
+      # traces always carry an SDK-set `service.name`, and third-party
+      # traces routed through the collector must keep their original
+      # service identity. Keeping the override logs-only avoids clobbering
+      # it.
+      #
+      # Pods not managed by a Deployment (e.g. the otel-collector DaemonSet
+      # itself) lack `k8s.deployment.name`; upsert+from_attribute is a no-op
+      # in that case so the label-derived fallback survives.
+      resource/logs_service_name:
+        attributes:
           - key: service.name
             from_attribute: k8s.deployment.name
             action: upsert
@@ -230,9 +241,10 @@ data:
       pipelines:
         logs:
           receivers: [file_log]
-          processors: [k8s_attributes, batch, resource]
+          processors: [k8s_attributes, batch, resource, resource/logs_service_name]
           exporters: [otlp_http]
         traces:
+          # Traces keep the SDK-set service.name; no logs_service_name override.
           receivers: [otlp]
           processors: [k8s_attributes, batch, resource]
           exporters: [otlp_http]

--- a/config/kustomize/base/otel-collector/configmap.yaml
+++ b/config/kustomize/base/otel-collector/configmap.yaml
@@ -9,6 +9,15 @@ metadata:
 data:
   config.yaml: |
     receivers:
+      # OTLP receiver accepts traces (and future signals) from in-cluster
+      # workloads. Traces are forwarded to icegate-ingest via the traces
+      # pipeline defined below.
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
       file_log:
         include:
           - /var/log/pods/*/*/*.log
@@ -95,21 +104,18 @@ data:
               - output: use-message
                 expr: 'attributes.fields.message != nil and attributes.fields.message != ""'
             default: use-fields
+          # Both branches converge at cleanup-level. The target→code.namespace
+          # move happens exactly once, on the common path below, so we never
+          # try to move an already-moved attribute.
           - type: move
             id: use-message
             from: attributes.fields.message
             to: body
-            output: cleanup-fields
+            output: cleanup-level
           - type: move
             id: use-fields
             from: attributes.fields
             to: body
-            output: cleanup-level
-          # Move target to attribute
-          - type: move
-            id: cleanup-fields
-            from: attributes.target
-            to: attributes["code.namespace"]
             output: cleanup-level
           # Remove parsed JSON fields that are now redundant
           - type: remove
@@ -124,14 +130,16 @@ data:
           - type: remove
             id: cleanup-fields-obj
             field: attributes.fields
-            on_error: send
+            on_error: send_quiet
             output: cleanup-target
-          # Move target if still present (use-fields path skipped earlier move)
+          # Move target → code.namespace. Some JSON logs (non-Rust producers)
+          # don't carry a target field; send_quiet swallows the missing-source
+          # error without spamming the collector's own log stream.
           - type: move
             id: cleanup-target
             from: attributes.target
             to: attributes["code.namespace"]
-            on_error: send
+            on_error: send_quiet
             output: rename-attributes
           # Rename attributes to semantic conventions
           - id: rename-attributes
@@ -199,6 +207,17 @@ data:
           - key: demo.source
             value: kubernetes
             action: upsert
+          # Align log `service.name` with the value traces carry.
+          # icegate's OTel SDK emits `service.name = icegate-ingest` /
+          # `icegate-query`, which matches the Deployment name k8s_attributes
+          # already extracted. Overriding the label-derived value (`icegate`)
+          # with `k8s.deployment.name` unifies logs and traces under one
+          # service identity. Pods not managed by a Deployment lack
+          # `k8s.deployment.name`; upsert+from_attribute becomes a no-op in
+          # that case so the label fallback survives.
+          - key: service.name
+            from_attribute: k8s.deployment.name
+            action: upsert
 
     exporters:
       otlp_http:
@@ -211,5 +230,9 @@ data:
       pipelines:
         logs:
           receivers: [file_log]
+          processors: [k8s_attributes, batch, resource]
+          exporters: [otlp_http]
+        traces:
+          receivers: [otlp]
           processors: [k8s_attributes, batch, resource]
           exporters: [otlp_http]

--- a/config/kustomize/base/otel-collector/daemonset.yaml
+++ b/config/kustomize/base/otel-collector/daemonset.yaml
@@ -28,6 +28,15 @@ spec:
           image: otel/opentelemetry-collector-contrib:0.149.0
           args:
             - --config=/etc/otelcol-contrib/config.yaml
+          ports:
+            # OTLP gRPC receiver for traces from in-cluster workloads.
+            - name: otlp-grpc
+              containerPort: 4317
+              protocol: TCP
+            # OTLP HTTP receiver.
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/config/kustomize/base/otel-collector/service.yaml
+++ b/config/kustomize/base/otel-collector/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: observability
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/component: log-collector
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp-grpc
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: otlp-http
+      protocol: TCP

--- a/config/kustomize/overlays/aws-glue/values-icegate.yaml
+++ b/config/kustomize/overlays/aws-glue/values-icegate.yaml
@@ -56,7 +56,7 @@ query:
     port: 3200
   tracing:
     enabled: true
-    otlpEndpoint: http://jaeger-collector.observability.svc.cluster.local.:4317
+    otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
     sampleRatio: 1.0
   rustLog: "info,icegate_query=debug,icegate_common=debug,datafusion_tracing=debug,opendal=debug,aws_sdk_s3=warn,aws_smithy_http=warn,aws_smithy_client=warn,aws_smithy_runtime=warn,aws_smithy_runtime_api=warn"
   resources:
@@ -88,7 +88,7 @@ ingest:
     port: 4317
   tracing:
     enabled: true
-    otlpEndpoint: http://jaeger-collector.observability.svc.cluster.local.:4317
+    otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
     sampleRatio: 1.0
   shift:
     jobsmanager:

--- a/config/kustomize/overlays/aws-s3tables/values-icegate.yaml
+++ b/config/kustomize/overlays/aws-s3tables/values-icegate.yaml
@@ -52,7 +52,7 @@ query:
     port: 3200
   tracing:
     enabled: true
-    otlpEndpoint: http://jaeger-collector.observability.svc.cluster.local.:4317
+    otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
     sampleRatio: 1.0
   rustLog: "info,icegate_query=debug,icegate_common=debug,datafusion_tracing=debug,opendal=debug,aws_sdk_s3=warn,aws_smithy_http=warn,aws_smithy_client=warn,aws_smithy_runtime=warn,aws_smithy_runtime_api=warn"
   resources:
@@ -75,7 +75,7 @@ ingest:
     port: 4317
   tracing:
     enabled: true
-    otlpEndpoint: http://jaeger-collector.observability.svc.cluster.local.:4317
+    otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
     sampleRatio: 1.0
   shift:
     jobsmanager:

--- a/config/kustomize/overlays/external-s3/values-icegate.yaml
+++ b/config/kustomize/overlays/external-s3/values-icegate.yaml
@@ -60,7 +60,7 @@ query:
     port: 3200
   tracing:
     enabled: true
-    otlpEndpoint: http://jaeger-collector.observability.svc.cluster.local.:4317
+    otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
     sampleRatio: 1.0
   rustLog: "info,icegate_query=debug,icegate_common=debug,datafusion_tracing=debug,opendal=debug,aws_sdk_s3=warn,aws_smithy_http=warn,aws_smithy_client=warn,aws_smithy_runtime=warn,aws_smithy_runtime_api=warn"
   resources:
@@ -87,7 +87,7 @@ ingest:
     port: 4317
   tracing:
     enabled: true
-    otlpEndpoint: http://jaeger-collector.observability.svc.cluster.local.:4317
+    otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
     sampleRatio: 1.0
   shift:
     jobsmanager:

--- a/config/kustomize/overlays/orbstack/values-icegate.yaml
+++ b/config/kustomize/overlays/orbstack/values-icegate.yaml
@@ -63,7 +63,7 @@ query:
     port: 3200
   tracing:
     enabled: true
-    otlpEndpoint: http://jaeger-collector.observability.svc.cluster.local.:4317
+    otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
     sampleRatio: 1.0
   rustLog: "info,icegate_query=debug,icegate_common=debug,datafusion_tracing=debug,opendal=debug,reqwest_tracing=debug,aws_sdk_s3=warn,aws_smithy_http=warn,aws_smithy_client=warn,aws_smithy_runtime=warn,aws_smithy_runtime_api=warn"
   resources:
@@ -91,7 +91,7 @@ ingest:
     port: 4317
   tracing:
     enabled: true
-    otlpEndpoint: http://jaeger-collector.observability.svc.cluster.local.:4317
+    otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
     sampleRatio: 1.0
   shift:
     jobsmanager:

--- a/config/kustomize/overlays/skaffold/kustomization.yaml
+++ b/config/kustomize/overlays/skaffold/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base
   - secret-aws.yaml
   - secret-aws-infra.yaml
+  - trino
 
 helmGlobals:
   chartHome: ../../../helm

--- a/config/kustomize/overlays/skaffold/trino/configmap.yaml
+++ b/config/kustomize/overlays/skaffold/trino/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trino-config
+  namespace: infra
+  labels:
+    app.kubernetes.io/name: trino
+    app.kubernetes.io/component: coordinator
+data:
+  # Iceberg catalog backed by Nessie REST + MinIO S3. Mirrors the
+  # docker-compose config at config/docker/trino/iceberg.properties with
+  # in-cluster DNS for Nessie and MinIO.
+  iceberg.properties: |
+    connector.name=iceberg
+    iceberg.catalog.type=rest
+    iceberg.rest-catalog.uri=http://nessie.infra.svc.cluster.local.:19120/iceberg
+    iceberg.rest-catalog.prefix=main
+    fs.native-s3.enabled=true
+    s3.endpoint=http://minio.infra.svc.cluster.local.:9000
+    s3.region=us-east-1
+    s3.path-style-access=true
+    s3.aws-access-key=minioadmin
+    s3.aws-secret-key=minioadmin

--- a/config/kustomize/overlays/skaffold/trino/deployment.yaml
+++ b/config/kustomize/overlays/skaffold/trino/deployment.yaml
@@ -20,18 +20,42 @@ spec:
         app.kubernetes.io/name: trino
         app.kubernetes.io/component: coordinator
     spec:
+      # Trino's coordinator image runs as the `trino` user (UID/GID 1000) by
+      # default. `runAsNonRoot: true` requires a numeric UID so the kubelet
+      # can verify the user is non-root without resolving names inside the
+      # image, hence the explicit 1000s. Trino writes its working state to
+      # /data/trino, so we can't set readOnlyRootFilesystem: true without
+      # adding an emptyDir volume; that's a follow-up if stricter hardening
+      # is needed.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: trino
           image: trinodb/trino:479
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
           env:
             - name: AWS_ACCESS_KEY_ID
-              value: minioadmin
+              valueFrom:
+                secretKeyRef:
+                  name: trino-s3-credentials
+                  key: AWS_ACCESS_KEY_ID
             - name: AWS_SECRET_ACCESS_KEY
-              value: minioadmin
+              valueFrom:
+                secretKeyRef:
+                  name: trino-s3-credentials
+                  key: AWS_SECRET_ACCESS_KEY
+            # Region is not sensitive — keep inline.
             - name: AWS_REGION
               value: us-east-1
           volumeMounts:

--- a/config/kustomize/overlays/skaffold/trino/deployment.yaml
+++ b/config/kustomize/overlays/skaffold/trino/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trino
+  namespace: infra
+  labels:
+    app.kubernetes.io/name: trino
+    app.kubernetes.io/component: coordinator
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trino
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: trino
+        app.kubernetes.io/component: coordinator
+    spec:
+      containers:
+        - name: trino
+          image: trinodb/trino:479
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: minioadmin
+            - name: AWS_SECRET_ACCESS_KEY
+              value: minioadmin
+            - name: AWS_REGION
+              value: us-east-1
+          volumeMounts:
+            - name: catalog
+              mountPath: /etc/trino/catalog/iceberg.properties
+              subPath: iceberg.properties
+              readOnly: true
+          readinessProbe:
+            exec:
+              command:
+                - /usr/lib/trino/bin/health-check
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - /usr/lib/trino/bin/health-check
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 4
+          resources:
+            requests:
+              cpu: 500m
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+      volumes:
+        - name: catalog
+          configMap:
+            name: trino-config
+            items:
+              - key: iceberg.properties
+                path: iceberg.properties

--- a/config/kustomize/overlays/skaffold/trino/deployment.yaml
+++ b/config/kustomize/overlays/skaffold/trino/deployment.yaml
@@ -13,6 +13,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: trino
+      app.kubernetes.io/component: coordinator
   template:
     metadata:
       labels:

--- a/config/kustomize/overlays/skaffold/trino/kustomization.yaml
+++ b/config/kustomize/overlays/skaffold/trino/kustomization.yaml
@@ -2,9 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - serviceaccount.yaml
-  - clusterrole.yaml
-  - clusterrolebinding.yaml
   - configmap.yaml
-  - daemonset.yaml
+  - deployment.yaml
   - service.yaml

--- a/config/kustomize/overlays/skaffold/trino/kustomization.yaml
+++ b/config/kustomize/overlays/skaffold/trino/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - service.yaml
+  - secret.yaml

--- a/config/kustomize/overlays/skaffold/trino/secret.yaml
+++ b/config/kustomize/overlays/skaffold/trino/secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trino-s3-credentials
+  namespace: infra
+  labels:
+    app.kubernetes.io/name: trino
+    app.kubernetes.io/component: coordinator
+type: Opaque
+# Dev-stack credentials for the in-cluster MinIO (matches the
+# values-minio.yaml rootUser/rootPassword). The skaffold overlay is the
+# local development surface; production overlays must ship their own
+# Secret with the cluster's real credentials out-of-band and must not
+# commit plaintext values.
+stringData:
+  AWS_ACCESS_KEY_ID: minioadmin
+  AWS_SECRET_ACCESS_KEY: minioadmin

--- a/config/kustomize/overlays/skaffold/trino/service.yaml
+++ b/config/kustomize/overlays/skaffold/trino/service.yaml
@@ -10,6 +10,7 @@ spec:
   type: ClusterIP
   selector:
     app.kubernetes.io/name: trino
+    app.kubernetes.io/component: coordinator
   ports:
     - name: http
       port: 8080

--- a/config/kustomize/overlays/skaffold/trino/service.yaml
+++ b/config/kustomize/overlays/skaffold/trino/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trino
+  namespace: infra
+  labels:
+    app.kubernetes.io/name: trino
+    app.kubernetes.io/component: coordinator
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: trino
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/config/kustomize/overlays/skaffold/values-icegate.yaml
+++ b/config/kustomize/overlays/skaffold/values-icegate.yaml
@@ -63,7 +63,7 @@ query:
     port: 3200
   tracing:
     enabled: true
-    otlpEndpoint: http://jaeger-collector.observability.svc.cluster.local.:4317
+    otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
     sampleRatio: 1.0
   rustLog: "info,icegate_query=debug,icegate_common=debug,datafusion_tracing=debug,opendal=debug,reqwest_tracing=debug,aws_sdk_s3=warn,aws_smithy_http=warn,aws_smithy_client=warn,aws_smithy_runtime=warn,aws_smithy_runtime_api=warn"
   resources:
@@ -94,7 +94,7 @@ ingest:
     port: 6669
   tracing:
     enabled: true
-    otlpEndpoint: http://jaeger-collector.observability.svc.cluster.local.:4317
+    otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
     sampleRatio: 1.0
   shift:
     jobsmanager:

--- a/crates/icegate-common/src/lib.rs
+++ b/crates/icegate-common/src/lib.rs
@@ -43,6 +43,9 @@ pub fn is_valid_tenant_id(value: &str) -> bool {
 /// Topic name for logs in the WAL queue.
 pub const LOGS_TOPIC: &str = "logs";
 
+/// Topic name for spans in the WAL queue.
+pub const SPANS_TOPIC: &str = "spans";
+
 /// Iceberg snapshot summary key for the last committed WAL queue offset.
 ///
 /// Written by the Shifter after each WAL-to-Iceberg commit and read by the

--- a/crates/icegate-common/src/schema.rs
+++ b/crates/icegate-common/src/schema.rs
@@ -201,82 +201,9 @@ pub fn logs_sort_order(schema: &Schema) -> Result<SortOrder> {
 /// - `timestamp` (descending)
 #[allow(clippy::too_many_lines)]
 pub fn spans_schema() -> Result<Schema> {
-    // Create Map<String, String> for main attributes (field IDs: 24, 25)
-    let attributes_map = Type::Map(MapType::new(
-        Arc::new(NestedField::required(24, "key", Type::Primitive(PrimitiveType::String))),
-        Arc::new(NestedField::required(
-            25,
-            "value",
-            Type::Primitive(PrimitiveType::String),
-        )),
-    ));
-
-    // Create Map<String, String> for event attributes (field IDs: 26, 27)
-    let event_attributes_map = Type::Map(MapType::new(
-        Arc::new(NestedField::required(26, "key", Type::Primitive(PrimitiveType::String))),
-        Arc::new(NestedField::required(
-            27,
-            "value",
-            Type::Primitive(PrimitiveType::String),
-        )),
-    ));
-
-    // Create Map<String, String> for link attributes (field IDs: 28, 29)
-    let link_attributes_map = Type::Map(MapType::new(
-        Arc::new(NestedField::required(28, "key", Type::Primitive(PrimitiveType::String))),
-        Arc::new(NestedField::required(
-            29,
-            "value",
-            Type::Primitive(PrimitiveType::String),
-        )),
-    ));
-
-    // Event struct (nested in spans) - NO trace_id/span_id
-    let event_struct = Type::Struct(StructType::new(vec![
-        Arc::new(NestedField::required(
-            30,
-            "timestamp",
-            Type::Primitive(PrimitiveType::Timestamp),
-        )),
-        Arc::new(NestedField::required(
-            31,
-            "name",
-            Type::Primitive(PrimitiveType::String),
-        )),
-        Arc::new(NestedField::required(32, "attributes", event_attributes_map)),
-        Arc::new(NestedField::required(
-            33,
-            "dropped_attributes_count",
-            Type::Primitive(PrimitiveType::Int),
-        )),
-    ]));
-
-    // Link struct (nested in spans) - HAS trace_id/span_id
-    let link_struct = Type::Struct(StructType::new(vec![
-        Arc::new(NestedField::required(
-            34,
-            "trace_id",
-            Type::Primitive(PrimitiveType::String),
-        )),
-        Arc::new(NestedField::required(
-            35,
-            "span_id",
-            Type::Primitive(PrimitiveType::String),
-        )),
-        Arc::new(NestedField::optional(
-            36,
-            "trace_state",
-            Type::Primitive(PrimitiveType::String),
-        )),
-        Arc::new(NestedField::required(37, "attributes", link_attributes_map)),
-        Arc::new(NestedField::required(
-            38,
-            "dropped_attributes_count",
-            Type::Primitive(PrimitiveType::Int),
-        )),
-        Arc::new(NestedField::optional(39, "flags", Type::Primitive(PrimitiveType::Int))),
-    ]));
-
+    // Field IDs are hardcoded depth-first so reading top-to-bottom gives the
+    // assignment order. Parents sit on the left column, their nested children
+    // on indented lines immediately below.
     let schema = Schema::builder()
         .with_schema_id(2)
         .with_fields(vec![
@@ -333,12 +260,12 @@ pub fn spans_schema() -> Result<Schema> {
                 "duration_micros",
                 Type::Primitive(PrimitiveType::Long),
             )),
+            // Span metadata
             Arc::new(NestedField::optional(
                 11,
                 "trace_state",
                 Type::Primitive(PrimitiveType::String),
             )),
-            // Span metadata
             Arc::new(NestedField::required(
                 12,
                 "name",
@@ -355,42 +282,120 @@ pub fn spans_schema() -> Result<Schema> {
                 "status_message",
                 Type::Primitive(PrimitiveType::String),
             )),
-            // Attributes (merged from resource, scope, and span attributes)
-            Arc::new(NestedField::required(16, "attributes", attributes_map)),
+            // Attributes (merged from resource, scope, and span attributes).
+            // Map nested key/value consume IDs 17, 18.
+            Arc::new(NestedField::required(
+                16,
+                "attributes",
+                Type::Map(MapType::new(
+                    Arc::new(NestedField::required(17, "key", Type::Primitive(PrimitiveType::String))),
+                    Arc::new(NestedField::required(
+                        18,
+                        "value",
+                        Type::Primitive(PrimitiveType::String),
+                    )),
+                )),
+            )),
             // Flags and monitoring
-            Arc::new(NestedField::optional(17, "flags", Type::Primitive(PrimitiveType::Int))),
+            Arc::new(NestedField::optional(19, "flags", Type::Primitive(PrimitiveType::Int))),
             Arc::new(NestedField::optional(
-                18,
+                20,
                 "dropped_attributes_count",
                 Type::Primitive(PrimitiveType::Int),
             )),
             Arc::new(NestedField::optional(
-                19,
+                21,
                 "dropped_events_count",
                 Type::Primitive(PrimitiveType::Int),
             )),
             Arc::new(NestedField::optional(
-                20,
+                22,
                 "dropped_links_count",
                 Type::Primitive(PrimitiveType::Int),
             )),
-            // Nested events (NO trace_id/span_id - inherits from parent span)
+            // Nested events (NO trace_id/span_id — inherits from parent span).
+            // List element struct consumes ID 24; its fields consume 25–27, 30;
+            // the nested attributes Map consumes 27 with key/value 28, 29.
             Arc::new(NestedField::optional(
-                21,
+                23,
                 "events",
                 Type::List(ListType::new(Arc::new(NestedField::list_element(
-                    40,
-                    event_struct,
+                    24,
+                    Type::Struct(StructType::new(vec![
+                        Arc::new(NestedField::required(
+                            25,
+                            "timestamp",
+                            Type::Primitive(PrimitiveType::Timestamp),
+                        )),
+                        Arc::new(NestedField::required(
+                            26,
+                            "name",
+                            Type::Primitive(PrimitiveType::String),
+                        )),
+                        Arc::new(NestedField::required(
+                            27,
+                            "attributes",
+                            Type::Map(MapType::new(
+                                Arc::new(NestedField::required(28, "key", Type::Primitive(PrimitiveType::String))),
+                                Arc::new(NestedField::required(
+                                    29,
+                                    "value",
+                                    Type::Primitive(PrimitiveType::String),
+                                )),
+                            )),
+                        )),
+                        Arc::new(NestedField::required(
+                            30,
+                            "dropped_attributes_count",
+                            Type::Primitive(PrimitiveType::Int),
+                        )),
+                    ])),
                     true,
                 )))),
             )),
-            // Nested links (HAS trace_id/span_id - references linked span)
+            // Nested links (HAS trace_id/span_id — references linked span).
+            // List element struct consumes ID 32; its fields consume 33–36, 39, 40;
+            // the nested attributes Map consumes 36 with key/value 37, 38.
             Arc::new(NestedField::optional(
-                22,
+                31,
                 "links",
                 Type::List(ListType::new(Arc::new(NestedField::list_element(
-                    41,
-                    link_struct,
+                    32,
+                    Type::Struct(StructType::new(vec![
+                        Arc::new(NestedField::required(
+                            33,
+                            "trace_id",
+                            Type::Primitive(PrimitiveType::String),
+                        )),
+                        Arc::new(NestedField::required(
+                            34,
+                            "span_id",
+                            Type::Primitive(PrimitiveType::String),
+                        )),
+                        Arc::new(NestedField::optional(
+                            35,
+                            "trace_state",
+                            Type::Primitive(PrimitiveType::String),
+                        )),
+                        Arc::new(NestedField::required(
+                            36,
+                            "attributes",
+                            Type::Map(MapType::new(
+                                Arc::new(NestedField::required(37, "key", Type::Primitive(PrimitiveType::String))),
+                                Arc::new(NestedField::required(
+                                    38,
+                                    "value",
+                                    Type::Primitive(PrimitiveType::String),
+                                )),
+                            )),
+                        )),
+                        Arc::new(NestedField::required(
+                            39,
+                            "dropped_attributes_count",
+                            Type::Primitive(PrimitiveType::Int),
+                        )),
+                        Arc::new(NestedField::optional(40, "flags", Type::Primitive(PrimitiveType::Int))),
+                    ])),
                     true,
                 )))),
             )),
@@ -1041,12 +1046,66 @@ mod tests {
     #[test]
     fn test_spans_schema() {
         let schema = spans_schema().expect("Failed to create spans schema");
-        // highest_field_id includes nested field IDs from Maps, Lists, and Structs
-        assert!(schema.highest_field_id() >= 22);
+        assert_eq!(schema.highest_field_id(), 40);
         assert!(schema.field_by_name("trace_id").is_some());
         assert!(schema.field_by_name("span_id").is_some());
         assert!(schema.field_by_name("events").is_some());
         assert!(schema.field_by_name("links").is_some());
+    }
+
+    #[test]
+    fn test_spans_schema_nested_ids_sequential() {
+        use iceberg::spec::Type;
+
+        let schema = spans_schema().expect("Failed to create spans schema");
+        // attributes Map: parent=16, key=17, value=18
+        let attrs = schema.field_by_name("attributes").expect("attributes field");
+        assert_eq!(attrs.id, 16);
+        let Type::Map(map) = &*attrs.field_type else {
+            panic!("attributes must be Map");
+        };
+        assert_eq!(map.key_field.id, 17);
+        assert_eq!(map.value_field.id, 18);
+
+        // events List<Struct>: list=23, elem struct=24,
+        // struct fields timestamp=25, name=26, attributes=27 (map key=28, value=29), dropped_attributes_count=30
+        let events = schema.field_by_name("events").expect("events field");
+        assert_eq!(events.id, 23);
+        let Type::List(list) = &*events.field_type else {
+            panic!("events must be List");
+        };
+        assert_eq!(list.element_field.id, 24);
+        let Type::Struct(s) = &*list.element_field.field_type else {
+            panic!("events element must be Struct");
+        };
+        let ids: Vec<i32> = s.fields().iter().map(|f| f.id).collect();
+        assert_eq!(ids, vec![25, 26, 27, 30]);
+        let inner_attrs = s.fields().iter().find(|f| f.name == "attributes").expect("event attrs");
+        let Type::Map(m) = &*inner_attrs.field_type else {
+            panic!("event attributes must be Map");
+        };
+        assert_eq!(m.key_field.id, 28);
+        assert_eq!(m.value_field.id, 29);
+
+        // links List<Struct>: list=31, elem struct=32,
+        // struct fields trace_id=33, span_id=34, trace_state=35, attributes=36 (key=37, value=38), dropped_attributes_count=39, flags=40
+        let links = schema.field_by_name("links").expect("links field");
+        assert_eq!(links.id, 31);
+        let Type::List(list) = &*links.field_type else {
+            panic!("links must be List");
+        };
+        assert_eq!(list.element_field.id, 32);
+        let Type::Struct(s) = &*list.element_field.field_type else {
+            panic!("links element must be Struct");
+        };
+        let ids: Vec<i32> = s.fields().iter().map(|f| f.id).collect();
+        assert_eq!(ids, vec![33, 34, 35, 36, 39, 40]);
+        let inner_attrs = s.fields().iter().find(|f| f.name == "attributes").expect("link attrs");
+        let Type::Map(m) = &*inner_attrs.field_type else {
+            panic!("link attributes must be Map");
+        };
+        assert_eq!(m.key_field.id, 37);
+        assert_eq!(m.value_field.id, 38);
     }
 
     #[test]

--- a/crates/icegate-ingest/src/cli/commands/run.rs
+++ b/crates/icegate-ingest/src/cli/commands/run.rs
@@ -9,7 +9,10 @@ use std::{
 };
 
 use futures::stream::{FuturesUnordered, StreamExt};
-use icegate_common::{IoHandle, MetricsRuntime, catalog::CatalogBuilder, create_object_store, run_metrics_server};
+use icegate_common::{
+    IoHandle, LOGS_TABLE, LOGS_TOPIC, MetricsRuntime, SPANS_TABLE, SPANS_TOPIC, catalog::CatalogBuilder,
+    create_object_store, run_metrics_server,
+};
 use icegate_queue::{NoopQueueWriterEvents, ParquetQueueReader, QueueConfig, QueueWriter, channel};
 use object_store::ObjectStore;
 use tokio::runtime::Builder;
@@ -24,7 +27,8 @@ use crate::{
         WalWriterMetrics,
     },
     runtime_threads::compute_runtime_threads,
-    shift::Shifter,
+    shift::{ShiftJobSpec, Shifter},
+    wal::SortColumnsDescriptor,
 };
 
 struct ShiftRuntimeHandle {
@@ -429,6 +433,21 @@ async fn run_services(
     let otlp_metrics = metrics_runtime
         .as_ref()
         .map_or_else(OtlpMetrics::new_disabled, |runtime| OtlpMetrics::new(&runtime.meter()));
+    let jobs: &[ShiftJobSpec] = &[
+        ShiftJobSpec {
+            job_name: "shift_logs",
+            topic: LOGS_TOPIC,
+            table: LOGS_TABLE,
+            descriptor: SortColumnsDescriptor::logs()?,
+        },
+        ShiftJobSpec {
+            job_name: "shift_spans",
+            topic: SPANS_TOPIC,
+            table: SPANS_TABLE,
+            descriptor: SortColumnsDescriptor::spans()?,
+        },
+    ];
+
     let shifter = Shifter::new(
         catalog,
         queue_reader,
@@ -436,6 +455,7 @@ async fn run_services(
         jobs_storage,
         shift_metrics,
         jobsmanager_metrics,
+        jobs,
     )
     .await?;
     let runtime_plan = compute_runtime_threads();

--- a/crates/icegate-ingest/src/lib.rs
+++ b/crates/icegate-ingest/src/lib.rs
@@ -21,6 +21,9 @@ pub mod otlp_http;
 /// OTLP to Arrow transform utilities (shared by gRPC and HTTP)
 pub mod transform;
 
+/// Shared helpers for OTLP traces partial-success response composition.
+pub(crate) mod otlp_traces_partial;
+
 /// Shift operations: moving data from WAL to Iceberg
 pub(crate) mod shift;
 

--- a/crates/icegate-ingest/src/otlp_grpc/services.rs
+++ b/crates/icegate-ingest/src/otlp_grpc/services.rs
@@ -216,7 +216,7 @@ impl TraceService for OtlpGrpcService {
         let Some(batch) = batch_opt else {
             // No valid spans - return success with any transform-time drops as rejected.
             request_metrics.record_records_per_request(0);
-            request_metrics.finish_ok();
+            crate::otlp_traces_partial::finish_metrics_with_drops(&request_metrics, drops);
             return Ok(Response::new(ExportTraceServiceResponse {
                 partial_success: grpc_partial_success_from_drops(drops).map_err(Status::from)?,
             }));
@@ -235,7 +235,7 @@ impl TraceService for OtlpGrpcService {
         })?;
         request_metrics.record_wal_sorting_duration(prepare_start.elapsed(), SIGNAL_TRACES, STATUS_OK);
         let Some(prepared) = prepared else {
-            request_metrics.finish_ok();
+            crate::otlp_traces_partial::finish_metrics_with_drops(&request_metrics, drops);
             return Ok(Response::new(ExportTraceServiceResponse {
                 partial_success: grpc_partial_success_from_drops(drops).map_err(Status::from)?,
             }));
@@ -274,7 +274,7 @@ impl TraceService for OtlpGrpcService {
                     "OTLP GRPC traces request ended successfully"
                 );
                 request_metrics.record_wal_ack_duration(ack_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_OK);
-                request_metrics.finish_ok();
+                crate::otlp_traces_partial::finish_metrics_with_drops(&request_metrics, drops);
                 Ok(Response::new(ExportTraceServiceResponse {
                     partial_success: grpc_partial_success_from_drops(drops).map_err(Status::from)?,
                 }))

--- a/crates/icegate-ingest/src/otlp_grpc/services.rs
+++ b/crates/icegate-ingest/src/otlp_grpc/services.rs
@@ -20,7 +20,6 @@ use tracing::debug;
 
 use crate::transform;
 use crate::{
-    error::IngestError,
     infra::metrics::{OtlpMetrics, OtlpRequestRecorder},
     otlp_grpc::error::GrpcError,
 };
@@ -187,7 +186,6 @@ impl TraceService for OtlpGrpcService {
     /// Transforms OTLP spans to Arrow `RecordBatch` and writes to the WAL
     /// queue. Transform-time drops (invalid `trace_id`/`span_id`) surface as
     /// `ExportTracePartialSuccess.rejected_spans`.
-    #[allow(clippy::cast_possible_wrap)]
     #[allow(clippy::too_many_lines)]
     #[tracing::instrument(name = "export_traces", skip(self, request))]
     async fn export(
@@ -287,14 +285,16 @@ impl TraceService for OtlpGrpcService {
                 }
                 request_metrics.record_wal_ack_duration(ack_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_ERROR);
                 request_metrics.finish_partial();
-                let rejected = drops
+                let combined = drops
                     .checked_add(partial.rejected_records)
-                    .and_then(|n| i64::try_from(n).ok())
-                    .ok_or_else(|| Status::internal("Rejected spans count exceeds i64"))?;
+                    .ok_or_else(|| Status::internal("Rejected spans count exceeds usize::MAX"))?;
+                let rejected =
+                    i64::try_from(combined).map_err(|_| Status::internal("Rejected spans count exceeds i64"))?;
+                let error_message = crate::otlp_traces_partial::compose_partial_reason(&partial.reason, drops);
                 Ok(Response::new(ExportTraceServiceResponse {
                     partial_success: Some(ExportTracePartialSuccess {
                         rejected_spans: rejected,
-                        error_message: partial.reason,
+                        error_message,
                     }),
                 }))
             }
@@ -303,18 +303,19 @@ impl TraceService for OtlpGrpcService {
 }
 
 /// Build an `ExportTracePartialSuccess` from transform-time drops, or `None` if there were none.
+///
+/// Delegates to the shared `otlp_traces_partial::rejected_spans_from_drops` helper so
+/// the HTTP and gRPC handlers report identical rejected counts and messages.
 fn grpc_partial_success_from_drops(
     drops: usize,
 ) -> Result<Option<opentelemetry_proto::tonic::collector::trace::v1::ExportTracePartialSuccess>, GrpcError> {
     use opentelemetry_proto::tonic::collector::trace::v1::ExportTracePartialSuccess;
-    if drops == 0 {
+    let Some(rejected) = crate::otlp_traces_partial::rejected_spans_from_drops(drops).map_err(GrpcError)? else {
         return Ok(None);
-    }
-    let rejected = i64::try_from(drops)
-        .map_err(|_| GrpcError(IngestError::Validation("Rejected spans count exceeds i64".to_string())))?;
+    };
     Ok(Some(ExportTracePartialSuccess {
         rejected_spans: rejected,
-        error_message: "invalid trace_id or span_id".to_string(),
+        error_message: crate::otlp_traces_partial::INVALID_TRACE_MSG.to_string(),
     }))
 }
 

--- a/crates/icegate-ingest/src/otlp_grpc/services.rs
+++ b/crates/icegate-ingest/src/otlp_grpc/services.rs
@@ -20,11 +20,13 @@ use tracing::debug;
 
 use crate::transform;
 use crate::{
+    error::IngestError,
     infra::metrics::{OtlpMetrics, OtlpRequestRecorder},
     otlp_grpc::error::GrpcError,
 };
 
 const SIGNAL_LOGS: &str = "logs";
+const SIGNAL_TRACES: &str = "traces";
 const PROTOCOL_GRPC: &str = "grpc";
 const ENCODING_PROTOBUF: &str = "protobuf";
 const STATUS_OK: &str = "ok";
@@ -129,7 +131,7 @@ impl LogsService for OtlpGrpcService {
         };
 
         let enqueue_start = Instant::now();
-        let pending = crate::wal::submit_sorted_logs_to_wal(&self.write_channel, prepared)
+        let pending = crate::wal::submit_sorted_rows_to_wal(&self.write_channel, prepared)
             .await
             .map_err(|err| {
                 request_metrics.record_wal_enqueue_duration(enqueue_start.elapsed(), LOGS_TOPIC, STATUS_ERROR);
@@ -182,24 +184,138 @@ impl LogsService for OtlpGrpcService {
 impl TraceService for OtlpGrpcService {
     /// Handle OTLP traces export request.
     ///
-    /// # TODO
-    /// - Parse OTLP spans from request
-    /// - Transform to Iceberg schema format (from schema.rs)
-    /// - Write spans to Iceberg spans table via catalog
-    /// - Handle batching and backpressure
-    /// - Return partial success for rejected spans
-    #[tracing::instrument(
-        skip(self, _request),
-        fields(method = "/opentelemetry.proto.collector.trace.v1.TraceService/Export")
-    )]
+    /// Transforms OTLP spans to Arrow `RecordBatch` and writes to the WAL
+    /// queue. Transform-time drops (invalid `trace_id`/`span_id`) surface as
+    /// `ExportTracePartialSuccess.rejected_spans`.
+    #[allow(clippy::cast_possible_wrap)]
+    #[allow(clippy::too_many_lines)]
+    #[tracing::instrument(name = "export_traces", skip(self, request))]
     async fn export(
         &self,
-        _request: Request<ExportTraceServiceRequest>,
+        request: Request<ExportTraceServiceRequest>,
     ) -> Result<Response<ExportTraceServiceResponse>, Status> {
-        Err(Status::unimplemented(
-            "OTLP traces ingestion: Parse OTLP → transform → write to Iceberg",
-        ))
+        use opentelemetry_proto::tonic::collector::trace::v1::ExportTracePartialSuccess;
+
+        debug!("Start handle OTLP GRPC traces request");
+        let request_size = request.get_ref().encoded_len();
+        let request_metrics = OtlpRequestRecorder::new(&self.metrics, PROTOCOL_GRPC, SIGNAL_TRACES, ENCODING_PROTOBUF);
+        request_metrics.record_request_size(request_size);
+
+        let tenant_id = extract_tenant_id(&request);
+        let export_request = request.into_inner();
+
+        // Transform OTLP spans to Arrow RecordBatch (offload to blocking thread).
+        let span = tracing::Span::current();
+        let transform_start = Instant::now();
+        let (batch_opt, drops) = tokio::task::spawn_blocking(move || {
+            span.in_scope(|| transform::spans_to_record_batch(&export_request, tenant_id.as_deref()))
+        })
+        .await
+        .map_err(|e| Status::internal(format!("Transform task panicked: {e}")))?
+        .map_err(|e| Status::from(GrpcError(e)))?;
+        request_metrics.record_transform_duration(transform_start.elapsed(), SIGNAL_TRACES, STATUS_OK);
+
+        let Some(batch) = batch_opt else {
+            // No valid spans - return success with any transform-time drops as rejected.
+            request_metrics.record_records_per_request(0);
+            request_metrics.finish_ok();
+            return Ok(Response::new(ExportTraceServiceResponse {
+                partial_success: grpc_partial_success_from_drops(drops).map_err(Status::from)?,
+            }));
+        };
+
+        let record_count = batch.num_rows();
+        debug!(records = record_count, "Transformed OTLP spans to RecordBatch");
+        request_metrics.record_records_per_request(record_count);
+
+        let wal_row_group_size = self.wal_row_group_size;
+        let trace_context = icegate_common::extract_current_trace_context();
+        let prepare_start = Instant::now();
+        let prepared = crate::wal::sort_spans(&batch, wal_row_group_size, trace_context).map_err(|err| {
+            request_metrics.finish_error();
+            Status::from(GrpcError(err))
+        })?;
+        request_metrics.record_wal_sorting_duration(prepare_start.elapsed(), SIGNAL_TRACES, STATUS_OK);
+        let Some(prepared) = prepared else {
+            request_metrics.finish_ok();
+            return Ok(Response::new(ExportTraceServiceResponse {
+                partial_success: grpc_partial_success_from_drops(drops).map_err(Status::from)?,
+            }));
+        };
+
+        let enqueue_start = Instant::now();
+        let pending = crate::wal::submit_sorted_rows_to_wal(&self.write_channel, prepared)
+            .await
+            .map_err(|err| {
+                request_metrics.record_wal_enqueue_duration(
+                    enqueue_start.elapsed(),
+                    icegate_common::SPANS_TOPIC,
+                    STATUS_ERROR,
+                );
+                request_metrics.add_wal_queue_unavailable(icegate_common::SPANS_TOPIC, WAL_REASON_CHANNEL_CLOSED);
+                request_metrics.finish_error();
+                Status::from(GrpcError(err))
+            })?;
+        request_metrics.record_wal_enqueue_duration(enqueue_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_OK);
+
+        let ack_start = Instant::now();
+        let ack_outcome = pending.wait_for_ack().await.map_err(|err| {
+            request_metrics.record_wal_ack_duration(ack_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_ERROR);
+            request_metrics.finish_error();
+            Status::from(GrpcError(err))
+        })?;
+
+        match ack_outcome {
+            crate::wal::WalAckOutcome::Success(write_result) => {
+                if let Some(ctx) = write_result.trace_context.as_deref() {
+                    icegate_common::add_span_link(ctx);
+                }
+                debug!(
+                    offset = write_result.offset.unwrap_or_default(),
+                    records = write_result.records,
+                    "OTLP GRPC traces request ended successfully"
+                );
+                request_metrics.record_wal_ack_duration(ack_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_OK);
+                request_metrics.finish_ok();
+                Ok(Response::new(ExportTraceServiceResponse {
+                    partial_success: grpc_partial_success_from_drops(drops).map_err(Status::from)?,
+                }))
+            }
+            crate::wal::WalAckOutcome::Partial(partial) => {
+                if let Some(ctx) = partial.trace_context.as_deref() {
+                    icegate_common::add_span_link(ctx);
+                }
+                request_metrics.record_wal_ack_duration(ack_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_ERROR);
+                request_metrics.finish_partial();
+                let rejected = drops
+                    .checked_add(partial.rejected_records)
+                    .and_then(|n| i64::try_from(n).ok())
+                    .ok_or_else(|| Status::internal("Rejected spans count exceeds i64"))?;
+                Ok(Response::new(ExportTraceServiceResponse {
+                    partial_success: Some(ExportTracePartialSuccess {
+                        rejected_spans: rejected,
+                        error_message: partial.reason,
+                    }),
+                }))
+            }
+        }
     }
+}
+
+/// Build an `ExportTracePartialSuccess` from transform-time drops, or `None` if there were none.
+fn grpc_partial_success_from_drops(
+    drops: usize,
+) -> Result<Option<opentelemetry_proto::tonic::collector::trace::v1::ExportTracePartialSuccess>, GrpcError> {
+    use opentelemetry_proto::tonic::collector::trace::v1::ExportTracePartialSuccess;
+    if drops == 0 {
+        return Ok(None);
+    }
+    let rejected = i64::try_from(drops)
+        .map_err(|_| GrpcError(IngestError::Validation("Rejected spans count exceeds i64".to_string())))?;
+    Ok(Some(ExportTracePartialSuccess {
+        rejected_spans: rejected,
+        error_message: "invalid trace_id or span_id".to_string(),
+    }))
 }
 
 #[tonic::async_trait]
@@ -351,5 +467,62 @@ mod tests {
 
         assert_eq!(status.code(), tonic::Code::Internal);
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn export_traces_returns_success_on_wal_ack() {
+        use opentelemetry_proto::tonic::{
+            collector::trace::v1::{ExportTraceServiceRequest, trace_service_server::TraceService},
+            trace::v1::{ResourceSpans, ScopeSpans, Span},
+        };
+
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![Span {
+                        trace_id: vec![1u8; 16],
+                        span_id: vec![2u8; 8],
+                        parent_span_id: vec![],
+                        trace_state: String::new(),
+                        name: "op".to_string(),
+                        kind: 0,
+                        start_time_unix_nano: 1,
+                        end_time_unix_nano: 2,
+                        attributes: vec![],
+                        dropped_attributes_count: 0,
+                        events: vec![],
+                        dropped_events_count: 0,
+                        links: vec![],
+                        dropped_links_count: 0,
+                        status: None,
+                        flags: 0,
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+
+        let (tx, mut rx) = channel(1);
+        let writer = tokio::spawn(async move {
+            let req = rx.recv().await.expect("write request");
+            assert_eq!(req.topic, icegate_common::SPANS_TOPIC);
+            let total = req.row_groups.iter().map(|rg| rg.batch.num_rows()).sum::<usize>();
+            req.response_tx.send(WriteResult::success(1, total, None)).expect("ack");
+        });
+
+        let service = test_service(tx);
+        let response = TraceService::export(&service, Request::new(request))
+            .await
+            .expect("grpc ok")
+            .into_inner();
+        writer.await.expect("writer");
+        assert!(response.partial_success.is_none());
     }
 }

--- a/crates/icegate-ingest/src/otlp_http/handlers.rs
+++ b/crates/icegate-ingest/src/otlp_http/handlers.rs
@@ -226,7 +226,7 @@ pub async fn ingest_traces(
     let Some(batch) = batch_opt else {
         // No valid spans - return success with any transform-time drops as rejected.
         request_metrics.record_records_per_request(0);
-        request_metrics.finish_ok();
+        crate::otlp_traces_partial::finish_metrics_with_drops(&request_metrics, drops);
         return Ok(Json(ExportTracesResponse {
             partial_success: partial_success_from_drops(drops)?,
         }));
@@ -244,7 +244,7 @@ pub async fn ingest_traces(
     })?;
     request_metrics.record_wal_sorting_duration(prepare_start.elapsed(), SIGNAL_TRACES, STATUS_OK);
     let Some(prepared) = prepared else {
-        request_metrics.finish_ok();
+        crate::otlp_traces_partial::finish_metrics_with_drops(&request_metrics, drops);
         return Ok(Json(ExportTracesResponse {
             partial_success: partial_success_from_drops(drops)?,
         }));
@@ -283,7 +283,7 @@ pub async fn ingest_traces(
                 "Spans written to WAL"
             );
             request_metrics.record_wal_ack_duration(ack_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_OK);
-            request_metrics.finish_ok();
+            crate::otlp_traces_partial::finish_metrics_with_drops(&request_metrics, drops);
             Ok(Json(ExportTracesResponse {
                 partial_success: partial_success_from_drops(drops)?,
             }))

--- a/crates/icegate-ingest/src/otlp_http/handlers.rs
+++ b/crates/icegate-ingest/src/otlp_http/handlers.rs
@@ -189,7 +189,6 @@ fn parse_logs_request(content_type: &str, body: &Bytes) -> Result<ExportLogsServ
 /// Transforms OTLP spans to Arrow `RecordBatch` and writes to the WAL queue.
 /// Transform-time drops (invalid `trace_id`/`span_id`) surface as
 /// `partial_success.rejected_spans`.
-#[allow(clippy::cast_possible_wrap)]
 #[allow(clippy::too_many_lines)]
 #[tracing::instrument(skip(state, headers, body), fields(protocol = PROTOCOL_HTTP, signal = SIGNAL_TRACES))]
 pub async fn ingest_traces(
@@ -295,14 +294,20 @@ pub async fn ingest_traces(
             }
             request_metrics.record_wal_ack_duration(ack_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_ERROR);
             request_metrics.finish_partial();
-            let rejected = drops
-                .checked_add(partial.rejected_records)
-                .and_then(|n| i64::try_from(n).ok())
-                .ok_or_else(|| OtlpError(IngestError::Validation("Rejected spans count exceeds i64".to_string())))?;
+            let combined = drops.checked_add(partial.rejected_records).ok_or_else(|| {
+                OtlpError(IngestError::Validation(
+                    "Rejected spans count exceeds usize::MAX".to_string(),
+                ))
+            })?;
+            let rejected = i64::try_from(combined)
+                .map_err(|_| OtlpError(IngestError::Validation("Rejected spans count exceeds i64".to_string())))?;
             Ok(Json(ExportTracesResponse {
                 partial_success: Some(TracesPartialSuccess {
                     rejected_spans: rejected,
-                    error_message: Some(partial.reason),
+                    error_message: Some(crate::otlp_traces_partial::compose_partial_reason(
+                        &partial.reason,
+                        drops,
+                    )),
                 }),
             }))
         }
@@ -311,14 +316,12 @@ pub async fn ingest_traces(
 
 /// Build a `TracesPartialSuccess` from transform-time drops, or `None` if there were none.
 fn partial_success_from_drops(drops: usize) -> OtlpResult<Option<TracesPartialSuccess>> {
-    if drops == 0 {
+    let Some(rejected) = crate::otlp_traces_partial::rejected_spans_from_drops(drops).map_err(OtlpError)? else {
         return Ok(None);
-    }
-    let rejected = i64::try_from(drops)
-        .map_err(|_| OtlpError(IngestError::Validation("Rejected spans count exceeds i64".to_string())))?;
+    };
     Ok(Some(TracesPartialSuccess {
         rejected_spans: rejected,
-        error_message: Some("invalid trace_id or span_id".to_string()),
+        error_message: Some(crate::otlp_traces_partial::INVALID_TRACE_MSG.to_string()),
     }))
 }
 

--- a/crates/icegate-ingest/src/otlp_http/handlers.rs
+++ b/crates/icegate-ingest/src/otlp_http/handlers.rs
@@ -18,7 +18,7 @@ use super::{
     error::{OtlpError, OtlpResult},
     models::{
         ExportLogsResponse, ExportMetricsResponse, ExportTracesResponse, HealthResponse, HealthStatus,
-        LogsPartialSuccess,
+        LogsPartialSuccess, TracesPartialSuccess,
     },
     server::OtlpHttpState,
 };
@@ -31,6 +31,7 @@ const CONTENT_TYPE_PROTOBUF: &str = "application/x-protobuf";
 const CONTENT_TYPE_JSON: &str = "application/json";
 
 const SIGNAL_LOGS: &str = "logs";
+const SIGNAL_TRACES: &str = "traces";
 const PROTOCOL_HTTP: &str = "http";
 const WAL_REASON_CHANNEL_CLOSED: &str = "channel_closed";
 const STATUS_OK: &str = "ok";
@@ -114,7 +115,7 @@ pub async fn ingest_logs(
     };
 
     let enqueue_start = Instant::now();
-    let pending = crate::wal::submit_sorted_logs_to_wal(&state.write_channel, prepared)
+    let pending = crate::wal::submit_sorted_rows_to_wal(&state.write_channel, prepared)
         .await
         .map_err(|e| {
             request_metrics.record_wal_enqueue_duration(enqueue_start.elapsed(), LOGS_TOPIC, STATUS_ERROR);
@@ -181,17 +182,162 @@ fn parse_logs_request(content_type: &str, body: &Bytes) -> Result<ExportLogsServ
 
 /// Handle OTLP traces ingestion.
 ///
-/// # TODO
-/// - Parse Content-Type header (application/x-protobuf or application/json)
-/// - Deserialize OTLP `TracesData` from request body
-/// - Transform OTLP spans to Iceberg schema format (from schema.rs)
-/// - Write spans to Iceberg spans table via catalog
-/// - Handle batching and backpressure
-/// - Return OTLP `ExportTracesServiceResponse`
-pub async fn ingest_traces(State(_state): State<OtlpHttpState>) -> OtlpResult<Json<ExportTracesResponse>> {
-    Err(OtlpError(IngestError::NotImplemented(
-        "OTLP traces ingestion: Parse OTLP → transform → write to Iceberg".to_string(),
-    )))
+/// Supports both Content-Types:
+/// - `application/x-protobuf` (binary protobuf)
+/// - `application/json` (JSON encoding)
+///
+/// Transforms OTLP spans to Arrow `RecordBatch` and writes to the WAL queue.
+/// Transform-time drops (invalid `trace_id`/`span_id`) surface as
+/// `partial_success.rejected_spans`.
+#[allow(clippy::cast_possible_wrap)]
+#[allow(clippy::too_many_lines)]
+#[tracing::instrument(skip(state, headers, body), fields(protocol = PROTOCOL_HTTP, signal = SIGNAL_TRACES))]
+pub async fn ingest_traces(
+    State(state): State<OtlpHttpState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> OtlpResult<Json<ExportTracesResponse>> {
+    use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+
+    // Determine content type (default to protobuf per OTLP spec)
+    let content_type = headers
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(CONTENT_TYPE_PROTOBUF);
+    let encoding = otlp_encoding_from_content_type(content_type);
+    let request_metrics = OtlpRequestRecorder::new(&state.metrics, PROTOCOL_HTTP, SIGNAL_TRACES, encoding);
+    request_metrics.record_request_size(body.len());
+
+    // Parse the request based on content type.
+    let export_request: ExportTraceServiceRequest = request_metrics
+        .record_decode(content_type, || parse_traces_request(content_type, &body))
+        .map_err(OtlpError::from)?;
+
+    let tenant_id = extract_tenant_id(&headers);
+
+    // Transform OTLP spans to Arrow RecordBatch (offload to blocking thread).
+    let span = tracing::Span::current();
+    let transform_start = Instant::now();
+    let (batch_opt, drops) = tokio::task::spawn_blocking(move || {
+        span.in_scope(|| transform::spans_to_record_batch(&export_request, tenant_id.as_deref()))
+    })
+    .await??;
+    request_metrics.record_transform_duration(transform_start.elapsed(), SIGNAL_TRACES, STATUS_OK);
+
+    let Some(batch) = batch_opt else {
+        // No valid spans - return success with any transform-time drops as rejected.
+        request_metrics.record_records_per_request(0);
+        request_metrics.finish_ok();
+        return Ok(Json(ExportTracesResponse {
+            partial_success: partial_success_from_drops(drops)?,
+        }));
+    };
+
+    let record_count = batch.num_rows();
+    debug!(records = record_count, "Transformed OTLP spans to RecordBatch");
+    request_metrics.record_records_per_request(record_count);
+
+    let trace_context = icegate_common::extract_current_trace_context();
+    let prepare_start = Instant::now();
+    let prepared = crate::wal::sort_spans(&batch, state.wal_row_group_size, trace_context).map_err(|e| {
+        request_metrics.finish_error();
+        OtlpError(e)
+    })?;
+    request_metrics.record_wal_sorting_duration(prepare_start.elapsed(), SIGNAL_TRACES, STATUS_OK);
+    let Some(prepared) = prepared else {
+        request_metrics.finish_ok();
+        return Ok(Json(ExportTracesResponse {
+            partial_success: partial_success_from_drops(drops)?,
+        }));
+    };
+
+    let enqueue_start = Instant::now();
+    let pending = crate::wal::submit_sorted_rows_to_wal(&state.write_channel, prepared)
+        .await
+        .map_err(|e| {
+            request_metrics.record_wal_enqueue_duration(
+                enqueue_start.elapsed(),
+                icegate_common::SPANS_TOPIC,
+                STATUS_ERROR,
+            );
+            request_metrics.add_wal_queue_unavailable(icegate_common::SPANS_TOPIC, WAL_REASON_CHANNEL_CLOSED);
+            request_metrics.finish_error();
+            OtlpError(e)
+        })?;
+    request_metrics.record_wal_enqueue_duration(enqueue_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_OK);
+
+    let ack_start = Instant::now();
+    let ack_outcome = pending.wait_for_ack().await.map_err(|e| {
+        request_metrics.record_wal_ack_duration(ack_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_ERROR);
+        request_metrics.finish_error();
+        OtlpError(e)
+    })?;
+
+    match ack_outcome {
+        crate::wal::WalAckOutcome::Success(write_result) => {
+            if let Some(ctx) = write_result.trace_context.as_deref() {
+                icegate_common::add_span_link(ctx);
+            }
+            debug!(
+                offset = write_result.offset.unwrap_or_default(),
+                records = write_result.records,
+                "Spans written to WAL"
+            );
+            request_metrics.record_wal_ack_duration(ack_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_OK);
+            request_metrics.finish_ok();
+            Ok(Json(ExportTracesResponse {
+                partial_success: partial_success_from_drops(drops)?,
+            }))
+        }
+        crate::wal::WalAckOutcome::Partial(partial) => {
+            if let Some(ctx) = partial.trace_context.as_deref() {
+                icegate_common::add_span_link(ctx);
+            }
+            request_metrics.record_wal_ack_duration(ack_start.elapsed(), icegate_common::SPANS_TOPIC, STATUS_ERROR);
+            request_metrics.finish_partial();
+            let rejected = drops
+                .checked_add(partial.rejected_records)
+                .and_then(|n| i64::try_from(n).ok())
+                .ok_or_else(|| OtlpError(IngestError::Validation("Rejected spans count exceeds i64".to_string())))?;
+            Ok(Json(ExportTracesResponse {
+                partial_success: Some(TracesPartialSuccess {
+                    rejected_spans: rejected,
+                    error_message: Some(partial.reason),
+                }),
+            }))
+        }
+    }
+}
+
+/// Build a `TracesPartialSuccess` from transform-time drops, or `None` if there were none.
+fn partial_success_from_drops(drops: usize) -> OtlpResult<Option<TracesPartialSuccess>> {
+    if drops == 0 {
+        return Ok(None);
+    }
+    let rejected = i64::try_from(drops)
+        .map_err(|_| OtlpError(IngestError::Validation("Rejected spans count exceeds i64".to_string())))?;
+    Ok(Some(TracesPartialSuccess {
+        rejected_spans: rejected,
+        error_message: Some("invalid trace_id or span_id".to_string()),
+    }))
+}
+
+/// Parse traces request from either protobuf or JSON encoding.
+fn parse_traces_request(
+    content_type: &str,
+    body: &Bytes,
+) -> Result<opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest, IngestError> {
+    use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+    if content_type.starts_with(CONTENT_TYPE_PROTOBUF) {
+        ExportTraceServiceRequest::decode(body.as_ref())
+            .map_err(|e| IngestError::Decode(format!("Failed to decode protobuf: {e}")))
+    } else if content_type.starts_with(CONTENT_TYPE_JSON) {
+        serde_json::from_slice(body.as_ref()).map_err(|e| IngestError::Decode(format!("Failed to decode JSON: {e}")))
+    } else {
+        Err(IngestError::Validation(format!(
+            "Unsupported Content-Type: {content_type}. Expected application/x-protobuf or application/json"
+        )))
+    }
 }
 
 /// Handle OTLP metrics ingestion.
@@ -419,5 +565,138 @@ mod tests {
         let result = ingest_logs(State(state), HeaderMap::new(), encode_protobuf_request()).await;
         assert!(result.is_err());
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn ingest_traces_returns_success_on_wal_ack() {
+        use opentelemetry_proto::tonic::{
+            collector::trace::v1::ExportTraceServiceRequest,
+            trace::v1::{ResourceSpans, ScopeSpans, Span},
+        };
+
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![Span {
+                        trace_id: vec![1u8; 16],
+                        span_id: vec![2u8; 8],
+                        parent_span_id: vec![],
+                        trace_state: String::new(),
+                        name: "op".to_string(),
+                        kind: 0,
+                        start_time_unix_nano: 1,
+                        end_time_unix_nano: 2,
+                        attributes: vec![],
+                        dropped_attributes_count: 0,
+                        events: vec![],
+                        dropped_events_count: 0,
+                        links: vec![],
+                        dropped_links_count: 0,
+                        status: None,
+                        flags: 0,
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+
+        let (tx, mut rx) = channel(1);
+        let writer = tokio::spawn(async move {
+            let req = rx.recv().await.expect("write request");
+            assert_eq!(req.topic, icegate_common::SPANS_TOPIC);
+            let total = req.row_groups.iter().map(|rg| rg.batch.num_rows()).sum::<usize>();
+            req.response_tx.send(WriteResult::success(1, total, None)).expect("ack");
+        });
+
+        let body = Bytes::from(request.encode_to_vec());
+        let response = ingest_traces(State(test_state(tx)), HeaderMap::new(), body)
+            .await
+            .expect("http ok");
+        writer.await.expect("writer");
+        assert!(response.0.partial_success.is_none());
+    }
+
+    #[tokio::test]
+    async fn ingest_traces_returns_partial_success_for_transform_drops() {
+        use opentelemetry_proto::tonic::{
+            collector::trace::v1::ExportTraceServiceRequest,
+            trace::v1::{ResourceSpans, ScopeSpans, Span},
+        };
+
+        // Two spans: one valid, one with zero trace_id (dropped).
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![
+                        Span {
+                            trace_id: vec![1u8; 16],
+                            span_id: vec![2u8; 8],
+                            parent_span_id: vec![],
+                            trace_state: String::new(),
+                            name: "ok".to_string(),
+                            kind: 0,
+                            start_time_unix_nano: 1,
+                            end_time_unix_nano: 2,
+                            attributes: vec![],
+                            dropped_attributes_count: 0,
+                            events: vec![],
+                            dropped_events_count: 0,
+                            links: vec![],
+                            dropped_links_count: 0,
+                            status: None,
+                            flags: 0,
+                        },
+                        Span {
+                            trace_id: vec![0u8; 16], // invalid
+                            span_id: vec![2u8; 8],
+                            parent_span_id: vec![],
+                            trace_state: String::new(),
+                            name: "bad".to_string(),
+                            kind: 0,
+                            start_time_unix_nano: 1,
+                            end_time_unix_nano: 2,
+                            attributes: vec![],
+                            dropped_attributes_count: 0,
+                            events: vec![],
+                            dropped_events_count: 0,
+                            links: vec![],
+                            dropped_links_count: 0,
+                            status: None,
+                            flags: 0,
+                        },
+                    ],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+
+        let (tx, mut rx) = channel(1);
+        let writer = tokio::spawn(async move {
+            let req = rx.recv().await.expect("write request");
+            let total = req.row_groups.iter().map(|rg| rg.batch.num_rows()).sum::<usize>();
+            req.response_tx.send(WriteResult::success(1, total, None)).expect("ack");
+        });
+
+        let body = Bytes::from(request.encode_to_vec());
+        let response = ingest_traces(State(test_state(tx)), HeaderMap::new(), body)
+            .await
+            .expect("http ok");
+        writer.await.expect("writer");
+        let partial = response.0.partial_success.expect("partial");
+        assert_eq!(partial.rejected_spans, 1);
     }
 }

--- a/crates/icegate-ingest/src/otlp_traces_partial.rs
+++ b/crates/icegate-ingest/src/otlp_traces_partial.rs
@@ -6,6 +6,7 @@
 //! protocols stay in lockstep.
 
 use crate::error::IngestError;
+use crate::infra::metrics::OtlpRequestRecorder;
 
 /// Message reported when spans are dropped at transform time because their
 /// `trace_id` or `span_id` failed validation.
@@ -24,6 +25,20 @@ pub fn rejected_spans_from_drops(drops: usize) -> Result<Option<i64>, IngestErro
     i64::try_from(drops)
         .map(Some)
         .map_err(|_| IngestError::Validation("Rejected spans count exceeds i64".to_string()))
+}
+
+/// Finish request metrics with status "partial" when there are transform-time
+/// drops, otherwise with status "ok".
+///
+/// Shared by the HTTP and gRPC trace handlers: both report partial success
+/// on any drop count > 0 so Grafana panels for `status="partial"` reflect
+/// every path where some spans failed validation.
+pub fn finish_metrics_with_drops(request_metrics: &OtlpRequestRecorder, drops: usize) {
+    if drops > 0 {
+        request_metrics.finish_partial();
+    } else {
+        request_metrics.finish_ok();
+    }
 }
 
 /// Compose a combined error message when both transform-time drops and a

--- a/crates/icegate-ingest/src/otlp_traces_partial.rs
+++ b/crates/icegate-ingest/src/otlp_traces_partial.rs
@@ -1,0 +1,70 @@
+//! Shared helpers for composing OTLP traces partial-success responses.
+//!
+//! Transform-time drops (invalid `trace_id` / `span_id`) and WAL-side
+//! partial failures both contribute to `rejected_spans`. The HTTP and gRPC
+//! handlers share the conversion and message formatting so the two
+//! protocols stay in lockstep.
+
+use crate::error::IngestError;
+
+/// Message reported when spans are dropped at transform time because their
+/// `trace_id` or `span_id` failed validation.
+pub const INVALID_TRACE_MSG: &str = "invalid trace_id or span_id";
+
+/// Narrow a `usize` drop count to `i64` for OTLP partial-success reporting.
+///
+/// Returns `Ok(None)` when `drops == 0` so callers can skip emitting a
+/// `partial_success` payload entirely. Returns `Err` only on the
+/// mathematically-unreachable i64 overflow path (a 64-bit platform with
+/// more than `i64::MAX` dropped spans), surfacing the cause to the caller.
+pub fn rejected_spans_from_drops(drops: usize) -> Result<Option<i64>, IngestError> {
+    if drops == 0 {
+        return Ok(None);
+    }
+    i64::try_from(drops)
+        .map(Some)
+        .map_err(|_| IngestError::Validation("Rejected spans count exceeds i64".to_string()))
+}
+
+/// Compose a combined error message when both transform-time drops and a
+/// WAL-side partial failure contributed to rejections.
+///
+/// * `wal_reason` — reason reported by the WAL writer.
+/// * `drops` — spans dropped at transform time (invalid IDs).
+///
+/// When `drops == 0` the WAL reason is returned verbatim so existing
+/// WAL-only failures keep their original wording.
+pub fn compose_partial_reason(wal_reason: &str, drops: usize) -> String {
+    if drops == 0 {
+        return wal_reason.to_string();
+    }
+    format!("{wal_reason}; also {drops} span(s) rejected at transform: {INVALID_TRACE_MSG}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejected_spans_from_drops_zero_returns_none() {
+        assert_eq!(rejected_spans_from_drops(0).expect("ok"), None);
+    }
+
+    #[test]
+    fn rejected_spans_from_drops_small_value_passes_through() {
+        assert_eq!(rejected_spans_from_drops(5).expect("ok"), Some(5));
+    }
+
+    #[test]
+    fn compose_partial_reason_without_drops_returns_wal_verbatim() {
+        assert_eq!(compose_partial_reason("wal-err", 0), "wal-err".to_string());
+    }
+
+    #[test]
+    fn compose_partial_reason_with_drops_combines_causes() {
+        let msg = compose_partial_reason("wal-err", 3);
+        assert!(msg.starts_with("wal-err"));
+        assert!(msg.contains("3 span(s)"));
+        assert!(msg.contains(INVALID_TRACE_MSG));
+    }
+}

--- a/crates/icegate-ingest/src/shift/mod.rs
+++ b/crates/icegate-ingest/src/shift/mod.rs
@@ -31,7 +31,6 @@ pub(crate) use executor::{
 };
 use iceberg::Catalog;
 pub(crate) use iceberg_storage::IcebergStorage;
-use icegate_common::{LOGS_TABLE, LOGS_TOPIC};
 use icegate_jobmanager::{
     CachedStorage, JobDefinition, JobRegistry, JobsManager, JobsManagerConfig, JobsManagerHandle,
     Metrics as JobMetrics, S3Storage, TaskCode, TaskDefinition, WorkerConfig, s3_storage::S3StorageConfig,
@@ -48,7 +47,21 @@ use timeout::TimeoutEstimator;
 use crate::{
     error::{IngestError, Result},
     infra::metrics::ShiftMetrics,
+    wal::SortColumnsDescriptor,
 };
+
+/// Specification for one per-signal shift job.
+#[derive(Clone, Copy)]
+pub struct ShiftJobSpec {
+    /// Stable job name used in job registry and logs (e.g. `shift_logs`).
+    pub job_name: &'static str,
+    /// WAL topic to read from (e.g. `LOGS_TOPIC`).
+    pub topic: &'static str,
+    /// Iceberg table name to commit to (e.g. `LOGS_TABLE`).
+    pub table: &'static str,
+    /// Sort descriptor shared with the WAL sorter for this topic.
+    pub descriptor: &'static SortColumnsDescriptor,
+}
 
 /// Runs shift jobs inside the ingest process.
 pub struct Shifter {
@@ -69,79 +82,92 @@ impl Shifter {
         jobs_storage: S3StorageConfig,
         shift_metrics: ShiftMetrics,
         jobs_manager_metrics: JobMetrics,
+        jobs: &[ShiftJobSpec],
     ) -> Result<Self> {
         shift_config.validate()?;
-        let storage = Arc::new(IcebergStorage::new(
-            Arc::clone(&catalog),
-            LOGS_TABLE,
-            shift_config.as_ref(),
-        ));
+        if jobs.is_empty() {
+            return Err(IngestError::Shift("no shift jobs configured".to_string()));
+        }
+
+        let queue_reader = Arc::new(QueueReaderWithMetrics::new(queue_reader, shift_metrics.clone()));
         let timeouts = TimeoutEstimator::new(&shift_config.timeouts)?;
         let plan_timeout = timeouts.plan_timeout();
-        let queue_reader = Arc::new(QueueReaderWithMetrics::new(queue_reader, shift_metrics.clone()));
-        let plan_runner = Arc::new(PlanTaskRunnerImpl::new(
-            Arc::clone(&queue_reader),
-            Arc::clone(&storage),
-            shift_config.clone(),
-            timeouts,
-            LOGS_TOPIC,
-        ));
-        let plan_runner = Arc::new(PlanTaskRunnerWithMetrics::new(
-            plan_runner,
-            shift_metrics.clone(),
-            LOGS_TOPIC,
-        ));
 
-        let shift_storage = Arc::new(StorageWithMetrics::new(storage, shift_metrics.clone(), LOGS_TOPIC));
-        let shift_storage_for_runner = Arc::clone(&shift_storage);
-        let row_groups_merger_observer = Arc::new(RowGroupsMergerObserverWithMetrics::new(
-            shift_metrics.clone(),
-            LOGS_TOPIC,
-        ));
-        let shift_runner = Arc::new(
-            ShiftTaskRunnerImpl::new(
-                queue_reader,
-                shift_storage_for_runner,
-                LOGS_TOPIC,
-                shift_config.write.row_group_size,
-            )?
-            .with_row_groups_merger_observer(row_groups_merger_observer)
-            .with_segment_read_parallelism(shift_config.read.shift_segment_read_parallelism)?,
-        );
-        let shift_runner = Arc::new(ShiftTaskRunnerWithMetrics::new(
-            shift_runner,
-            shift_metrics.clone(),
-            LOGS_TOPIC,
-        ));
-        let commit_runner = Arc::new(CommitTaskRunnerImpl::new(Arc::clone(&shift_storage), LOGS_TOPIC));
-        let commit_runner = Arc::new(CommitTaskRunnerWithMetrics::new(
-            commit_runner,
-            shift_metrics,
-            LOGS_TOPIC,
-        ));
+        let mut job_defs: Vec<JobDefinition> = Vec::with_capacity(jobs.len());
 
-        let executor = Arc::new(Executor::new(plan_runner, shift_runner, commit_runner));
+        for spec in jobs {
+            let storage = Arc::new(IcebergStorage::new(
+                Arc::clone(&catalog),
+                spec.table,
+                shift_config.as_ref(),
+            ));
+            let plan_runner = Arc::new(PlanTaskRunnerImpl::new(
+                Arc::clone(&queue_reader),
+                Arc::clone(&storage),
+                shift_config.clone(),
+                timeouts.clone(),
+                spec.topic,
+            ));
+            let plan_runner = Arc::new(PlanTaskRunnerWithMetrics::new(
+                plan_runner,
+                shift_metrics.clone(),
+                spec.topic,
+            ));
 
-        let initial_task =
-            TaskDefinition::new(TaskCode::new(PLAN_TASK_CODE), vec![], plan_timeout).map_err(map_shift_error)?;
+            let shift_storage = Arc::new(StorageWithMetrics::new(storage, shift_metrics.clone(), spec.topic));
+            let shift_storage_for_runner = Arc::clone(&shift_storage);
+            let row_groups_merger_observer = Arc::new(RowGroupsMergerObserverWithMetrics::new(
+                shift_metrics.clone(),
+                spec.topic,
+            ));
+            let shift_runner = Arc::new(
+                ShiftTaskRunnerImpl::new(
+                    Arc::clone(&queue_reader),
+                    shift_storage_for_runner,
+                    spec.topic,
+                    shift_config.write.row_group_size,
+                    spec.descriptor,
+                )?
+                .with_row_groups_merger_observer(row_groups_merger_observer)
+                .with_segment_read_parallelism(shift_config.read.shift_segment_read_parallelism)?,
+            );
+            let shift_runner = Arc::new(ShiftTaskRunnerWithMetrics::new(
+                shift_runner,
+                shift_metrics.clone(),
+                spec.topic,
+            ));
+            let commit_runner = Arc::new(CommitTaskRunnerImpl::new(Arc::clone(&shift_storage), spec.topic));
+            let commit_runner = Arc::new(CommitTaskRunnerWithMetrics::new(
+                commit_runner,
+                shift_metrics.clone(),
+                spec.topic,
+            ));
 
-        let mut executors = HashMap::new();
-        executors.insert(TaskCode::new(PLAN_TASK_CODE), Arc::clone(&executor).plan_executor());
-        executors.insert(TaskCode::new(SHIFT_TASK_CODE), Arc::clone(&executor).shift_executor());
-        executors.insert(TaskCode::new(COMMIT_TASK_CODE), Arc::clone(&executor).commit_executor());
+            let executor = Arc::new(Executor::new(plan_runner, shift_runner, commit_runner));
 
-        let iteration_interval_ms =
-            i64::try_from(shift_config.jobsmanager.iteration_interval_millisecs).map_err(|_| {
-                IngestError::Shift(format!(
-                    "jobsmanager.iteration_interval_millisecs {} exceeds i64",
-                    shift_config.jobsmanager.iteration_interval_millisecs
-                ))
-            })?;
-        let job_def = JobDefinition::new("shift_logs".into(), vec![initial_task], executors)
-            .map_err(map_shift_error)?
-            .with_iteration_interval(ChronoDuration::milliseconds(iteration_interval_ms))
-            .map_err(map_shift_error)?;
-        let job_registry = Arc::new(JobRegistry::new(vec![job_def]).map_err(map_shift_error)?);
+            let initial_task =
+                TaskDefinition::new(TaskCode::new(PLAN_TASK_CODE), vec![], plan_timeout).map_err(map_shift_error)?;
+
+            let mut executors = HashMap::new();
+            executors.insert(TaskCode::new(PLAN_TASK_CODE), Arc::clone(&executor).plan_executor());
+            executors.insert(TaskCode::new(SHIFT_TASK_CODE), Arc::clone(&executor).shift_executor());
+            executors.insert(TaskCode::new(COMMIT_TASK_CODE), Arc::clone(&executor).commit_executor());
+
+            let iteration_interval_ms =
+                i64::try_from(shift_config.jobsmanager.iteration_interval_millisecs).map_err(|_| {
+                    IngestError::Shift(format!(
+                        "jobsmanager.iteration_interval_millisecs {} exceeds i64",
+                        shift_config.jobsmanager.iteration_interval_millisecs
+                    ))
+                })?;
+            let job_def = JobDefinition::new(spec.job_name.into(), vec![initial_task], executors)
+                .map_err(map_shift_error)?
+                .with_iteration_interval(ChronoDuration::milliseconds(iteration_interval_ms))
+                .map_err(map_shift_error)?;
+            job_defs.push(job_def);
+        }
+
+        let job_registry = Arc::new(JobRegistry::new(job_defs).map_err(map_shift_error)?);
 
         let s3_storage = Arc::new(
             S3Storage::new(jobs_storage, job_registry.clone(), jobs_manager_metrics.clone())

--- a/crates/icegate-ingest/src/shift/row_groups_merger.rs
+++ b/crates/icegate-ingest/src/shift/row_groups_merger.rs
@@ -307,6 +307,8 @@ pub struct SortedBatchMergerConfig {
     pub topic: Topic,
     /// Shared cancellation token for all queue reads.
     pub cancel_token: CancellationToken,
+    /// Sort descriptor used to compare rows across WAL row groups.
+    pub sort_descriptor: &'static SortColumnsDescriptor,
 }
 
 /// Streams sorted row groups from WAL and merges them into one sorted output stream.
@@ -387,9 +389,10 @@ where
         validate_boundary_ranges(&read_plan)?;
         validate_unique_row_group_positions(&read_plan)?;
 
+        let sort_descriptor = config.sort_descriptor;
         Ok(Self {
             config,
-            sort_descriptor: SortColumnsDescriptor::logs()?, // TODO(high): make a generic solution without binding to logs
+            sort_descriptor,
             schema: SchemaRef::new(arrow::datatypes::Schema::empty()),
             queue_reader,
             observer,
@@ -1299,14 +1302,16 @@ mod tests {
 
     fn cluster_sizes_from_metadata(segments: impl AsRef<[SegmentToRead]>) -> Vec<usize> {
         let segments = segments.as_ref();
+        let sort_descriptor = SortColumnsDescriptor::logs().expect("sort descriptor");
         let mut merger = RowGroupsMerger::<FakeQueueReader> {
             config: SortedBatchMergerConfig {
                 row_group_size: 8,
                 read_parallelism: 1,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor,
             },
-            sort_descriptor: SortColumnsDescriptor::logs().expect("sort descriptor"),
+            sort_descriptor,
             schema: Arc::new(Schema::empty()),
             queue_reader: Arc::new(FakeQueueReader {
                 batches: HashMap::new(),
@@ -1352,6 +1357,7 @@ mod tests {
                 read_parallelism: 2,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger");
@@ -1382,6 +1388,7 @@ mod tests {
                 read_parallelism: 2,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger");
@@ -1443,6 +1450,7 @@ mod tests {
                 read_parallelism: 2,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger");
@@ -1535,6 +1543,7 @@ mod tests {
                 read_parallelism: 2,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger");
@@ -1576,6 +1585,7 @@ mod tests {
                 read_parallelism: 2,
                 topic: "logs".to_string(),
                 cancel_token: cancel_token.clone(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger");
@@ -1617,6 +1627,7 @@ mod tests {
                 read_parallelism: 1,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger");
@@ -2030,6 +2041,7 @@ mod tests {
                 read_parallelism: 1,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
             Arc::new(NoopRowGroupsMergerObserver),
         ) else {
@@ -2068,6 +2080,7 @@ mod tests {
                 read_parallelism: 1,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
             Arc::new(NoopRowGroupsMergerObserver),
         ) else {

--- a/crates/icegate-ingest/src/shift/row_groups_merger.rs
+++ b/crates/icegate-ingest/src/shift/row_groups_merger.rs
@@ -317,10 +317,11 @@ pub struct SortedBatchMergerConfig {
 /// row groups whose key ranges intersect, performs k-way merge across them, and
 /// then moves to the next cluster.
 pub struct RowGroupsMerger<Q: QueueReader + ?Sized + 'static> {
-    /// Immutable read/output settings.
+    /// Immutable read/output settings. The sort descriptor lives inside
+    /// `config.sort_descriptor`; there is no separate cached copy on the
+    /// merger itself — every read goes through the config to keep a single
+    /// source of truth.
     config: SortedBatchMergerConfig,
-    /// Immutable logs sort descriptor shared by all per-batch column caches.
-    sort_descriptor: &'static SortColumnsDescriptor,
     /// Schema shared by all opened batches. Filled from the first batch.
     schema: SchemaRef,
     /// Queue reader used to open WAL row groups as Arrow streams.
@@ -389,10 +390,8 @@ where
         validate_boundary_ranges(&read_plan)?;
         validate_unique_row_group_positions(&read_plan)?;
 
-        let sort_descriptor = config.sort_descriptor;
         Ok(Self {
             config,
-            sort_descriptor,
             schema: SchemaRef::new(arrow::datatypes::Schema::empty()),
             queue_reader,
             observer,
@@ -847,7 +846,7 @@ where
             )));
         }
 
-        let cache = SortColumnCache::try_new(&opened.row_group, self.sort_descriptor, "merge input")?;
+        let cache = SortColumnCache::try_new(&opened.row_group, self.config.sort_descriptor, "merge input")?;
         let stream_idx = self.active_cluster_streams.len();
         self.active_cluster_streams.push(ActiveClusterState {
             source: opened.source,
@@ -967,7 +966,7 @@ where
             .ok_or_else(|| IngestError::Shift("batch generation overflow".to_string()))?;
         stream_state.cache = Some(SortColumnCache::try_new(
             &next_batch,
-            self.sort_descriptor,
+            self.config.sort_descriptor,
             "merge input",
         )?);
         stream_state.current_batch = Some(next_batch);
@@ -1311,7 +1310,6 @@ mod tests {
                 cancel_token: CancellationToken::new(),
                 sort_descriptor,
             },
-            sort_descriptor,
             schema: Arc::new(Schema::empty()),
             queue_reader: Arc::new(FakeQueueReader {
                 batches: HashMap::new(),

--- a/crates/icegate-ingest/src/shift/row_groups_merger.rs
+++ b/crates/icegate-ingest/src/shift/row_groups_merger.rs
@@ -1407,6 +1407,7 @@ mod tests {
                 read_parallelism: 2,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger")
@@ -1735,6 +1736,7 @@ mod tests {
                 read_parallelism: 2,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger")
@@ -1779,6 +1781,7 @@ mod tests {
                 read_parallelism: 2,
                 topic: "logs".to_string(),
                 cancel_token: cancel_token.clone(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger")
@@ -1814,6 +1817,7 @@ mod tests {
                 read_parallelism: 1,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger")
@@ -1908,6 +1912,7 @@ mod tests {
                 read_parallelism: 1,
                 topic: "logs".to_string(),
                 cancel_token: CancellationToken::new(),
+                sort_descriptor: SortColumnsDescriptor::logs().expect("logs descriptor"),
             },
         )
         .expect("merger")

--- a/crates/icegate-ingest/src/shift/shift_runner.rs
+++ b/crates/icegate-ingest/src/shift/shift_runner.rs
@@ -18,6 +18,7 @@ use super::{
         NoopRowGroupsMergerObserver, RowGroupsMerger, RowGroupsMergerObserver, SortedBatchMergerConfig,
     },
 };
+use crate::wal::SortColumnsDescriptor;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 /// Reason for shift task failure.
@@ -107,6 +108,7 @@ pub struct ShiftTaskRunnerImpl<Q, S> {
     topic: Topic,
     output_batch_size: usize,
     segment_read_parallelism: usize,
+    sort_descriptor: &'static SortColumnsDescriptor,
     retrier: Retrier,
     row_groups_merger_observer: Arc<dyn RowGroupsMergerObserver>,
 }
@@ -128,6 +130,7 @@ where
         storage: Arc<S>,
         topic: impl Into<String>,
         output_batch_size: usize,
+        sort_descriptor: &'static SortColumnsDescriptor,
     ) -> std::result::Result<Self, crate::error::IngestError> {
         if output_batch_size == 0 {
             return Err(crate::error::IngestError::Config(
@@ -141,6 +144,7 @@ where
             topic: topic.into(),
             output_batch_size,
             segment_read_parallelism: Self::DEFAULT_SEGMENT_READ_PARALLELISM,
+            sort_descriptor,
             retrier: Retrier::new(RetrierConfig::default()),
             row_groups_merger_observer: Arc::new(NoopRowGroupsMergerObserver),
         })
@@ -331,6 +335,7 @@ where
                 read_parallelism: self.segment_read_parallelism,
                 topic: self.topic.clone(),
                 cancel_token: cancel_token.clone(),
+                sort_descriptor: self.sort_descriptor,
             },
         )
         .map_err(ShiftWriteError::queue_read)?
@@ -455,7 +460,7 @@ mod tests {
             plan_runner::{PlanTaskRunner, PlanTaskRunnerImpl},
             timeout::TimeoutEstimator,
         },
-        wal::{logs_row_group_boundary_range_from_batch, sort_logs},
+        wal::{SortColumnsDescriptor, logs_row_group_boundary_range_from_batch, sort_logs},
     };
 
     struct TestTask {
@@ -1325,10 +1330,16 @@ mod tests {
             concurrency_gate: None,
         });
         let storage = Arc::new(FakeStorage::always_fail());
-        let runner = ShiftTaskRunnerImpl::new(queue_reader, Arc::clone(&storage), "logs", 1)
-            .expect("non-zero output_batch_size must be accepted")
-            .with_segment_read_parallelism(3)
-            .expect("non-zero segment read parallelism must be accepted");
+        let runner = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            Arc::clone(&storage),
+            "logs",
+            1,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted")
+        .with_segment_read_parallelism(3)
+        .expect("non-zero segment read parallelism must be accepted");
         let segment_1 = vec![test_batch(1)];
         let segment_2 = vec![test_batch(2)];
         let segment_3 = vec![test_batch(3)];
@@ -1389,8 +1400,14 @@ mod tests {
             concurrency_gate: None,
         });
         let storage = Arc::new(FakeStorage::always_fail());
-        let runner = ShiftTaskRunnerImpl::new(queue_reader, Arc::clone(&storage), "logs", 4)
-            .expect("non-zero output_batch_size must be accepted");
+        let runner = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            Arc::clone(&storage),
+            "logs",
+            4,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted");
         let segment_1 = vec![
             logs_batch_for_shift(vec![
                 (Some("acc-1"), Some("svc-3"), Some(30), 1),
@@ -1448,8 +1465,14 @@ mod tests {
             concurrency_gate: None,
         });
         let storage = Arc::new(FakeStorage::always_fail());
-        let runner = ShiftTaskRunnerImpl::new(queue_reader, Arc::clone(&storage), "logs", 2)
-            .expect("non-zero output_batch_size must be accepted");
+        let runner = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            Arc::clone(&storage),
+            "logs",
+            2,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted");
         let segment_1 = vec![
             logs_batch_for_shift(vec![
                 (Some("acc-1"), Some("svc-3"), Some(30), 1),
@@ -1511,10 +1534,16 @@ mod tests {
             1,
             vec![test_data_file("s3://warehouse/logs/part-00001.parquet", 3)],
         ));
-        let runner = ShiftTaskRunnerImpl::new(queue_reader, Arc::clone(&storage), "logs", 2)
-            .expect("non-zero output_batch_size must be accepted")
-            .with_segment_read_parallelism(3)
-            .expect("non-zero segment read parallelism must be accepted");
+        let runner = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            Arc::clone(&storage),
+            "logs",
+            2,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted")
+        .with_segment_read_parallelism(3)
+        .expect("non-zero segment read parallelism must be accepted");
         let segment_1 = vec![test_batch(1)];
         let segment_2 = vec![test_batch(2)];
         let segment_3 = vec![test_batch(3)];
@@ -1580,10 +1609,16 @@ mod tests {
             concurrency_gate: None,
         });
         let storage = Arc::new(FakeStorage::fail_then_succeed(0, Vec::new()));
-        let runner = ShiftTaskRunnerImpl::new(queue_reader, Arc::clone(&storage), "logs", 1)
-            .expect("non-zero output_batch_size must be accepted")
-            .with_segment_read_parallelism(3)
-            .expect("non-zero segment read parallelism must be accepted");
+        let runner = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            Arc::clone(&storage),
+            "logs",
+            1,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted")
+        .with_segment_read_parallelism(3)
+        .expect("non-zero segment read parallelism must be accepted");
         let segment_1 = vec![test_batch(1)];
         let segment_2 = vec![test_batch(2)];
         let segment_3 = vec![test_batch(3)];
@@ -1634,8 +1669,14 @@ mod tests {
             fail_after_batch_offset: Some((1, 2)),
         });
         let storage = Arc::new(FakeStorage::fail_then_succeed(0, Vec::new()));
-        let runner = ShiftTaskRunnerImpl::new(queue_reader, Arc::clone(&storage), "logs", 1)
-            .expect("non-zero output_batch_size must be accepted");
+        let runner = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            Arc::clone(&storage),
+            "logs",
+            1,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted");
         let segment_1 = vec![
             ordered_single_row_batch("svc", 30, 1),
             ordered_single_row_batch("svc", 20, 2),
@@ -1719,10 +1760,16 @@ mod tests {
             concurrency_gate: None,
         });
         let storage = Arc::new(FakeStorage::always_fail());
-        let runner = ShiftTaskRunnerImpl::new(queue_reader, Arc::clone(&storage), "logs", 1)
-            .expect("non-zero output_batch_size must be accepted")
-            .with_segment_read_parallelism(2)
-            .expect("non-zero segment read parallelism must be accepted");
+        let runner = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            Arc::clone(&storage),
+            "logs",
+            1,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted")
+        .with_segment_read_parallelism(2)
+        .expect("non-zero segment read parallelism must be accepted");
         let input = ShiftInput {
             tenant_id: "tenant-a".to_string(),
             segments: vec![
@@ -1799,10 +1846,16 @@ mod tests {
             concurrency_gate: None,
         });
         let storage = Arc::new(FakeStorage::always_fail());
-        let runner = ShiftTaskRunnerImpl::new(queue_reader, Arc::clone(&storage), "logs", 1)
-            .expect("non-zero output_batch_size must be accepted")
-            .with_segment_read_parallelism(1)
-            .expect("non-zero segment read parallelism must be accepted");
+        let runner = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            Arc::clone(&storage),
+            "logs",
+            1,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted")
+        .with_segment_read_parallelism(1)
+        .expect("non-zero segment read parallelism must be accepted");
         let input = ShiftInput {
             tenant_id: "tenant-a".to_string(),
             segments: vec![
@@ -1850,7 +1903,13 @@ mod tests {
         });
         let storage = Arc::new(FakeStorage::fail_then_succeed(0, Vec::new()));
 
-        let result = ShiftTaskRunnerImpl::new(queue_reader, storage, "logs", 0);
+        let result = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            storage,
+            "logs",
+            0,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        );
 
         match result {
             Ok(_) => panic!("zero row_group_size must be rejected"),
@@ -1872,9 +1931,15 @@ mod tests {
         });
         let storage = Arc::new(FakeStorage::fail_then_succeed(0, Vec::new()));
 
-        let result = ShiftTaskRunnerImpl::new(queue_reader, storage, "logs", 1)
-            .expect("non-zero output_batch_size must be accepted")
-            .with_segment_read_parallelism(0);
+        let result = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            storage,
+            "logs",
+            1,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted")
+        .with_segment_read_parallelism(0);
 
         match result {
             Ok(_) => panic!("zero shift_segment_read_parallelism must be rejected"),
@@ -1910,10 +1975,16 @@ mod tests {
             concurrency_gate: None,
         });
         let storage = Arc::new(FakeStorage::always_fail());
-        let runner = ShiftTaskRunnerImpl::new(queue_reader, Arc::clone(&storage), "logs", 1)
-            .expect("non-zero output_batch_size must be accepted")
-            .with_segment_read_parallelism(2)
-            .expect("non-zero segment read parallelism must be accepted");
+        let runner = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            Arc::clone(&storage),
+            "logs",
+            1,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted")
+        .with_segment_read_parallelism(2)
+        .expect("non-zero segment read parallelism must be accepted");
         let input = ShiftInput {
             tenant_id: "tenant-a".to_string(),
             segments: vec![
@@ -1983,10 +2054,16 @@ mod tests {
             concurrency_gate: Some(Arc::new(ReadConcurrencyGate::new(2, Duration::from_secs(2)))),
         });
         let storage = Arc::new(FakeStorage::fail_then_succeed(0, Vec::new()));
-        let runner = ShiftTaskRunnerImpl::new(queue_reader, Arc::clone(&storage), "logs", 1)
-            .expect("non-zero output_batch_size must be accepted")
-            .with_segment_read_parallelism(2)
-            .expect("non-zero segment read parallelism must be accepted");
+        let runner = ShiftTaskRunnerImpl::new(
+            queue_reader,
+            Arc::clone(&storage),
+            "logs",
+            1,
+            SortColumnsDescriptor::logs().expect("logs descriptor"),
+        )
+        .expect("non-zero output_batch_size must be accepted")
+        .with_segment_read_parallelism(2)
+        .expect("non-zero segment read parallelism must be accepted");
         let segments = (1..=4).map(test_batch).map(|batch| vec![batch]).collect::<Vec<_>>();
         let input = ShiftInput {
             tenant_id: "tenant-a".to_string(),
@@ -2129,10 +2206,16 @@ mod tests {
                     1,
                 )],
             ));
-            let shift_runner = ShiftTaskRunnerImpl::new(Arc::clone(&queue_reader), Arc::clone(&storage), "logs", 2)
-                .expect("non-zero output_batch_size must be accepted")
-                .with_segment_read_parallelism(2)
-                .expect("valid read parallelism");
+            let shift_runner = ShiftTaskRunnerImpl::new(
+                Arc::clone(&queue_reader),
+                Arc::clone(&storage),
+                "logs",
+                2,
+                SortColumnsDescriptor::logs().expect("logs descriptor"),
+            )
+            .expect("non-zero output_batch_size must be accepted")
+            .with_segment_read_parallelism(2)
+            .expect("valid read parallelism");
             let manager = RecordingJobManager::new();
             let task = Arc::new(TestTask {
                 id: task_id,

--- a/crates/icegate-ingest/src/shift/timeout.rs
+++ b/crates/icegate-ingest/src/shift/timeout.rs
@@ -6,6 +6,7 @@ use super::config::ShiftTimeoutsConfig;
 use crate::error::IngestError;
 
 #[allow(clippy::struct_field_names)]
+#[derive(Clone)]
 pub struct TimeoutEstimator {
     plan_base: ChronoDuration,
     shift_base: ChronoDuration,

--- a/crates/icegate-ingest/src/transform.rs
+++ b/crates/icegate-ingest/src/transform.rs
@@ -246,9 +246,11 @@ pub fn logs_to_record_batch(
 /// dropped silently and counted in the second return value so the caller
 /// can surface partial-success metrics.
 ///
-/// Top-level columns are populated here. Attributes map, nested events,
-/// and nested links are placeholder null values; subsequent tasks fill
-/// them in.
+/// Produces every column in the spans schema: top-level fields, the merged
+/// attributes map (resource + scope + span attributes plus indexed-column
+/// duplicates), and the nested `events` / `links` `List<Struct>` arrays.
+/// Links with invalid `trace_id` / `span_id` are dropped from the list and
+/// counted into the parent span's `dropped_links_count`.
 ///
 /// # Arguments
 ///
@@ -549,7 +551,10 @@ pub fn spans_to_record_batch(
                         struct_builder
                             .field_builder::<Int32Builder>(3)
                             .expect("event dropped count builder")
-                            .append_value(event.dropped_attributes_count as i32);
+                            .append_value(u32_count_to_i32(
+                                event.dropped_attributes_count,
+                                "event.dropped_attributes_count",
+                            )?);
                         struct_builder.append(true);
                     }
                     events_builder.append(true);
@@ -596,12 +601,15 @@ pub fn spans_to_record_batch(
                         struct_builder
                             .field_builder::<Int32Builder>(4)
                             .expect("link dropped count builder")
-                            .append_value(link.dropped_attributes_count as i32);
+                            .append_value(u32_count_to_i32(
+                                link.dropped_attributes_count,
+                                "link.dropped_attributes_count",
+                            )?);
                         let flags_b = struct_builder.field_builder::<Int32Builder>(5).expect("link flags builder");
                         if link.flags == 0 {
                             flags_b.append_null();
                         } else {
-                            flags_b.append_value(link.flags as i32);
+                            flags_b.append_value(u32_count_to_i32(link.flags, "link.flags")?);
                         }
                         struct_builder.append(true);
                     }
@@ -611,19 +619,32 @@ pub fn spans_to_record_batch(
                 if span.flags == 0 {
                     flags_builder.append_null();
                 } else {
-                    flags_builder.append_value(span.flags as i32);
+                    flags_builder.append_value(u32_count_to_i32(span.flags, "span.flags")?);
                 }
                 if span.dropped_attributes_count == 0 {
                     dropped_attributes_count_builder.append_null();
                 } else {
-                    dropped_attributes_count_builder.append_value(span.dropped_attributes_count as i32);
+                    dropped_attributes_count_builder.append_value(u32_count_to_i32(
+                        span.dropped_attributes_count,
+                        "span.dropped_attributes_count",
+                    )?);
                 }
                 if span.dropped_events_count == 0 {
                     dropped_events_count_builder.append_null();
                 } else {
-                    dropped_events_count_builder.append_value(span.dropped_events_count as i32);
+                    dropped_events_count_builder.append_value(u32_count_to_i32(
+                        span.dropped_events_count,
+                        "span.dropped_events_count",
+                    )?);
                 }
-                let total_dropped_links = span.dropped_links_count as i32 + extra_dropped_links;
+                // Sum u32 and per-transform i32 counter in i64, then narrow:
+                // avoids wrapping at the i32 boundary if they happen to add up.
+                let total_dropped_links_i64 = i64::from(span.dropped_links_count) + i64::from(extra_dropped_links);
+                let total_dropped_links = i32::try_from(total_dropped_links_i64).map_err(|_| {
+                    crate::error::IngestError::Validation(format!(
+                        "dropped_links_count total exceeds i32::MAX: {total_dropped_links_i64}"
+                    ))
+                })?;
                 if total_dropped_links == 0 {
                     dropped_links_count_builder.append_null();
                 } else {
@@ -783,6 +804,19 @@ fn any_value_to_json(value: &AnyValue) -> Option<serde_json::Value> {
 /// Checks if a byte slice is all zeros.
 fn is_zero_bytes(bytes: &[u8]) -> bool {
     bytes.iter().all(|&b| b == 0)
+}
+
+/// Convert an OTLP `u32` counter into the schema's signed `i32` field.
+///
+/// OTLP represents `flags` and `dropped_*_count` as `u32`. Iceberg stores
+/// them as `Int` (i32). Realistic telemetry values sit far below `i32::MAX`,
+/// but `as i32` silently wraps for anything above `2^31 - 1`, producing a
+/// negative count that later readers would see as "-2 billion dropped
+/// events". Fail the transform instead so the caller can surface the
+/// malformed span via `partial_success`.
+fn u32_count_to_i32(value: u32, context: &'static str) -> crate::error::Result<i32> {
+    i32::try_from(value)
+        .map_err(|_| crate::error::IngestError::Validation(format!("{context} exceeds i32::MAX: {value}")))
 }
 
 /// Extracts map field metadata from the Arrow schema for attributes field.

--- a/crates/icegate-ingest/src/transform.rs
+++ b/crates/icegate-ingest/src/transform.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use arrow::{
-    array::{ArrayRef, MapBuilder, MapFieldNames, RecordBatch, StringBuilder, TimestampMicrosecondArray},
+    array::{ArrayBuilder, ArrayRef, MapBuilder, MapFieldNames, RecordBatch, StringBuilder, TimestampMicrosecondArray},
     datatypes::{DataType, Schema},
 };
 use iceberg::arrow::schema_to_arrow_schema;
@@ -30,6 +30,22 @@ use opentelemetry_proto::tonic::{
 pub fn logs_arrow_schema() -> Schema {
     let iceberg_schema = icegate_common::schema::logs_schema().expect("logs_schema should always be valid");
     schema_to_arrow_schema(&iceberg_schema).expect("schema conversion should succeed")
+}
+
+/// Returns the Arrow schema for spans, derived from the Iceberg spans schema.
+///
+/// Uses `icegate_common::schema::spans_schema()` as the source of truth
+/// and converts it to Arrow format using
+/// `iceberg::arrow::schema_to_arrow_schema()`.
+///
+/// # Panics
+///
+/// Panics if the Iceberg schema cannot be created or converted to Arrow.
+/// This should never happen in practice as the schema is statically defined.
+#[allow(clippy::expect_used)]
+pub fn spans_arrow_schema() -> Schema {
+    let iceberg_schema = icegate_common::schema::spans_schema().expect("spans_schema should always be valid");
+    schema_to_arrow_schema(&iceberg_schema).expect("spans schema conversion should succeed")
 }
 
 /// Transforms an OTLP logs export request to an Arrow `RecordBatch`.
@@ -223,6 +239,443 @@ pub fn logs_to_record_batch(
     })
 }
 
+/// Transforms an OTLP traces export request to an Arrow `RecordBatch`.
+///
+/// Extracts all spans from the request, validating `trace_id` (16 bytes,
+/// non-zero) and `span_id` (8 bytes, non-zero) per span. Invalid spans are
+/// dropped silently and counted in the second return value so the caller
+/// can surface partial-success metrics.
+///
+/// Top-level columns are populated here. Attributes map, nested events,
+/// and nested links are placeholder null values; subsequent tasks fill
+/// them in.
+///
+/// # Arguments
+///
+/// * `request` - The OTLP export traces request
+/// * `tenant_id` - Tenant identifier (from request metadata or default)
+///
+/// # Returns
+///
+/// `(Some(batch), drops)` if at least one span is valid, or
+/// `(None, drops)` if zero valid spans remain.
+///
+/// # Errors
+///
+/// Returns `IngestError` if schema validation or `RecordBatch` creation fails.
+#[allow(clippy::cast_possible_wrap)]
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+#[allow(clippy::expect_used)]
+#[allow(clippy::too_many_lines)]
+#[tracing::instrument(skip(request))]
+pub fn spans_to_record_batch(
+    request: &opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest,
+    tenant_id: Option<&str>,
+) -> crate::error::Result<(Option<RecordBatch>, usize)> {
+    use arrow::array::{Int32Builder, Int64Array, ListBuilder, StructBuilder, TimestampMicrosecondBuilder};
+
+    let ingested_timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_micros() as i64;
+
+    let total_spans: usize = request
+        .resource_spans
+        .iter()
+        .flat_map(|rs| &rs.scope_spans)
+        .map(|ss| ss.spans.len())
+        .sum();
+
+    if total_spans == 0 {
+        return Ok((None, 0));
+    }
+
+    let schema = spans_arrow_schema();
+    let (attr_key_field, attr_value_field) = extract_map_fields_from_schema_named(&schema, "attributes")?;
+
+    // Top-level column builders. Events and links are written as all-null
+    // placeholders; Tasks 14 and 15 replace these with real list builders.
+    let mut tenant_id_builder = StringBuilder::with_capacity(total_spans, total_spans * 16);
+    let mut cloud_account_id_builder = StringBuilder::with_capacity(total_spans, total_spans * 16);
+    let mut service_name_builder = StringBuilder::with_capacity(total_spans, total_spans * 32);
+    let mut trace_id_builder = StringBuilder::with_capacity(total_spans, total_spans * 32);
+    let mut span_id_builder = StringBuilder::with_capacity(total_spans, total_spans * 16);
+    let mut parent_span_id_builder = StringBuilder::with_capacity(total_spans, total_spans * 16);
+    let mut timestamp_builder: Vec<i64> = Vec::with_capacity(total_spans);
+    let mut end_timestamp_builder: Vec<i64> = Vec::with_capacity(total_spans);
+    let mut ingested_timestamp_builder: Vec<i64> = Vec::with_capacity(total_spans);
+    let mut duration_micros_builder: Vec<i64> = Vec::with_capacity(total_spans);
+    let mut trace_state_builder = StringBuilder::with_capacity(total_spans, total_spans * 16);
+    let mut name_builder = StringBuilder::with_capacity(total_spans, total_spans * 32);
+    let mut kind_builder = Int32Builder::with_capacity(total_spans);
+    let mut status_code_builder = Int32Builder::with_capacity(total_spans);
+    let mut status_message_builder = StringBuilder::with_capacity(total_spans, total_spans * 32);
+    let mut attributes_builder = MapBuilder::new(
+        Some(MapFieldNames {
+            entry: "key_value".to_string(),
+            key: "key".to_string(),
+            value: "value".to_string(),
+        }),
+        StringBuilder::new(),
+        StringBuilder::new(),
+    )
+    .with_keys_field(attr_key_field)
+    .with_values_field(attr_value_field);
+    let mut flags_builder = Int32Builder::with_capacity(total_spans);
+    let mut dropped_attributes_count_builder = Int32Builder::with_capacity(total_spans);
+    let mut dropped_events_count_builder = Int32Builder::with_capacity(total_spans);
+    let mut dropped_links_count_builder = Int32Builder::with_capacity(total_spans);
+
+    // Events list<struct> builder: struct fields (in schema order) are
+    // (timestamp, name, attributes: Map<Utf8,Utf8>, dropped_attributes_count).
+    let events_field = schema.field_with_name("events").expect("events field").clone();
+    let events_element_field = match events_field.data_type() {
+        DataType::List(inner) => inner.clone(),
+        _ => {
+            return Err(crate::error::IngestError::Validation("events must be List".into()));
+        }
+    };
+    let event_struct_fields = match events_element_field.data_type() {
+        DataType::Struct(fs) => fs.clone(),
+        _ => {
+            return Err(crate::error::IngestError::Validation(
+                "events element must be Struct".into(),
+            ));
+        }
+    };
+    let (event_attr_key_field, event_attr_value_field) =
+        extract_map_fields_from_nested_struct(&event_struct_fields, "attributes")?;
+
+    let mut events_builder = ListBuilder::new(StructBuilder::new(
+        event_struct_fields.iter().cloned().collect::<Vec<_>>(),
+        vec![
+            Box::new(TimestampMicrosecondBuilder::new()) as Box<dyn ArrayBuilder>,
+            Box::new(StringBuilder::new()) as Box<dyn ArrayBuilder>,
+            Box::new(
+                MapBuilder::new(
+                    Some(MapFieldNames {
+                        entry: "key_value".to_string(),
+                        key: "key".to_string(),
+                        value: "value".to_string(),
+                    }),
+                    StringBuilder::new(),
+                    StringBuilder::new(),
+                )
+                .with_keys_field(event_attr_key_field)
+                .with_values_field(event_attr_value_field),
+            ) as Box<dyn ArrayBuilder>,
+            Box::new(Int32Builder::new()) as Box<dyn ArrayBuilder>,
+        ],
+    ))
+    .with_field(events_element_field);
+
+    // Links list<struct> builder: struct fields (in schema order) are
+    // (trace_id, span_id, trace_state?, attributes: Map, dropped_attributes_count, flags?).
+    let links_field = schema.field_with_name("links").expect("links field").clone();
+    let links_element_field = match links_field.data_type() {
+        DataType::List(inner) => inner.clone(),
+        _ => {
+            return Err(crate::error::IngestError::Validation("links must be List".into()));
+        }
+    };
+    let link_struct_fields = match links_element_field.data_type() {
+        DataType::Struct(fs) => fs.clone(),
+        _ => {
+            return Err(crate::error::IngestError::Validation(
+                "links element must be Struct".into(),
+            ));
+        }
+    };
+    let (link_attr_key_field, link_attr_value_field) =
+        extract_map_fields_from_nested_struct(&link_struct_fields, "attributes")?;
+
+    let mut links_builder = ListBuilder::new(StructBuilder::new(
+        link_struct_fields.iter().cloned().collect::<Vec<_>>(),
+        vec![
+            Box::new(StringBuilder::new()) as Box<dyn ArrayBuilder>, // trace_id
+            Box::new(StringBuilder::new()) as Box<dyn ArrayBuilder>, // span_id
+            Box::new(StringBuilder::new()) as Box<dyn ArrayBuilder>, // trace_state (nullable)
+            Box::new(
+                MapBuilder::new(
+                    Some(MapFieldNames {
+                        entry: "key_value".to_string(),
+                        key: "key".to_string(),
+                        value: "value".to_string(),
+                    }),
+                    StringBuilder::new(),
+                    StringBuilder::new(),
+                )
+                .with_keys_field(link_attr_key_field)
+                .with_values_field(link_attr_value_field),
+            ) as Box<dyn ArrayBuilder>,
+            Box::new(Int32Builder::new()) as Box<dyn ArrayBuilder>, // dropped_attributes_count
+            Box::new(Int32Builder::new()) as Box<dyn ArrayBuilder>, // flags (nullable)
+        ],
+    ))
+    .with_field(links_element_field);
+
+    let tenant = tenant_id.unwrap_or(DEFAULT_TENANT_ID);
+    let empty_attrs: Vec<opentelemetry_proto::tonic::common::v1::KeyValue> = Vec::new();
+    let mut drops: usize = 0;
+
+    for resource_spans in &request.resource_spans {
+        let resource_attrs = resource_spans.resource.as_ref().map_or(&empty_attrs, |r| &r.attributes);
+        let service_name = resource_attrs
+            .iter()
+            .find(|kv| kv.key == "service.name")
+            .and_then(|kv| extract_string_value(kv.value.as_ref()));
+        let cloud_account_id = resource_attrs
+            .iter()
+            .find(|kv| kv.key == "cloud.account.id")
+            .and_then(|kv| extract_string_value(kv.value.as_ref()));
+
+        for scope_spans in &resource_spans.scope_spans {
+            for span in &scope_spans.spans {
+                if span.trace_id.len() != 16 || is_zero_bytes(&span.trace_id) {
+                    drops += 1;
+                    continue;
+                }
+                if span.span_id.len() != 8 || is_zero_bytes(&span.span_id) {
+                    drops += 1;
+                    continue;
+                }
+
+                // Tracks how many links were dropped during transform (invalid
+                // trace_id/span_id). Added to span.dropped_links_count so the
+                // caller sees a faithful total.
+                let mut extra_dropped_links: i32 = 0;
+
+                tenant_id_builder.append_value(tenant);
+                match cloud_account_id.as_deref() {
+                    Some(acc) => cloud_account_id_builder.append_value(acc),
+                    None => cloud_account_id_builder.append_null(),
+                }
+                match service_name.as_deref() {
+                    Some(svc) => service_name_builder.append_value(svc),
+                    None => service_name_builder.append_null(),
+                }
+
+                trace_id_builder.append_value(hex::encode(&span.trace_id));
+                span_id_builder.append_value(hex::encode(&span.span_id));
+                if span.parent_span_id.len() == 8 && !is_zero_bytes(&span.parent_span_id) {
+                    parent_span_id_builder.append_value(hex::encode(&span.parent_span_id));
+                } else {
+                    parent_span_id_builder.append_null();
+                }
+
+                let start_micros = (span.start_time_unix_nano / 1000) as i64;
+                let end_micros = (span.end_time_unix_nano / 1000) as i64;
+                timestamp_builder.push(start_micros);
+                end_timestamp_builder.push(end_micros);
+                ingested_timestamp_builder.push(ingested_timestamp);
+                duration_micros_builder.push((end_micros - start_micros).max(0));
+
+                if span.trace_state.is_empty() {
+                    trace_state_builder.append_null();
+                } else {
+                    trace_state_builder.append_value(&span.trace_state);
+                }
+                name_builder.append_value(&span.name);
+
+                if span.kind == 0 {
+                    kind_builder.append_null();
+                } else {
+                    kind_builder.append_value(span.kind);
+                }
+
+                match span.status.as_ref() {
+                    Some(status) => {
+                        if status.code == 0 {
+                            status_code_builder.append_null();
+                        } else {
+                            status_code_builder.append_value(status.code);
+                        }
+                        if status.message.is_empty() {
+                            status_message_builder.append_null();
+                        } else {
+                            status_message_builder.append_value(&status.message);
+                        }
+                    }
+                    None => {
+                        status_code_builder.append_null();
+                        status_message_builder.append_null();
+                    }
+                }
+
+                // Resource + scope + span-level attributes, flattened with dot separator.
+                add_flattened_attributes_dotted(resource_attrs, &mut attributes_builder);
+                let scope_attrs = scope_spans.scope.as_ref().map_or(&empty_attrs, |s| &s.attributes);
+                add_flattened_attributes_dotted(scope_attrs, &mut attributes_builder);
+                add_flattened_attributes_dotted(&span.attributes, &mut attributes_builder);
+
+                // Indexed column duplication — schema-column-name keys (underscore form).
+                duplicate_span_indexed_columns(
+                    &mut attributes_builder,
+                    service_name.as_deref(),
+                    cloud_account_id.as_deref(),
+                    &span.trace_id,
+                    &span.span_id,
+                    &span.parent_span_id,
+                    span.kind,
+                    span.status.as_ref().map(|s| s.code),
+                    &span.name,
+                );
+
+                attributes_builder.append(true).expect("append attributes map entry");
+
+                // Events list<struct>: one row per parent span.
+                {
+                    let struct_builder = events_builder.values();
+                    for event in &span.events {
+                        struct_builder
+                            .field_builder::<TimestampMicrosecondBuilder>(0)
+                            .expect("event timestamp builder")
+                            .append_value((event.time_unix_nano / 1000) as i64);
+                        struct_builder
+                            .field_builder::<StringBuilder>(1)
+                            .expect("event name builder")
+                            .append_value(&event.name);
+                        let attr_b = struct_builder
+                            .field_builder::<MapBuilder<StringBuilder, StringBuilder>>(2)
+                            .expect("event attrs builder");
+                        for kv in &event.attributes {
+                            for (k, v) in flatten_any_value_dotted(&kv.key, kv.value.as_ref()) {
+                                attr_b.keys().append_value(&k);
+                                attr_b.values().append_value(v);
+                            }
+                        }
+                        attr_b.append(true).expect("append event attrs map");
+                        struct_builder
+                            .field_builder::<Int32Builder>(3)
+                            .expect("event dropped count builder")
+                            .append_value(event.dropped_attributes_count as i32);
+                        struct_builder.append(true);
+                    }
+                    events_builder.append(true);
+                }
+
+                // Links list<struct>: drop entries with invalid ids and count them.
+                {
+                    let struct_builder = links_builder.values();
+                    for link in &span.links {
+                        if link.trace_id.len() != 16
+                            || is_zero_bytes(&link.trace_id)
+                            || link.span_id.len() != 8
+                            || is_zero_bytes(&link.span_id)
+                        {
+                            extra_dropped_links += 1;
+                            continue;
+                        }
+                        struct_builder
+                            .field_builder::<StringBuilder>(0)
+                            .expect("link trace_id builder")
+                            .append_value(hex::encode(&link.trace_id));
+                        struct_builder
+                            .field_builder::<StringBuilder>(1)
+                            .expect("link span_id builder")
+                            .append_value(hex::encode(&link.span_id));
+                        let ts_b = struct_builder
+                            .field_builder::<StringBuilder>(2)
+                            .expect("link trace_state builder");
+                        if link.trace_state.is_empty() {
+                            ts_b.append_null();
+                        } else {
+                            ts_b.append_value(&link.trace_state);
+                        }
+                        let attr_b = struct_builder
+                            .field_builder::<MapBuilder<StringBuilder, StringBuilder>>(3)
+                            .expect("link attrs builder");
+                        for kv in &link.attributes {
+                            for (k, v) in flatten_any_value_dotted(&kv.key, kv.value.as_ref()) {
+                                attr_b.keys().append_value(&k);
+                                attr_b.values().append_value(v);
+                            }
+                        }
+                        attr_b.append(true).expect("append link attrs map");
+                        struct_builder
+                            .field_builder::<Int32Builder>(4)
+                            .expect("link dropped count builder")
+                            .append_value(link.dropped_attributes_count as i32);
+                        let flags_b = struct_builder.field_builder::<Int32Builder>(5).expect("link flags builder");
+                        if link.flags == 0 {
+                            flags_b.append_null();
+                        } else {
+                            flags_b.append_value(link.flags as i32);
+                        }
+                        struct_builder.append(true);
+                    }
+                    links_builder.append(true);
+                }
+
+                if span.flags == 0 {
+                    flags_builder.append_null();
+                } else {
+                    flags_builder.append_value(span.flags as i32);
+                }
+                if span.dropped_attributes_count == 0 {
+                    dropped_attributes_count_builder.append_null();
+                } else {
+                    dropped_attributes_count_builder.append_value(span.dropped_attributes_count as i32);
+                }
+                if span.dropped_events_count == 0 {
+                    dropped_events_count_builder.append_null();
+                } else {
+                    dropped_events_count_builder.append_value(span.dropped_events_count as i32);
+                }
+                let total_dropped_links = span.dropped_links_count as i32 + extra_dropped_links;
+                if total_dropped_links == 0 {
+                    dropped_links_count_builder.append_null();
+                } else {
+                    dropped_links_count_builder.append_value(total_dropped_links);
+                }
+            }
+        }
+    }
+
+    let valid_rows = tenant_id_builder.len();
+    if valid_rows == 0 {
+        return Ok((None, drops));
+    }
+
+    let events_array: ArrayRef = Arc::new(events_builder.finish());
+    let links_array: ArrayRef = Arc::new(links_builder.finish());
+
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(tenant_id_builder.finish()),
+        Arc::new(cloud_account_id_builder.finish()),
+        Arc::new(service_name_builder.finish()),
+        Arc::new(trace_id_builder.finish()),
+        Arc::new(span_id_builder.finish()),
+        Arc::new(parent_span_id_builder.finish()),
+        Arc::new(arrow::array::TimestampMicrosecondArray::from(timestamp_builder)),
+        Arc::new(arrow::array::TimestampMicrosecondArray::from(end_timestamp_builder)),
+        Arc::new(arrow::array::TimestampMicrosecondArray::from(
+            ingested_timestamp_builder,
+        )),
+        Arc::new(Int64Array::from(duration_micros_builder)),
+        Arc::new(trace_state_builder.finish()),
+        Arc::new(name_builder.finish()),
+        Arc::new(kind_builder.finish()),
+        Arc::new(status_code_builder.finish()),
+        Arc::new(status_message_builder.finish()),
+        Arc::new(attributes_builder.finish()),
+        Arc::new(flags_builder.finish()),
+        Arc::new(dropped_attributes_count_builder.finish()),
+        Arc::new(dropped_events_count_builder.finish()),
+        Arc::new(dropped_links_count_builder.finish()),
+        events_array,
+        links_array,
+    ];
+
+    let batch = RecordBatch::try_new(Arc::new(schema), columns).map_err(|e| {
+        tracing::error!("Failed to create spans RecordBatch: {e}");
+        crate::error::IngestError::Validation(format!("Failed to create spans RecordBatch: {e}"))
+    })?;
+
+    Ok((Some(batch), drops))
+}
+
 /// Extracts a string value from an OTLP `AnyValue` reference.
 ///
 /// Converts various OTLP value types to string representation.
@@ -346,29 +799,69 @@ fn is_zero_bytes(bytes: &[u8]) -> bool {
 fn extract_map_fields_from_schema(
     schema: &Schema,
 ) -> crate::error::Result<(arrow::datatypes::FieldRef, arrow::datatypes::FieldRef)> {
-    let attributes_field = schema
-        .field_with_name("attributes")
-        .map_err(|_| crate::error::IngestError::Validation("Schema must contain an 'attributes' field".to_string()))?;
+    extract_map_fields_from_schema_named(schema, "attributes")
+}
 
-    // Extract map field information from schema
-    match attributes_field.data_type() {
+/// Extracts map field metadata from the Arrow schema by field name.
+///
+/// Used by both `logs_to_record_batch` (via `extract_map_fields_from_schema`)
+/// and `spans_to_record_batch` (directly).
+fn extract_map_fields_from_schema_named(
+    schema: &Schema,
+    name: &str,
+) -> crate::error::Result<(arrow::datatypes::FieldRef, arrow::datatypes::FieldRef)> {
+    let field = schema
+        .field_with_name(name)
+        .map_err(|_| crate::error::IngestError::Validation(format!("Schema must contain a '{name}' field")))?;
+    match field.data_type() {
         DataType::Map(entries_field, _) => match entries_field.data_type() {
             DataType::Struct(fields) => {
                 if fields.len() < 2 {
                     return Err(crate::error::IngestError::Validation(format!(
-                        "Expected at least 2 fields in map entries struct, found {}",
+                        "Expected at least 2 fields in map entries struct for '{name}', found {}",
                         fields.len()
                     )));
                 }
                 Ok((fields[0].clone(), fields[1].clone()))
             }
-            _ => Err(crate::error::IngestError::Validation(
-                "Expected Struct type for map entries in 'attributes' field".to_string(),
-            )),
+            _ => Err(crate::error::IngestError::Validation(format!(
+                "Expected Struct type for map entries in '{name}' field"
+            ))),
         },
         _ => Err(crate::error::IngestError::Validation(format!(
-            "Expected Map type for 'attributes' field, found {:?}",
-            attributes_field.data_type()
+            "Expected Map type for '{name}' field, found {:?}",
+            field.data_type()
+        ))),
+    }
+}
+
+/// Extracts map key/value field refs from a struct's inner field list.
+///
+/// Used to populate nested `Map` builders inside the events/links struct arrays.
+fn extract_map_fields_from_nested_struct(
+    fields: &arrow::datatypes::Fields,
+    map_field_name: &str,
+) -> crate::error::Result<(arrow::datatypes::FieldRef, arrow::datatypes::FieldRef)> {
+    let map_field = fields.iter().find(|f| f.name() == map_field_name).ok_or_else(|| {
+        crate::error::IngestError::Validation(format!("nested struct missing '{map_field_name}' field"))
+    })?;
+    match map_field.data_type() {
+        DataType::Map(entries_field, _) => match entries_field.data_type() {
+            DataType::Struct(inner_fields) => {
+                if inner_fields.len() < 2 {
+                    return Err(crate::error::IngestError::Validation(format!(
+                        "map entries struct for '{map_field_name}' needs 2+ fields, got {}",
+                        inner_fields.len()
+                    )));
+                }
+                Ok((inner_fields[0].clone(), inner_fields[1].clone()))
+            }
+            _ => Err(crate::error::IngestError::Validation(format!(
+                "map entries must be Struct for '{map_field_name}'"
+            ))),
+        },
+        _ => Err(crate::error::IngestError::Validation(format!(
+            "'{map_field_name}' must be Map"
         ))),
     }
 }
@@ -386,6 +879,75 @@ fn add_flattened_attributes(
             attributes_builder.keys().append_value(normalize_attribute_key(&key));
             attributes_builder.values().append_value(value);
         }
+    }
+}
+
+/// Appends flattened attributes to the map builder using dot-separator keys.
+///
+/// Used by spans where OTel-native dotted attribute names must be preserved.
+fn add_flattened_attributes_dotted(
+    attributes: &[opentelemetry_proto::tonic::common::v1::KeyValue],
+    attributes_builder: &mut MapBuilder<StringBuilder, StringBuilder>,
+) {
+    for kv in attributes {
+        for (key, value) in flatten_any_value_dotted(&kv.key, kv.value.as_ref()) {
+            attributes_builder.keys().append_value(&key);
+            attributes_builder.values().append_value(value);
+        }
+    }
+}
+
+/// Duplicates span indexed columns into the attributes map for UI/query parity.
+///
+/// Matches the logs pipeline's behaviour: indexed top-level columns are
+/// mirrored into the attributes map under schema-column-name keys
+/// (underscore form), which is how downstream consumers (Tempo eventually,
+/// but Grafana panels today) surface these values.
+#[allow(clippy::too_many_arguments)]
+fn duplicate_span_indexed_columns(
+    attributes_builder: &mut MapBuilder<StringBuilder, StringBuilder>,
+    service_name: Option<&str>,
+    cloud_account_id: Option<&str>,
+    trace_id: &[u8],
+    span_id: &[u8],
+    parent_span_id: &[u8],
+    kind: i32,
+    status_code: Option<i32>,
+    name: &str,
+) {
+    if let Some(svc) = service_name {
+        attributes_builder.keys().append_value("service_name");
+        attributes_builder.values().append_value(svc);
+    }
+    if let Some(acc) = cloud_account_id {
+        attributes_builder.keys().append_value("cloud_account_id");
+        attributes_builder.values().append_value(acc);
+    }
+    if trace_id.len() == 16 && !is_zero_bytes(trace_id) {
+        attributes_builder.keys().append_value("trace_id");
+        attributes_builder.values().append_value(hex::encode(trace_id));
+    }
+    if span_id.len() == 8 && !is_zero_bytes(span_id) {
+        attributes_builder.keys().append_value("span_id");
+        attributes_builder.values().append_value(hex::encode(span_id));
+    }
+    if parent_span_id.len() == 8 && !is_zero_bytes(parent_span_id) {
+        attributes_builder.keys().append_value("parent_span_id");
+        attributes_builder.values().append_value(hex::encode(parent_span_id));
+    }
+    if kind != 0 {
+        attributes_builder.keys().append_value("kind");
+        attributes_builder.values().append_value(kind.to_string());
+    }
+    if let Some(code) = status_code {
+        if code != 0 {
+            attributes_builder.keys().append_value("status_code");
+            attributes_builder.values().append_value(code.to_string());
+        }
+    }
+    if !name.is_empty() {
+        attributes_builder.keys().append_value("name");
+        attributes_builder.values().append_value(name);
     }
 }
 
@@ -514,6 +1076,56 @@ fn flatten_any_value(prefix: &str, value: Option<&AnyValue>) -> Vec<(String, Str
                         result.push((prefix.to_string(), s));
                     }
                 }
+            }
+        }
+    }
+
+    result
+}
+
+/// Flattens an OTLP `AnyValue` into dotted key-value pairs.
+///
+/// Mirrors [`flatten_any_value`] but joins nested `KvlistValue` keys with a
+/// dot (`.`) separator instead of underscore. Use this for spans and other
+/// signals where OTel-native dotted attribute names must be preserved.
+///
+/// # Arguments
+///
+/// * `prefix` - key prefix for nested values (empty string at the root).
+/// * `value` - OTLP `AnyValue` to flatten.
+///
+/// # Returns
+///
+/// Vector of (key, value) string pairs representing the flattened structure.
+/// Primitive values yield a single pair `(prefix, stringified_value)`.
+/// Arrays are stringified (not flattened) since they have no indexable keys.
+fn flatten_any_value_dotted(prefix: &str, value: Option<&AnyValue>) -> Vec<(String, String)> {
+    let mut result = Vec::new();
+    let Some(v) = value else {
+        return result;
+    };
+    let Some(val) = &v.value else {
+        return result;
+    };
+
+    match val {
+        Value::KvlistValue(kvs) => {
+            for kv in &kvs.values {
+                let nested_prefix = if prefix.is_empty() {
+                    kv.key.clone()
+                } else {
+                    format!("{prefix}.{}", kv.key)
+                };
+                result.extend(flatten_any_value_dotted(&nested_prefix, kv.value.as_ref()));
+            }
+        }
+        Value::ArrayValue(arr) => {
+            let items: Vec<String> = arr.values.iter().filter_map(|v| extract_any_value_string(Some(v))).collect();
+            result.push((prefix.to_string(), format!("[{}]", items.join(", "))));
+        }
+        _ => {
+            if let Some(s) = extract_any_value_string(Some(v)) {
+                result.push((prefix.to_string(), s));
             }
         }
     }
@@ -810,5 +1422,456 @@ mod tests {
         assert_eq!(flattened.len(), 1);
         assert_eq!(flattened[0].0, "key");
         assert_eq!(flattened[0].1, "simple");
+    }
+
+    #[test]
+    fn flatten_nested_attributes_with_dot_separator() {
+        use std::collections::HashMap;
+
+        use opentelemetry_proto::tonic::common::v1::{KeyValueList, any_value::Value};
+
+        let nested_kv = AnyValue {
+            value: Some(Value::KvlistValue(KeyValueList {
+                values: vec![
+                    KeyValue {
+                        key: "method".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(Value::StringValue("POST".to_string())),
+                        }),
+                    },
+                    KeyValue {
+                        key: "details".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(Value::KvlistValue(KeyValueList {
+                                values: vec![KeyValue {
+                                    key: "status".to_string(),
+                                    value: Some(AnyValue {
+                                        value: Some(Value::IntValue(200)),
+                                    }),
+                                }],
+                            })),
+                        }),
+                    },
+                ],
+            })),
+        };
+
+        let flattened = flatten_any_value_dotted("http", Some(&nested_kv));
+        let map: HashMap<String, String> = flattened.into_iter().collect();
+
+        assert_eq!(map.get("http.method"), Some(&"POST".to_string()));
+        assert_eq!(map.get("http.details.status"), Some(&"200".to_string()));
+    }
+
+    #[test]
+    fn spans_arrow_schema_has_nested_events_and_links() {
+        let schema = spans_arrow_schema();
+        assert!(schema.field_with_name("trace_id").is_ok());
+        assert!(schema.field_with_name("events").is_ok());
+        assert!(schema.field_with_name("links").is_ok());
+    }
+
+    #[test]
+    fn spans_to_record_batch_empty_request_returns_none() {
+        use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+        let request = ExportTraceServiceRequest { resource_spans: vec![] };
+        let (batch, drops) = spans_to_record_batch(&request, None).expect("should not error");
+        assert!(batch.is_none());
+        assert_eq!(drops, 0);
+    }
+
+    #[test]
+    fn spans_to_record_batch_single_span_populates_top_level_columns() {
+        use opentelemetry_proto::tonic::{
+            collector::trace::v1::ExportTraceServiceRequest,
+            resource::v1::Resource,
+            trace::v1::{ResourceSpans, ScopeSpans, Span, Status, status::StatusCode},
+        };
+
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![KeyValue {
+                        key: "service.name".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(Value::StringValue("svc".to_string())),
+                        }),
+                    }],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![Span {
+                        trace_id: vec![1u8; 16],
+                        span_id: vec![2u8; 8],
+                        parent_span_id: vec![3u8; 8],
+                        trace_state: "state-x".to_string(),
+                        name: "http.request".to_string(),
+                        kind: 2,
+                        start_time_unix_nano: 1_700_000_000_000_000_000,
+                        end_time_unix_nano: 1_700_000_000_000_500_000,
+                        attributes: vec![],
+                        dropped_attributes_count: 0,
+                        events: vec![],
+                        dropped_events_count: 0,
+                        links: vec![],
+                        dropped_links_count: 0,
+                        status: Some(Status {
+                            message: "ok".to_string(),
+                            code: StatusCode::Ok as i32,
+                        }),
+                        flags: 0,
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+
+        let (batch_opt, drops) = spans_to_record_batch(&request, Some("tenant-1")).expect("ok");
+        let batch = batch_opt.expect("batch");
+        assert_eq!(drops, 0);
+        assert_eq!(batch.num_rows(), 1);
+
+        let trace_id = batch
+            .column_by_name("trace_id")
+            .expect("trace_id")
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("utf8");
+        assert_eq!(trace_id.value(0), hex::encode(vec![1u8; 16]));
+
+        let span_id = batch
+            .column_by_name("span_id")
+            .expect("span_id")
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("utf8");
+        assert_eq!(span_id.value(0), hex::encode(vec![2u8; 8]));
+
+        let duration = batch
+            .column_by_name("duration_micros")
+            .expect("duration")
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .expect("i64");
+        assert_eq!(duration.value(0), 500);
+    }
+
+    #[test]
+    fn spans_to_record_batch_drops_span_with_invalid_trace_id() {
+        use opentelemetry_proto::tonic::{
+            collector::trace::v1::ExportTraceServiceRequest,
+            resource::v1::Resource,
+            trace::v1::{ResourceSpans, ScopeSpans, Span},
+        };
+
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![Span {
+                        trace_id: vec![0u8; 16], // all-zero -> invalid
+                        span_id: vec![2u8; 8],
+                        parent_span_id: vec![],
+                        trace_state: String::new(),
+                        name: "x".to_string(),
+                        kind: 0,
+                        start_time_unix_nano: 1,
+                        end_time_unix_nano: 2,
+                        attributes: vec![],
+                        dropped_attributes_count: 0,
+                        events: vec![],
+                        dropped_events_count: 0,
+                        links: vec![],
+                        dropped_links_count: 0,
+                        status: None,
+                        flags: 0,
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+
+        let (batch_opt, drops) = spans_to_record_batch(&request, None).expect("ok");
+        assert!(batch_opt.is_none());
+        assert_eq!(drops, 1);
+    }
+
+    #[test]
+    fn spans_attributes_preserve_dots_and_duplicate_indexed_columns() {
+        use arrow::array::{Array, MapArray, StringArray};
+        use opentelemetry_proto::tonic::{
+            collector::trace::v1::ExportTraceServiceRequest,
+            resource::v1::Resource,
+            trace::v1::{ResourceSpans, ScopeSpans, Span},
+        };
+
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![
+                        KeyValue {
+                            key: "service.name".to_string(),
+                            value: Some(AnyValue {
+                                value: Some(Value::StringValue("svc".to_string())),
+                            }),
+                        },
+                        KeyValue {
+                            key: "cloud.account.id".to_string(),
+                            value: Some(AnyValue {
+                                value: Some(Value::StringValue("acc-1".to_string())),
+                            }),
+                        },
+                    ],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![Span {
+                        trace_id: vec![1u8; 16],
+                        span_id: vec![2u8; 8],
+                        parent_span_id: vec![3u8; 8],
+                        trace_state: String::new(),
+                        name: "op".to_string(),
+                        kind: 2,
+                        start_time_unix_nano: 1,
+                        end_time_unix_nano: 2,
+                        attributes: vec![KeyValue {
+                            key: "http.method".to_string(),
+                            value: Some(AnyValue {
+                                value: Some(Value::StringValue("GET".to_string())),
+                            }),
+                        }],
+                        dropped_attributes_count: 0,
+                        events: vec![],
+                        dropped_events_count: 0,
+                        links: vec![],
+                        dropped_links_count: 0,
+                        status: None,
+                        flags: 0,
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+
+        let (batch, _) = spans_to_record_batch(&request, Some("tenant-1")).expect("ok");
+        let batch = batch.expect("batch");
+        let attrs = batch
+            .column_by_name("attributes")
+            .expect("attributes")
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("map");
+
+        let entries = attrs.value(0);
+        let entries_struct = entries.as_any().downcast_ref::<arrow::array::StructArray>().expect("struct");
+        let keys = entries_struct.column(0).as_any().downcast_ref::<StringArray>().expect("keys");
+        let values = entries_struct.column(1).as_any().downcast_ref::<StringArray>().expect("values");
+        let pairs: std::collections::BTreeMap<String, String> = (0..keys.len())
+            .map(|i| (keys.value(i).to_string(), values.value(i).to_string()))
+            .collect();
+
+        // User attribute preserves OTel dotted keys.
+        assert_eq!(pairs.get("http.method"), Some(&"GET".to_string()));
+        // Resource-derived attributes preserve dots.
+        assert_eq!(pairs.get("service.name"), Some(&"svc".to_string()));
+        assert_eq!(pairs.get("cloud.account.id"), Some(&"acc-1".to_string()));
+        // Indexed-column duplication: schema column names copied into attributes using underscore keys.
+        assert_eq!(pairs.get("service_name"), Some(&"svc".to_string()));
+        assert_eq!(pairs.get("cloud_account_id"), Some(&"acc-1".to_string()));
+        assert_eq!(pairs.get("trace_id"), Some(&hex::encode(vec![1u8; 16])));
+        assert_eq!(pairs.get("span_id"), Some(&hex::encode(vec![2u8; 8])));
+        assert_eq!(pairs.get("parent_span_id"), Some(&hex::encode(vec![3u8; 8])));
+        assert_eq!(pairs.get("kind"), Some(&"2".to_string()));
+        assert_eq!(pairs.get("name"), Some(&"op".to_string()));
+    }
+
+    #[test]
+    fn spans_events_are_materialized_as_list_of_structs() {
+        use arrow::array::{Array, ListArray, StringArray, StructArray, TimestampMicrosecondArray};
+        use opentelemetry_proto::tonic::{
+            collector::trace::v1::ExportTraceServiceRequest,
+            resource::v1::Resource,
+            trace::v1::{ResourceSpans, ScopeSpans, Span, span::Event},
+        };
+
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![Span {
+                        trace_id: vec![1u8; 16],
+                        span_id: vec![2u8; 8],
+                        parent_span_id: vec![],
+                        trace_state: String::new(),
+                        name: "op".to_string(),
+                        kind: 0,
+                        start_time_unix_nano: 1_000,
+                        end_time_unix_nano: 2_000,
+                        attributes: vec![],
+                        dropped_attributes_count: 0,
+                        events: vec![Event {
+                            time_unix_nano: 1_500,
+                            name: "cache.hit".to_string(),
+                            attributes: vec![KeyValue {
+                                key: "db.system".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(Value::StringValue("postgres".to_string())),
+                                }),
+                            }],
+                            dropped_attributes_count: 0,
+                        }],
+                        dropped_events_count: 0,
+                        links: vec![],
+                        dropped_links_count: 0,
+                        status: None,
+                        flags: 0,
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+
+        let (batch, _) = spans_to_record_batch(&request, None).expect("ok");
+        let batch = batch.expect("batch");
+        let events = batch
+            .column_by_name("events")
+            .expect("events")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list");
+        let row0 = events.value(0);
+        let row0_struct = row0.as_any().downcast_ref::<StructArray>().expect("struct");
+        assert_eq!(row0_struct.len(), 1);
+
+        let ts = row0_struct
+            .column_by_name("timestamp")
+            .expect("timestamp")
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .expect("ts");
+        assert_eq!(ts.value(0), 1); // 1500 ns / 1000 = 1 μs
+
+        let name = row0_struct
+            .column_by_name("name")
+            .expect("name")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name");
+        assert_eq!(name.value(0), "cache.hit");
+    }
+
+    #[test]
+    fn spans_links_are_materialized_and_invalid_ids_dropped() {
+        use arrow::array::{Array, Int32Array, ListArray, StringArray, StructArray};
+        use opentelemetry_proto::tonic::{
+            collector::trace::v1::ExportTraceServiceRequest,
+            resource::v1::Resource,
+            trace::v1::{ResourceSpans, ScopeSpans, Span, span::Link},
+        };
+
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                resource: Some(Resource {
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_spans: vec![ScopeSpans {
+                    scope: None,
+                    spans: vec![Span {
+                        trace_id: vec![1u8; 16],
+                        span_id: vec![2u8; 8],
+                        parent_span_id: vec![],
+                        trace_state: String::new(),
+                        name: "op".to_string(),
+                        kind: 0,
+                        start_time_unix_nano: 1,
+                        end_time_unix_nano: 2,
+                        attributes: vec![],
+                        dropped_attributes_count: 0,
+                        events: vec![],
+                        dropped_events_count: 0,
+                        links: vec![
+                            Link {
+                                trace_id: vec![9u8; 16],
+                                span_id: vec![8u8; 8],
+                                trace_state: "tstate".to_string(),
+                                attributes: vec![],
+                                dropped_attributes_count: 0,
+                                flags: 0,
+                            },
+                            Link {
+                                trace_id: vec![9u8; 16],
+                                span_id: vec![0u8; 4], // invalid -> dropped
+                                trace_state: String::new(),
+                                attributes: vec![],
+                                dropped_attributes_count: 0,
+                                flags: 0,
+                            },
+                        ],
+                        dropped_links_count: 0,
+                        status: None,
+                        flags: 0,
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+
+        let (batch, _) = spans_to_record_batch(&request, None).expect("ok");
+        let batch = batch.expect("batch");
+
+        let links = batch
+            .column_by_name("links")
+            .expect("links")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list");
+        let row0 = links.value(0);
+        let row0_struct = row0.as_any().downcast_ref::<StructArray>().expect("struct");
+        assert_eq!(row0_struct.len(), 1); // second link dropped
+
+        let trace_ids = row0_struct
+            .column_by_name("trace_id")
+            .expect("trace_id")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("utf8");
+        assert_eq!(trace_ids.value(0), hex::encode(vec![9u8; 16]));
+
+        let trace_state = row0_struct
+            .column_by_name("trace_state")
+            .expect("trace_state")
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("utf8");
+        assert_eq!(trace_state.value(0), "tstate");
+
+        let dropped_links = batch
+            .column_by_name("dropped_links_count")
+            .expect("dropped_links_count")
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("i32");
+        assert_eq!(dropped_links.value(0), 1);
     }
 }

--- a/crates/icegate-ingest/src/wal/columns.rs
+++ b/crates/icegate-ingest/src/wal/columns.rs
@@ -10,6 +10,7 @@ use super::{RowGroupBoundaryComponent, RowGroupBoundaryKey, RowGroupBoundaryValu
 use crate::error::{IngestError, Result};
 
 static LOGS_SORT_DESCRIPTOR: OnceLock<std::result::Result<SortColumnsDescriptor, String>> = OnceLock::new();
+static SPANS_SORT_DESCRIPTOR: OnceLock<std::result::Result<SortColumnsDescriptor, String>> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SortColumnDescriptor {
@@ -24,13 +25,21 @@ pub(crate) struct SortColumnsDescriptor {
     columns: Vec<SortColumnDescriptor>,
 }
 
-// TODO(high): make a generic solution without binding to logs
 impl SortColumnsDescriptor {
     pub(crate) fn logs() -> Result<&'static Self> {
-        match LOGS_SORT_DESCRIPTOR.get_or_init(|| Self::try_from_logs_sort_order().map_err(|err| err.to_string())) {
+        match LOGS_SORT_DESCRIPTOR.get_or_init(|| Self::try_from_logs().map_err(|err| err.to_string())) {
             Ok(descriptor) => Ok(descriptor),
             Err(message) => Err(IngestError::Config(format!(
                 "failed to initialize logs sort descriptor: {message}"
+            ))),
+        }
+    }
+
+    pub(crate) fn spans() -> Result<&'static Self> {
+        match SPANS_SORT_DESCRIPTOR.get_or_init(|| Self::try_from_spans().map_err(|err| err.to_string())) {
+            Ok(descriptor) => Ok(descriptor),
+            Err(message) => Err(IngestError::Config(format!(
+                "failed to initialize spans sort descriptor: {message}"
             ))),
         }
     }
@@ -39,9 +48,15 @@ impl SortColumnsDescriptor {
         self.columns.as_slice()
     }
 
-    fn try_from_logs_sort_order() -> Result<Self> {
+    fn try_from_logs() -> Result<Self> {
         let schema = icegate_common::schema::logs_schema()?;
         let sort_order = icegate_common::schema::logs_sort_order(&schema)?;
+        Self::try_from_schema_sort_order(&schema, &sort_order)
+    }
+
+    fn try_from_spans() -> Result<Self> {
+        let schema = icegate_common::schema::spans_schema()?;
+        let sort_order = icegate_common::schema::spans_sort_order(&schema)?;
         Self::try_from_schema_sort_order(&schema, &sort_order)
     }
 
@@ -49,13 +64,11 @@ impl SortColumnsDescriptor {
         let mut columns = Vec::with_capacity(sort_order.fields.len());
 
         for sort_field in &sort_order.fields {
-            let schema_field = resolve_logs_sort_schema_field(schema, sort_field)?;
+            let schema_field = resolve_sort_schema_field(schema, sort_field)?;
             let primitive_type = schema_field
                 .field_type
                 .as_primitive_type()
-                .ok_or_else(|| {
-                    IngestError::Shift(format!("logs sort field '{}' must be primitive", schema_field.name))
-                })?
+                .ok_or_else(|| IngestError::Shift(format!("sort field '{}' must be primitive", schema_field.name)))?
                 .clone();
             columns.push(SortColumnDescriptor {
                 column_name: schema_field.name.clone(),
@@ -107,7 +120,7 @@ impl SortColumnCache {
                 },
                 ref other => {
                     return Err(IngestError::Shift(format!(
-                        "unsupported logs sort column type for '{column_name}' in {context}: {other}"
+                        "unsupported sort column type for '{column_name}' in {context}: {other}"
                     )));
                 }
             };
@@ -146,14 +159,11 @@ impl SortColumnCache {
     }
 }
 
-fn resolve_logs_sort_schema_field<'a>(
-    schema: &'a Schema,
-    sort_field: &SortField,
-) -> Result<&'a iceberg::spec::NestedField> {
+fn resolve_sort_schema_field<'a>(schema: &'a Schema, sort_field: &SortField) -> Result<&'a iceberg::spec::NestedField> {
     if sort_field.transform != Transform::Identity {
         return Err(iceberg::Error::new(
             iceberg::ErrorKind::FeatureUnsupported,
-            format!("unsupported logs merge sort transform: {}", sort_field.transform),
+            format!("unsupported merge sort transform: {}", sort_field.transform),
         )
         .into());
     }
@@ -164,7 +174,7 @@ fn resolve_logs_sort_schema_field<'a>(
         .ok_or_else(|| {
             iceberg::Error::new(
                 iceberg::ErrorKind::DataInvalid,
-                format!("logs sort field source_id {} not found in schema", sort_field.source_id),
+                format!("sort field source_id {} not found in schema", sort_field.source_id),
             )
             .into()
         })
@@ -282,8 +292,38 @@ mod tests {
         NestedField, NullOrder, PrimitiveType, Schema, SortDirection, SortField, SortOrder, Transform, Type,
     };
 
-    use super::{SortColumnsDescriptor, resolve_logs_sort_schema_field};
+    use super::{SortColumnsDescriptor, resolve_sort_schema_field};
     use crate::error::IngestError;
+
+    #[test]
+    fn spans_sort_descriptor_matches_spans_sort_order() {
+        let schema = icegate_common::schema::spans_schema().expect("spans schema");
+        let sort_order = icegate_common::schema::spans_sort_order(&schema).expect("spans sort order");
+        let descriptor = SortColumnsDescriptor::spans().expect("spans descriptor");
+
+        assert_eq!(descriptor.columns().len(), sort_order.fields.len());
+
+        for (descriptor_column, sort_field) in descriptor.columns().iter().zip(&sort_order.fields) {
+            let schema_field = resolve_sort_schema_field(&schema, sort_field).expect("sort field must resolve");
+            assert_eq!(descriptor_column.column_name, schema_field.name);
+            assert_eq!(
+                descriptor_column.primitive_type,
+                schema_field
+                    .field_type
+                    .as_primitive_type()
+                    .expect("sort field must be primitive")
+                    .clone()
+            );
+            assert_eq!(
+                descriptor_column.descending,
+                matches!(sort_field.direction, SortDirection::Descending)
+            );
+            assert_eq!(
+                descriptor_column.nulls_first,
+                matches!(sort_field.null_order, NullOrder::First)
+            );
+        }
+    }
 
     #[test]
     fn logs_sort_descriptor_matches_logs_sort_order() {
@@ -294,7 +334,7 @@ mod tests {
         assert_eq!(descriptor.columns().len(), sort_order.fields.len());
 
         for (descriptor_column, sort_field) in descriptor.columns().iter().zip(&sort_order.fields) {
-            let schema_field = resolve_logs_sort_schema_field(&schema, sort_field).expect("sort field must resolve");
+            let schema_field = resolve_sort_schema_field(&schema, sort_field).expect("sort field must resolve");
             assert_eq!(descriptor_column.column_name, schema_field.name);
             assert_eq!(
                 descriptor_column.primitive_type,
@@ -339,7 +379,7 @@ mod tests {
 
         match err {
             IngestError::Iceberg(err) => {
-                assert!(err.to_string().contains("unsupported logs merge sort transform"));
+                assert!(err.to_string().contains("unsupported merge sort transform"));
             }
             other => panic!("unexpected error variant: {other}"),
         }

--- a/crates/icegate-ingest/src/wal/mod.rs
+++ b/crates/icegate-ingest/src/wal/mod.rs
@@ -15,5 +15,6 @@ pub(crate) use metadata::serialize_row_group_metadata;
 #[cfg(test)]
 pub(crate) use sorter::logs_row_group_boundary_range_from_batch;
 pub(crate) use sorter::sort_logs;
+pub(crate) use sorter::sort_spans;
 pub(crate) use writer::WalAckOutcome;
-pub(crate) use writer::submit_sorted_logs_to_wal;
+pub(crate) use writer::submit_sorted_rows_to_wal;

--- a/crates/icegate-ingest/src/wal/sorter.rs
+++ b/crates/icegate-ingest/src/wal/sorter.rs
@@ -5,7 +5,7 @@ use arrow::{
     compute::take,
     record_batch::RecordBatch,
 };
-use icegate_common::LOGS_TOPIC;
+use icegate_common::{LOGS_TOPIC, SPANS_TOPIC};
 use icegate_queue::{PreparedWalRowGroup, WriteRequest};
 
 use super::{
@@ -25,9 +25,12 @@ impl WalSorter {
         Self { row_group_size }
     }
 
-    /// Sort logs for WAL so that each output batch contains exactly one tenant.
-    fn sort_logs(&self, batch: &RecordBatch) -> Result<Vec<PreparedWalRowGroup>> {
-        // TODO(high): make a generic solution without binding to logs. Need to parameterize SortColumnsDescriptor.
+    /// Sort a batch for WAL so that each output batch contains exactly one tenant.
+    fn sort(
+        &self,
+        descriptor: &'static SortColumnsDescriptor,
+        batch: &RecordBatch,
+    ) -> Result<Vec<PreparedWalRowGroup>> {
         struct TenantGroup {
             row_indices: Vec<usize>,
         }
@@ -44,13 +47,13 @@ impl WalSorter {
         let tenant_idx = batch
             .schema()
             .index_of("tenant_id")
-            .map_err(|err| IngestError::Shift(format!("logs batch is missing tenant_id: {err}")))?;
+            .map_err(|err| IngestError::Shift(format!("batch is missing tenant_id: {err}")))?;
         let tenant_id_column = batch
             .column(tenant_idx)
             .as_any()
             .downcast_ref::<StringArray>()
             .ok_or_else(|| IngestError::Shift("tenant_id must be Utf8 for WAL sorting".to_string()))?;
-        let sort_columns = SortColumnCache::try_new(batch, SortColumnsDescriptor::logs()?, "WAL sorting")?;
+        let sort_columns = SortColumnCache::try_new(batch, descriptor, "WAL sorting")?;
 
         let mut tenant_groups = Vec::new();
         let mut tenant_group_idx_by_id = HashMap::new();
@@ -110,13 +113,44 @@ impl WalSorter {
     }
 }
 
-/// Prepare WAL batches for one ingest request.
+/// Prepare WAL batches for one logs ingest request.
 pub(crate) fn sort_logs(
     batch: &RecordBatch,
     row_group_size: usize,
     trace_context: Option<String>,
 ) -> Result<Option<PreparedWalWrite>> {
-    let row_groups = WalSorter::new(row_group_size).sort_logs(batch)?;
+    prepare(
+        SortColumnsDescriptor::logs()?,
+        LOGS_TOPIC,
+        batch,
+        row_group_size,
+        trace_context,
+    )
+}
+
+/// Prepare WAL batches for one spans ingest request.
+pub(crate) fn sort_spans(
+    batch: &RecordBatch,
+    row_group_size: usize,
+    trace_context: Option<String>,
+) -> Result<Option<PreparedWalWrite>> {
+    prepare(
+        SortColumnsDescriptor::spans()?,
+        SPANS_TOPIC,
+        batch,
+        row_group_size,
+        trace_context,
+    )
+}
+
+fn prepare(
+    descriptor: &'static SortColumnsDescriptor,
+    topic: &'static str,
+    batch: &RecordBatch,
+    row_group_size: usize,
+    trace_context: Option<String>,
+) -> Result<Option<PreparedWalWrite>> {
+    let row_groups = WalSorter::new(row_group_size).sort(descriptor, batch)?;
     if row_groups.is_empty() {
         return Ok(None);
     }
@@ -125,7 +159,7 @@ pub(crate) fn sort_logs(
     let (response_tx, response_rx) = tokio::sync::oneshot::channel();
     Ok(Some(PreparedWalWrite {
         write_request: WriteRequest {
-            topic: LOGS_TOPIC.to_string(),
+            topic: topic.to_string(),
             row_groups,
             response_tx,
             trace_context,
@@ -174,12 +208,17 @@ mod tests {
     };
     use icegate_queue::{WriteResult, channel};
 
-    use super::{WalSorter, logs_row_group_boundary_range_from_batch, sort_logs};
+    use super::{WalSorter, logs_row_group_boundary_range_from_batch, sort_logs, sort_spans};
     use crate::error::IngestError;
     use crate::wal::{
-        RowGroupBoundaryComponent, RowGroupBoundaryKey, RowGroupBoundaryRange, RowGroupBoundaryValue, WalAckOutcome,
-        deserialize_row_group_metadata, serialize_row_group_metadata, submit_sorted_logs_to_wal,
+        RowGroupBoundaryComponent, RowGroupBoundaryKey, RowGroupBoundaryRange, RowGroupBoundaryValue,
+        SortColumnsDescriptor, WalAckOutcome, deserialize_row_group_metadata, serialize_row_group_metadata,
+        submit_sorted_rows_to_wal,
     };
+
+    fn logs_descriptor() -> &'static SortColumnsDescriptor {
+        SortColumnsDescriptor::logs().expect("logs descriptor")
+    }
 
     fn logs_batch() -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
@@ -279,7 +318,7 @@ mod tests {
 
     #[test]
     fn pre_wal_sorter_splits_mixed_tenants_into_homogeneous_batches() {
-        let batches = WalSorter::new(2).sort_logs(&logs_batch()).expect("sort logs");
+        let batches = WalSorter::new(2).sort(logs_descriptor(), &logs_batch()).expect("sort logs");
 
         assert_eq!(batches.len(), 3);
         assert_eq!(
@@ -295,7 +334,7 @@ mod tests {
 
     #[test]
     fn pre_wal_sorter_keeps_logs_sort_order_inside_tenant() {
-        let batches = WalSorter::new(8).sort_logs(&logs_batch()).expect("sort logs");
+        let batches = WalSorter::new(8).sort(logs_descriptor(), &logs_batch()).expect("sort logs");
         let tenant_a = &batches[1].batch;
 
         assert_eq!(
@@ -316,7 +355,7 @@ mod tests {
 
     #[test]
     fn pre_wal_sorter_outputs_single_tenant_per_batch() {
-        let batches = WalSorter::new(1).sort_logs(&logs_batch()).expect("sort logs");
+        let batches = WalSorter::new(1).sort(logs_descriptor(), &logs_batch()).expect("sort logs");
 
         for batch in batches {
             let tenant_ids = tenant_values(&batch.batch);
@@ -326,7 +365,7 @@ mod tests {
 
     #[test]
     fn pre_wal_sorter_preserves_input_tenant_order() {
-        let batches = WalSorter::new(2).sort_logs(&logs_batch()).expect("sort logs");
+        let batches = WalSorter::new(2).sort(logs_descriptor(), &logs_batch()).expect("sort logs");
 
         let tenant_heads = batches
             .iter()
@@ -359,7 +398,7 @@ mod tests {
         )
         .expect("logs batch");
 
-        let batches = WalSorter::new(8).sort_logs(&batch).expect("sort logs");
+        let batches = WalSorter::new(8).sort(logs_descriptor(), &batch).expect("sort logs");
 
         assert_eq!(batches.len(), 1);
         assert_eq!(row_ids(&batches[0].batch), vec![11, 12, 13]);
@@ -367,7 +406,7 @@ mod tests {
 
     #[test]
     fn pre_wal_sorter_keeps_order_across_multiple_row_groups_for_same_tenant() {
-        let batches = WalSorter::new(2).sort_logs(&logs_batch()).expect("sort logs");
+        let batches = WalSorter::new(2).sort(logs_descriptor(), &logs_batch()).expect("sort logs");
 
         assert_eq!(row_ids(&batches[1].batch), vec![4, 2]);
         assert_eq!(row_ids(&batches[2].batch), vec![1]);
@@ -375,7 +414,7 @@ mod tests {
 
     #[test]
     fn pre_wal_sorter_metadata_matches_final_row_group_edges() {
-        let batches = WalSorter::new(2).sort_logs(&logs_batch()).expect("sort logs");
+        let batches = WalSorter::new(2).sort(logs_descriptor(), &logs_batch()).expect("sort logs");
 
         let ranges = batches
             .iter()
@@ -592,7 +631,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_sorted_logs_to_wal_sends_one_logical_request() {
+    async fn submit_sorted_rows_to_wal_sends_one_logical_request() {
         let batch = logs_batch();
         let (tx, mut rx) = channel(1);
 
@@ -615,7 +654,7 @@ mod tests {
         let prepared = sort_logs(&batch, 4, Some("trace-request".to_string()))
             .expect("prepare wal write")
             .expect("prepared wal write");
-        let pending = submit_sorted_logs_to_wal(&tx, prepared).await.expect("submit wal write");
+        let pending = submit_sorted_rows_to_wal(&tx, prepared).await.expect("submit wal write");
         let summary = match pending.wait_for_ack().await.expect("wait for wal ack") {
             WalAckOutcome::Success(summary) => summary,
             WalAckOutcome::Partial(_) => panic!("unexpected partial wal write"),
@@ -646,7 +685,7 @@ mod tests {
         let prepared = sort_logs(&batch, 4, Some("trace-request".to_string()))
             .expect("prepare wal write")
             .expect("prepared wal write");
-        let pending = submit_sorted_logs_to_wal(&tx, prepared).await.expect("submit wal write");
+        let pending = submit_sorted_rows_to_wal(&tx, prepared).await.expect("submit wal write");
         let outcome = pending.wait_for_ack().await.expect("wait for wal ack");
         writer.await.expect("writer task");
 
@@ -658,5 +697,142 @@ mod tests {
                 assert_eq!(partial.trace_context.as_deref(), Some("trace-ack"));
             }
         }
+    }
+
+    #[test]
+    fn sort_logs_regression_for_fixed_input() {
+        // Fixed input. Do not mutate once this test is green; it is the contract
+        // that the pipeline-generalization refactor must preserve.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("tenant_id", DataType::Utf8, false),
+            Field::new("cloud_account_id", DataType::Utf8, true),
+            Field::new("service_name", DataType::Utf8, true),
+            Field::new("timestamp", DataType::Timestamp(TimeUnit::Microsecond, None), true),
+            Field::new("row_id", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["tenant-a", "tenant-b", "tenant-a", "tenant-a"])) as ArrayRef,
+                Arc::new(StringArray::from(vec![
+                    Some("acc-1"),
+                    Some("acc-9"),
+                    Some("acc-2"),
+                    Some("acc-1"),
+                ])) as ArrayRef,
+                Arc::new(StringArray::from(vec![
+                    Some("svc-x"),
+                    Some("svc-q"),
+                    Some("svc-y"),
+                    Some("svc-x"),
+                ])) as ArrayRef,
+                Arc::new(TimestampMicrosecondArray::from(vec![
+                    Some(100),
+                    Some(200),
+                    Some(50),
+                    Some(75),
+                ])) as ArrayRef,
+                Arc::new(Int64Array::from(vec![1, 2, 3, 4])) as ArrayRef,
+            ],
+        )
+        .expect("regression batch");
+
+        let prepared = sort_logs(&batch, 8, None)
+            .expect("prepare wal write")
+            .expect("prepared wal write");
+
+        assert_eq!(prepared.write_request.topic, icegate_common::LOGS_TOPIC);
+        assert_eq!(prepared.write_request.row_groups.len(), 2);
+        assert_eq!(prepared.records, 4);
+
+        // Tenant-a group: 3 rows, sorted by (cloud_account_id asc, service_name asc, timestamp desc).
+        let rg0 = &prepared.write_request.row_groups[0];
+        assert_eq!(rg0.batch.num_rows(), 3);
+        let row_ids_rg0: Vec<i64> = (0..rg0.batch.num_rows())
+            .map(|i| {
+                rg0.batch
+                    .column(4)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("row_id")
+                    .value(i)
+            })
+            .collect();
+        assert_eq!(row_ids_rg0, vec![1, 4, 3]); // acc-1/svc-x/ts=100, acc-1/svc-x/ts=75, acc-2/svc-y/ts=50
+
+        // Tenant-b group: 1 row.
+        let rg1 = &prepared.write_request.row_groups[1];
+        assert_eq!(rg1.batch.num_rows(), 1);
+        let row_ids_rg1: Vec<i64> = (0..rg1.batch.num_rows())
+            .map(|i| {
+                rg1.batch
+                    .column(4)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("row_id")
+                    .value(i)
+            })
+            .collect();
+        assert_eq!(row_ids_rg1, vec![2]);
+
+        // Boundary metadata is non-empty JSON for every row group.
+        for rg in &prepared.write_request.row_groups {
+            let metadata = rg.metadata.as_deref().expect("metadata");
+            assert!(metadata.starts_with('{'));
+            assert!(metadata.contains("\"min_key\""));
+            assert!(metadata.contains("\"max_key\""));
+        }
+    }
+
+    #[test]
+    fn sort_spans_produces_spans_topic_and_tenant_homogeneous_groups() {
+        // Build a minimal batch with only the fields the spans sort descriptor cares about:
+        // tenant_id, cloud_account_id, service_name, trace_id, timestamp.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("tenant_id", DataType::Utf8, false),
+            Field::new("cloud_account_id", DataType::Utf8, true),
+            Field::new("service_name", DataType::Utf8, true),
+            Field::new("trace_id", DataType::Utf8, false),
+            Field::new("timestamp", DataType::Timestamp(TimeUnit::Microsecond, None), true),
+            Field::new("row_id", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["tenant-b", "tenant-a", "tenant-a"])) as ArrayRef,
+                Arc::new(StringArray::from(vec![Some("acc-2"), Some("acc-1"), Some("acc-1")])) as ArrayRef,
+                Arc::new(StringArray::from(vec![Some("svc-2"), Some("svc-1"), Some("svc-1")])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["trace-b", "trace-a2", "trace-a1"])) as ArrayRef,
+                Arc::new(TimestampMicrosecondArray::from(vec![Some(30), Some(10), Some(20)])) as ArrayRef,
+                Arc::new(Int64Array::from(vec![1, 2, 3])) as ArrayRef,
+            ],
+        )
+        .expect("spans batch");
+
+        let prepared = sort_spans(&batch, 8, None)
+            .expect("prepare wal write")
+            .expect("prepared wal write");
+
+        assert_eq!(prepared.write_request.topic, icegate_common::SPANS_TOPIC);
+        assert_eq!(prepared.write_request.row_groups.len(), 2);
+        // Tenant-a group sorted by (cloud_account_id asc, service_name asc, trace_id asc, timestamp desc).
+        // Both rows share acc-1/svc-1, so sort by trace_id asc: row_id 3 (trace-a1), row_id 2 (trace-a2).
+        let rg_a = prepared
+            .write_request
+            .row_groups
+            .iter()
+            .find(|rg| rg.batch.num_rows() == 2)
+            .expect("tenant-a group");
+        let row_ids: Vec<i64> = (0..rg_a.batch.num_rows())
+            .map(|i| {
+                rg_a.batch
+                    .column(5)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("row_id")
+                    .value(i)
+            })
+            .collect();
+        assert_eq!(row_ids, vec![3, 2]);
     }
 }

--- a/crates/icegate-ingest/src/wal/writer.rs
+++ b/crates/icegate-ingest/src/wal/writer.rs
@@ -44,8 +44,8 @@ pub(crate) struct PendingWalWrite {
     records: usize,
 }
 
-/// Submit a prepared WAL request into the queue.
-pub(crate) async fn submit_sorted_logs_to_wal(
+/// Submit a prepared WAL request (logs or spans) into the queue.
+pub(crate) async fn submit_sorted_rows_to_wal(
     write_channel: &WriteChannel,
     prepared: PreparedWalWrite,
 ) -> Result<PendingWalWrite> {

--- a/crates/icegate-maintain/src/error.rs
+++ b/crates/icegate-maintain/src/error.rs
@@ -19,6 +19,10 @@ pub enum MaintainError {
     /// Schema construction error.
     #[error("{0}")]
     Schema(#[from] SchemaError),
+
+    /// Migration requires operator intervention (e.g. manual table drop).
+    #[error("migration requires manual intervention: {0}")]
+    Migration(String),
 }
 
 impl From<icegate_common::error::CommonError> for MaintainError {

--- a/crates/icegate-maintain/src/migrate/operations.rs
+++ b/crates/icegate-maintain/src/migrate/operations.rs
@@ -218,6 +218,9 @@ pub async fn upgrade_schemas(catalog: &Arc<dyn Catalog>, dry_run: bool) -> Resul
     let namespace = NamespaceIdent::new(ICEGATE_NAMESPACE.to_string());
     let definitions = build_table_definitions()?;
     let mut operations = Vec::new();
+    // Collect every mismatched table instead of bailing on the first one so
+    // operators see the full remediation list in a single run.
+    let mut differing_tables: Vec<String> = Vec::new();
 
     for def in definitions {
         let table_ident = TableIdent::new(namespace.clone(), def.name.to_string());
@@ -243,32 +246,38 @@ pub async fn upgrade_schemas(catalog: &Arc<dyn Catalog>, dry_run: bool) -> Resul
         let needs_upgrade = schemas_differ(current_schema, target_schema);
 
         if needs_upgrade {
+            log_schema_differences(def.name, current_schema, target_schema);
             if dry_run {
                 tracing::info!("[dry-run] Would require manual migration for table: {}", def.name);
-                log_schema_differences(def.name, current_schema, target_schema);
                 operations.push(MigrationOperation::Upgrade {
                     table_name: def.name.to_string(),
                 });
             } else {
-                log_schema_differences(def.name, current_schema, target_schema);
-                return Err(crate::error::MaintainError::Migration(format_upgrade_required_message(
-                    def.name,
-                )));
+                differing_tables.push(def.name.to_string());
             }
         } else {
             tracing::info!("Table {} schema is up to date", def.name);
         }
     }
 
+    if !dry_run && !differing_tables.is_empty() {
+        return Err(crate::error::MaintainError::Migration(
+            format_upgrade_required_message_multi(&differing_tables),
+        ));
+    }
+
     Ok(operations)
 }
 
-/// Build the operator-facing error message when a table schema in the
-/// catalog differs from the code and automatic evolution is not supported.
-fn format_upgrade_required_message(table_name: &str) -> String {
+/// Build the operator-facing error message when a set of tables' schemas in
+/// the catalog differ from the code and automatic evolution is not supported.
+/// Accepts one or more table names and joins them into a single actionable
+/// message so the operator can see the full remediation list in one run.
+fn format_upgrade_required_message_multi(table_names: &[String]) -> String {
+    let list = table_names.join(", ");
     format!(
-        "Table `{table_name}` schema in catalog differs from code. Automatic evolution \
-         is not supported; drop the table manually and re-run `icegate-maintain migrate create`."
+        "Tables [{list}] schema in catalog differs from code. Automatic evolution \
+         is not supported; drop the tables manually and re-run `icegate-maintain migrate create`."
     )
 }
 
@@ -393,11 +402,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn format_upgrade_error_message_names_table_and_recovery() {
-        let msg = format_upgrade_required_message("spans");
+    fn format_upgrade_error_message_names_single_table_and_recovery() {
+        let msg = format_upgrade_required_message_multi(&["spans".to_string()]);
         assert!(msg.contains("spans"));
-        assert!(msg.contains("drop the table manually"));
+        assert!(msg.contains("drop the tables manually"));
         assert!(msg.contains("icegate-maintain migrate create"));
+    }
+
+    #[test]
+    fn format_upgrade_error_message_lists_all_differing_tables() {
+        let msg = format_upgrade_required_message_multi(&["logs".to_string(), "spans".to_string()]);
+        assert!(msg.contains("logs"));
+        assert!(msg.contains("spans"));
+        assert!(msg.contains("drop the tables manually"));
     }
 
     #[test]

--- a/crates/icegate-maintain/src/migrate/operations.rs
+++ b/crates/icegate-maintain/src/migrate/operations.rs
@@ -184,34 +184,37 @@ async fn create_table(catalog: &dyn Catalog, namespace: &NamespaceIdent, def: &T
     Ok(())
 }
 
-/// Upgrade existing table schemas
+/// Report schema differences between the catalog and the code.
 ///
-/// Checks each observability table for schema differences and applies
-/// necessary evolution operations.
+/// Checks each observability table for schema differences. **Automatic
+/// evolution is not performed.** When a difference is detected, operators
+/// must drop and re-create the affected table(s) to apply the code's
+/// schema; no in-place schema evolution is attempted.
 ///
-/// # Schema Evolution Support
+/// # Behavior
 ///
-/// Currently supports:
-/// - Adding new optional columns
-/// - Updating partition specs
-/// - Updating sort orders
-///
-/// Does NOT support (requires manual intervention):
-/// - Removing columns
-/// - Changing column types to incompatible types
-/// - Changing required columns to optional or vice versa
+/// - **Dry-run mode**: logs differences for every mismatched table and
+///   returns `Ok(operations)` containing one `MigrationOperation::Upgrade`
+///   entry per mismatch so the operator can preview the full list.
+/// - **Non-dry-run mode**: logs differences for every mismatched table
+///   discovered during the scan, then returns
+///   `Err(MaintainError::Migration)` with an aggregated message naming
+///   all tables that must be dropped and re-created. Tables that match the
+///   code's schema pass silently; missing tables log a warning and are
+///   skipped (operator must run `migrate create` first).
 ///
 /// # Return Value
 ///
-/// Returns a list of operations. In dry-run mode, operations represent what
-/// *would* happen, not what actually occurred.
+/// `Ok(Vec<MigrationOperation>)` only in dry-run mode (or when every
+/// table is up to date). Non-dry-run with at least one mismatch always
+/// returns `Err(MaintainError::Migration(..))`.
 ///
 /// # Errors
 ///
 /// Returns an error if:
-/// - Table loading fails
-/// - Schema comparison fails
-/// - Schema evolution fails
+/// - The catalog rejects a `table_exists` or `load_table` call.
+/// - One or more tables have schemas that differ from the code and we're
+///   not in dry-run mode (see `MaintainError::Migration`).
 #[allow(clippy::cognitive_complexity)]
 pub async fn upgrade_schemas(catalog: &Arc<dyn Catalog>, dry_run: bool) -> Result<Vec<MigrationOperation>> {
     let catalog_ref = catalog.as_ref();
@@ -261,23 +264,29 @@ pub async fn upgrade_schemas(catalog: &Arc<dyn Catalog>, dry_run: bool) -> Resul
     }
 
     if !dry_run && !differing_tables.is_empty() {
-        return Err(crate::error::MaintainError::Migration(
-            format_upgrade_required_message_multi(&differing_tables),
-        ));
+        return Err(crate::error::MaintainError::Migration(format_upgrade_required_message(
+            &differing_tables,
+        )));
     }
 
     Ok(operations)
 }
 
-/// Build the operator-facing error message when a set of tables' schemas in
-/// the catalog differ from the code and automatic evolution is not supported.
-/// Accepts one or more table names and joins them into a single actionable
-/// message so the operator can see the full remediation list in one run.
-fn format_upgrade_required_message_multi(table_names: &[String]) -> String {
+/// Build the operator-facing error message when one or more tables' schemas
+/// in the catalog differ from the code and automatic evolution is not
+/// supported. Accepts one or more table names, uses singular/plural wording
+/// based on the count, and joins names with `, ` for the bracketed list so
+/// the operator sees the full remediation list in one run.
+fn format_upgrade_required_message(table_names: &[String]) -> String {
+    let (subject, remediation) = if table_names.len() == 1 {
+        ("Table", "the table")
+    } else {
+        ("Tables", "the tables")
+    };
     let list = table_names.join(", ");
     format!(
-        "Tables [{list}] schema in catalog differs from code. Automatic evolution \
-         is not supported; drop the tables manually and re-run `icegate-maintain migrate create`."
+        "{subject} [{list}] schema in catalog differs from code. Automatic evolution \
+         is not supported; drop {remediation} manually and re-run `icegate-maintain migrate create`."
     )
 }
 
@@ -402,16 +411,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn format_upgrade_error_message_names_single_table_and_recovery() {
-        let msg = format_upgrade_required_message_multi(&["spans".to_string()]);
+    fn format_upgrade_error_message_single_table_uses_singular_wording() {
+        let msg = format_upgrade_required_message(&["spans".to_string()]);
+        assert!(msg.starts_with("Table ["));
         assert!(msg.contains("spans"));
-        assert!(msg.contains("drop the tables manually"));
+        assert!(msg.contains("drop the table manually"));
         assert!(msg.contains("icegate-maintain migrate create"));
     }
 
     #[test]
-    fn format_upgrade_error_message_lists_all_differing_tables() {
-        let msg = format_upgrade_required_message_multi(&["logs".to_string(), "spans".to_string()]);
+    fn format_upgrade_error_message_multiple_tables_uses_plural_wording() {
+        let msg = format_upgrade_required_message(&["logs".to_string(), "spans".to_string()]);
+        assert!(msg.starts_with("Tables ["));
         assert!(msg.contains("logs"));
         assert!(msg.contains("spans"));
         assert!(msg.contains("drop the tables manually"));

--- a/crates/icegate-maintain/src/migrate/operations.rs
+++ b/crates/icegate-maintain/src/migrate/operations.rs
@@ -244,28 +244,32 @@ pub async fn upgrade_schemas(catalog: &Arc<dyn Catalog>, dry_run: bool) -> Resul
 
         if needs_upgrade {
             if dry_run {
-                tracing::info!("[dry-run] Would upgrade table schema: {}", def.name);
+                tracing::info!("[dry-run] Would require manual migration for table: {}", def.name);
                 log_schema_differences(def.name, current_schema, target_schema);
+                operations.push(MigrationOperation::Upgrade {
+                    table_name: def.name.to_string(),
+                });
             } else {
-                tracing::info!("Upgrading table schema: {}", def.name);
-                // Note: Full schema evolution would require iceberg's update_schema API
-                // For now, we log what would need to change
                 log_schema_differences(def.name, current_schema, target_schema);
-                tracing::warn!(
-                    "Automatic schema evolution not yet implemented. Please update {} manually.",
-                    def.name
-                );
+                return Err(crate::error::MaintainError::Migration(format_upgrade_required_message(
+                    def.name,
+                )));
             }
-
-            operations.push(MigrationOperation::Upgrade {
-                table_name: def.name.to_string(),
-            });
         } else {
             tracing::info!("Table {} schema is up to date", def.name);
         }
     }
 
     Ok(operations)
+}
+
+/// Build the operator-facing error message when a table schema in the
+/// catalog differs from the code and automatic evolution is not supported.
+fn format_upgrade_required_message(table_name: &str) -> String {
+    format!(
+        "Table `{table_name}` schema in catalog differs from code. Automatic evolution \
+         is not supported; drop the table manually and re-run `icegate-maintain migrate create`."
+    )
 }
 
 /// Check if two schemas differ
@@ -381,5 +385,57 @@ fn log_schema_differences(table_name: &str, current: &iceberg::spec::Schema, tar
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_upgrade_error_message_names_table_and_recovery() {
+        let msg = format_upgrade_required_message("spans");
+        assert!(msg.contains("spans"));
+        assert!(msg.contains("drop the table manually"));
+        assert!(msg.contains("icegate-maintain migrate create"));
+    }
+
+    #[test]
+    fn schemas_differ_detects_modified_nested_types() {
+        use std::sync::Arc;
+
+        use iceberg::spec::{MapType, NestedField, PrimitiveType, Type};
+
+        let current = iceberg::spec::Schema::builder()
+            .with_schema_id(1)
+            .with_fields(vec![
+                NestedField::required(1, "tenant_id", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(
+                    2,
+                    "attributes",
+                    Type::Map(MapType::new(
+                        Arc::new(NestedField::required(3, "key", Type::Primitive(PrimitiveType::String))),
+                        Arc::new(NestedField::required(
+                            4,
+                            "value",
+                            Type::Primitive(PrimitiveType::String),
+                        )),
+                    )),
+                )
+                .into(),
+            ])
+            .build()
+            .expect("current schema");
+
+        let target = iceberg::spec::Schema::builder()
+            .with_schema_id(2)
+            .with_fields(vec![
+                NestedField::required(1, "tenant_id", Type::Primitive(PrimitiveType::String)).into(),
+                NestedField::required(2, "attributes", Type::Primitive(PrimitiveType::String)).into(),
+            ])
+            .build()
+            .expect("target schema");
+
+        assert!(schemas_differ(&current, &target));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OTLP traces ingestion enabled over gRPC and HTTP with partial-success reporting for rejected spans; traces and logs now use a unified row-based submission path.
  * Trino coordinator added to the development overlay with Iceberg catalog and in-cluster S3 access.

* **Infrastructure Updates**
  * otel-collector service and ports added; overlays and component endpoints updated to target the new collector.
  * Sorting, WAL, and schema support extended to handle spans alongside logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->