### PR TITLE
(fix) Improve `trace_id` validation and decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=03956eeae771991ebcb2ab3731b76bced0c640ca#03956eeae771991ebcb2ab3731b76bced0c640ca"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=27af5bd6d213dd775c99b36bf48dd4380e48c0bf#27af5bd6d213dd775c99b36bf48dd4380e48c0bf"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=03956eeae771991ebcb2ab3731b76bced0c640ca#03956eeae771991ebcb2ab3731b76bced0c640ca"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=27af5bd6d213dd775c99b36bf48dd4380e48c0bf#27af5bd6d213dd775c99b36bf48dd4380e48c0bf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=03956eeae771991ebcb2ab3731b76bced0c640ca#03956eeae771991ebcb2ab3731b76bced0c640ca"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=27af5bd6d213dd775c99b36bf48dd4380e48c0bf#27af5bd6d213dd775c99b36bf48dd4380e48c0bf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-s3tables"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=03956eeae771991ebcb2ab3731b76bced0c640ca#03956eeae771991ebcb2ab3731b76bced0c640ca"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=27af5bd6d213dd775c99b36bf48dd4380e48c0bf#27af5bd6d213dd775c99b36bf48dd4380e48c0bf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3915,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=03956eeae771991ebcb2ab3731b76bced0c640ca#03956eeae771991ebcb2ab3731b76bced0c640ca"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=27af5bd6d213dd775c99b36bf48dd4380e48c0bf#27af5bd6d213dd775c99b36bf48dd4380e48c0bf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=03956eeae771991ebcb2ab3731b76bced0c640ca#03956eeae771991ebcb2ab3731b76bced0c640ca"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=27af5bd6d213dd775c99b36bf48dd4380e48c0bf#27af5bd6d213dd775c99b36bf48dd4380e48c0bf"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,11 +82,11 @@ antlr4rust = "0.5"
 # transaction action that compaction commits through a generic `dyn Catalog`).
 # Pinned to an immutable rev (not a branch) for reproducible builds; bump the SHA
 # deliberately when adopting fork updates rather than letting `develop` float.
-iceberg = { git = "https://github.com/icegatetech/iceberg-rust", rev = "03956eeae771991ebcb2ab3731b76bced0c640ca" }
-iceberg-catalog-rest = { git = "https://github.com/icegatetech/iceberg-rust", rev = "03956eeae771991ebcb2ab3731b76bced0c640ca" }
-iceberg-catalog-s3tables = { git = "https://github.com/icegatetech/iceberg-rust", rev = "03956eeae771991ebcb2ab3731b76bced0c640ca" }
-iceberg-catalog-glue = { git = "https://github.com/icegatetech/iceberg-rust", rev = "03956eeae771991ebcb2ab3731b76bced0c640ca" }
-iceberg-datafusion = { git = "https://github.com/icegatetech/iceberg-rust", rev = "03956eeae771991ebcb2ab3731b76bced0c640ca" }
+iceberg = { git = "https://github.com/icegatetech/iceberg-rust", rev = "27af5bd6d213dd775c99b36bf48dd4380e48c0bf" }
+iceberg-catalog-rest = { git = "https://github.com/icegatetech/iceberg-rust", rev = "27af5bd6d213dd775c99b36bf48dd4380e48c0bf" }
+iceberg-catalog-s3tables = { git = "https://github.com/icegatetech/iceberg-rust", rev = "27af5bd6d213dd775c99b36bf48dd4380e48c0bf" }
+iceberg-catalog-glue = { git = "https://github.com/icegatetech/iceberg-rust", rev = "27af5bd6d213dd775c99b36bf48dd4380e48c0bf" }
+iceberg-datafusion = { git = "https://github.com/icegatetech/iceberg-rust", rev = "27af5bd6d213dd775c99b36bf48dd4380e48c0bf" }
 
 # DataFusion
 datafusion = "52.2"

--- a/crates/icegate-query/src/engine/provider/expr_to_predicate.rs
+++ b/crates/icegate-query/src/engine/provider/expr_to_predicate.rs
@@ -281,6 +281,13 @@ fn scalar_value_to_datum(value: &ScalarValue) -> Option<Datum> {
         ScalarValue::Float64(Some(v)) => Some(Datum::double(*v)),
         ScalarValue::Utf8(Some(v)) | ScalarValue::LargeUtf8(Some(v)) => Some(Datum::string(v.clone())),
         ScalarValue::Binary(Some(v)) | ScalarValue::LargeBinary(Some(v)) => Some(Datum::binary(v.clone())),
+        // Fixed-width binary columns (e.g. `trace_id` Fixed(16), `span_id`
+        // Fixed(8)). Map to a Fixed-typed `Datum`, NOT `Datum::binary`: the
+        // column's stored min/max bounds are `Fixed(N)`, and Iceberg's `Datum`
+        // ordering only compares Fixed-vs-Fixed. A `Binary` literal would be
+        // incomparable against those bounds, silently disabling metrics
+        // pruning and forcing a full scan.
+        ScalarValue::FixedSizeBinary(_, Some(v)) => Some(Datum::fixed(v.iter().copied())),
         ScalarValue::Date32(Some(v)) => Some(Datum::date(*v)),
         #[allow(clippy::cast_possible_truncation)]
         ScalarValue::Date64(Some(v)) => Some(Datum::date((*v / MILLIS_PER_DAY) as i32)),
@@ -541,6 +548,33 @@ mod tests {
             .equal_to(Datum::long(1))
             .and(Reference::new("bar").equal_to(Datum::binary(vec![1u8, 2u8])));
         assert_eq!(predicate, expected_predicate);
+    }
+
+    #[test]
+    fn test_predicate_conversion_with_fixed_size_binary() {
+        use datafusion::prelude::{col, lit};
+        use datafusion::scalar::ScalarValue;
+
+        // `trace_id`/`span_id` are Iceberg Fixed(N) columns; the Tempo
+        // trace-by-id path builds the literal as ScalarValue::FixedSizeBinary.
+        // It must push down as a Fixed-typed Datum so it stays comparable
+        // against the column's Fixed bounds during metrics pruning.
+        let id = vec![0xEEu8; 16];
+        let expr = col("trace_id").eq(lit(ScalarValue::FixedSizeBinary(16, Some(id.clone()))));
+        let predicate = convert_filters_to_predicate(std::slice::from_ref(&expr)).unwrap();
+        assert_eq!(predicate, Reference::new("trace_id").equal_to(Datum::fixed(id)));
+    }
+
+    #[test]
+    fn test_scalar_value_to_datum_fixed_size_binary() {
+        use datafusion::common::ScalarValue;
+
+        let bytes = vec![1u8, 2u8, 3u8, 4u8];
+        let datum = super::scalar_value_to_datum(&ScalarValue::FixedSizeBinary(4, Some(bytes.clone())));
+        assert_eq!(datum, Some(Datum::fixed(bytes)));
+
+        let datum = super::scalar_value_to_datum(&ScalarValue::FixedSizeBinary(4, None));
+        assert_eq!(datum, None);
     }
 
     #[test]

--- a/crates/icegate-query/src/tempo/handlers.rs
+++ b/crates/icegate-query/src/tempo/handlers.rs
@@ -148,6 +148,7 @@ pub async fn get_trace(
     let (default_start, default_end) = default_window(now);
     let start = params.start.map(parse_epoch_seconds).transpose()?.unwrap_or(default_start);
     let end = params.end.map(parse_epoch_seconds).transpose()?.unwrap_or(default_end);
+    validation::validate_trace_id(&trace_id).map_err(TempoError::new)?;
     validation::validate_query_window(start, end).map_err(TempoError::new)?;
 
     let result = fetch(state.engine, &tenant_id, &trace_id, start, end).await?;

--- a/crates/icegate-query/src/tempo/trace_by_id.rs
+++ b/crates/icegate-query/src/tempo/trace_by_id.rs
@@ -52,7 +52,8 @@ pub struct FetchResult {
 ///
 /// # Errors
 ///
-/// Returns [`crate::error::QueryError`] for engine, planning, or
+/// Returns [`crate::error::QueryError::Validation`] if `trace_id` is not
+/// decodable hex, and [`crate::error::QueryError`] for engine, planning, or
 /// execution failures.
 pub async fn fetch(
     engine: Arc<QueryEngine>,
@@ -61,10 +62,13 @@ pub async fn fetch(
     start: DateTime<Utc>,
     end: DateTime<Utc>,
 ) -> TempoResult<FetchResult> {
-    // `trace_id` arrives from the URL as lowercase hex (32 chars). Decode to
-    // 16 raw bytes and compare against the typed FixedSizeBinary column;
-    // an invalid id yields no matches.
-    let trace_id_bytes = hex::decode(trace_id).unwrap_or_default();
+    // `trace_id` is validated upstream by `validation::validate_trace_id`
+    // (exactly 32 hex chars), so it decodes to exactly 16 raw bytes — the
+    // Fixed(16) column width that keeps the pushed-down literal comparable
+    // against the column's Fixed(16) bounds. Map any residual decode error to
+    // a validation error (HTTP 400) rather than panicking or returning a
+    // misleading empty trace.
+    let trace_id_bytes = hex::decode(trace_id).map_err(|e| QueryError::Validation(format!("invalid trace_id: {e}")))?;
     let trace_id_lit = lit(ScalarValue::FixedSizeBinary(16, Some(trace_id_bytes)));
 
     let session = engine.create_session().await?;

--- a/crates/icegate-query/src/tempo/validation.rs
+++ b/crates/icegate-query/src/tempo/validation.rs
@@ -123,6 +123,40 @@ pub fn validate_query_window(start: DateTime<Utc>, end: DateTime<Utc>) -> Result
     Ok(())
 }
 
+/// Length of a canonical `trace_id` path parameter, in hex characters.
+///
+/// `trace_id` is a W3C 16-byte trace identifier stored as Iceberg
+/// `Fixed(16)`, so its hex spelling is exactly 32 characters. IceGate does
+/// not accept the shorter 8-byte form that upstream Tempo left-pads, because
+/// no ingested span can carry one.
+pub const TRACE_ID_HEX_LEN: usize = 32;
+
+/// Validate the `trace_id` path parameter of `/api/traces/{trace_id}`.
+///
+/// The id must be exactly [`TRACE_ID_HEX_LEN`] ASCII hex characters. A
+/// malformed id is rejected with HTTP 400 rather than silently returning an
+/// empty trace, matching the Tempo protocol's bad-request contract for an
+/// unparseable trace id.
+///
+/// # Errors
+///
+/// Returns [`QueryError::Validation`] when the id is not [`TRACE_ID_HEX_LEN`]
+/// characters long or contains a non-hex character.
+pub fn validate_trace_id(trace_id: &str) -> Result<()> {
+    if trace_id.len() != TRACE_ID_HEX_LEN {
+        return Err(QueryError::Validation(format!(
+            "invalid trace_id: expected {TRACE_ID_HEX_LEN} hex characters, got {}",
+            trace_id.len(),
+        )));
+    }
+    if let Some(c) = trace_id.chars().find(|c| !c.is_ascii_hexdigit()) {
+        return Err(QueryError::Validation(format!(
+            "invalid trace_id: non-hex character '{c}'"
+        )));
+    }
+    Ok(())
+}
+
 /// Validate a `TraceQL` query string before parsing it.
 ///
 /// # Errors
@@ -236,6 +270,34 @@ mod tests {
         let e = s + MAX_QUERY_WINDOW + Duration::seconds(1);
         let err = validate_query_window(s, e).expect_err("oversized window must reject");
         assert!(matches!(err, QueryError::Validation(_)));
+    }
+
+    #[test]
+    fn trace_id_validator_accepts_canonical_id() {
+        assert!(validate_trace_id("ee2066e01950d8e51a55481d716dc265").is_ok());
+        // Upper-case hex is also valid (hex decode is case-insensitive).
+        assert!(validate_trace_id("EE2066E01950D8E51A55481D716DC265").is_ok());
+    }
+
+    #[test]
+    fn trace_id_validator_rejects_wrong_length() {
+        assert!(matches!(validate_trace_id(""), Err(QueryError::Validation(_))));
+        // 16 hex chars (8-byte form) is rejected — our spans are 16-byte ids.
+        assert!(matches!(
+            validate_trace_id("ee2066e01950d8e5"),
+            Err(QueryError::Validation(_))
+        ));
+        let too_long = "a".repeat(TRACE_ID_HEX_LEN + 1);
+        assert!(matches!(validate_trace_id(&too_long), Err(QueryError::Validation(_))));
+    }
+
+    #[test]
+    fn trace_id_validator_rejects_non_hex() {
+        // 32 chars but with a non-hex character.
+        assert!(matches!(
+            validate_trace_id("zz2066e01950d8e51a55481d716dc265"),
+            Err(QueryError::Validation(_))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
add upstream validation checks,
handle decode errors gracefully