### PR TITLE
add ready_to_next_iteration tests to job manager

### DIFF
--- a/crates/icegate-jobmanager/src/core/job.rs
+++ b/crates/icegate-jobmanager/src/core/job.rs
@@ -1179,6 +1179,64 @@ mod tests {
     }
 
     #[test]
+    fn test_is_ready_to_next_iteration_anchors_to_restored_started_at() {
+        // Simulates a process restart: the job is reloaded from storage carrying the
+        // started_at of the iteration that already completed. The next-iteration gate
+        // must anchor on that persisted started_at, not on the reload moment, so an
+        // interval that already elapsed before the restart becomes eligible immediately
+        // instead of waiting another full interval from restart time.
+        let task = make_task(Uuid::from_u128(370), "done", TaskStatus::Completed, Vec::new());
+        let started_at = Utc::now() - Duration::seconds(120);
+        let job = Job::restore(
+            Uuid::from_u128(371),
+            JobCode::new("job"),
+            String::new(),
+            1,
+            JobStatus::Completed,
+            vec![task],
+            Uuid::from_u128(372),
+            started_at,
+            None,
+            Some(started_at + Duration::seconds(2)),
+            None,
+            HashMap::new(),
+            None,
+            Some(Duration::seconds(60)),
+            TaskLimits::default(),
+        );
+
+        assert_eq!(job.started_at(), started_at);
+        assert!(job.is_ready_to_next_iteration());
+    }
+
+    #[test]
+    fn test_is_ready_to_next_iteration_waits_from_restored_started_at() {
+        // Counterpart of the restart anchor test: when the persisted started_at is recent,
+        // the gate stays closed for the remainder of the interval regardless of reload time.
+        let task = make_task(Uuid::from_u128(373), "done", TaskStatus::Completed, Vec::new());
+        let started_at = Utc::now() - Duration::seconds(5);
+        let job = Job::restore(
+            Uuid::from_u128(374),
+            JobCode::new("job"),
+            String::new(),
+            1,
+            JobStatus::Completed,
+            vec![task],
+            Uuid::from_u128(375),
+            started_at,
+            None,
+            Some(started_at + Duration::seconds(2)),
+            None,
+            HashMap::new(),
+            None,
+            Some(Duration::seconds(60)),
+            TaskLimits::default(),
+        );
+
+        assert!(!job.is_ready_to_next_iteration());
+    }
+
+    #[test]
     fn test_set_next_start_at_blocks_next_iteration_when_future() {
         let task = make_task(Uuid::from_u128(360), "done", TaskStatus::Completed, Vec::new());
         let mut job = restore_job(

--- a/crates/icegate-jobmanager/src/execution/worker.rs
+++ b/crates/icegate-jobmanager/src/execution/worker.rs
@@ -259,11 +259,25 @@ impl Worker {
             worker_id = %self.id,
             job_code = %job.code(),
             job_id = %job.id(),
+            job_start_at = %job.started_at(),
             iter = job.iter_num()
         )
     )]
     async fn try_process_job(&self, mut job: Job, cancel_token: &CancellationToken) -> bool {
-        if job.is_ready_to_next_iteration() {
+        // The next-iteration gate anchors on the persisted started_at of the current
+        // iteration, which survives process restarts. Log the inputs so a restart that
+        // appears to "shift" the schedule can be traced back to the actual anchor.
+        let ready_for_next = job.is_ready_to_next_iteration();
+        debug!(
+            status = %job.status(),
+            started_at = %job.started_at(),
+            completed_at = ?job.completed_at(),
+            next_start_at = ?job.next_start_at(),
+            ready_for_next,
+            "Evaluating job scheduling on pickup"
+        );
+
+        if ready_for_next {
             job = match self.start_new_job_iteration(job, cancel_token).await {
                 Ok(job) => job,
                 Err(InternalError::Cancelled) => {
@@ -278,9 +292,19 @@ impl Worker {
         } else if job.is_processed() && job.is_iteration_limit_reached() {
             self.update_cache(job.code().clone(), job.version().to_string(), true);
             return false;
+        } else if job.is_processed() {
+            debug!(
+                started_at = %job.started_at(),
+                next_start_at = ?job.next_start_at(),
+                "Job completed; next iteration not yet due, waiting for schedule"
+            );
         }
 
         if job.is_ready_for_processing() {
+            debug!(
+                started_at = %job.started_at(),
+                "Job ready for processing"
+            );
             self.pick_and_execute_task(job, cancel_token).await.unwrap_or_else(|e| {
                 if matches!(e, InternalError::Cancelled) {
                     debug!("Job processing cancelled");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job scheduling after restore so jobs now respect their saved start time and iteration interval more consistently.
  * Fixed cases where a job could be treated as finished too early or delayed incorrectly after being loaded from storage.
  * Added clearer internal logging around when a job is ready to run or must wait for the next iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->