### PR TITLE
(feat) LLM pricing reference

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,4 +10,13 @@ ignore = [
     "RUSTSEC-2026-0099",
     "RUSTSEC-2026-0104",
     "RUSTSEC-2026-0185",  # `quinn-proto` via `testcontainers`, wait for new version
+    # quick-xml <0.41 DoS pair (both fixed in >=0.41.0): 0194 quadratic-time
+    # duplicate-attribute check, 0195 unbounded namespace-declaration allocation.
+    # Transitive only, via object_store / opendal / reqsign parsing S3 XML responses;
+    # input comes from our trusted object store, not from an attacker. No upstream fix
+    # is reachable yet: even the latest object_store 0.14.0 still pins quick-xml ^0.40.1
+    # (also <0.41). Remove once object_store ships quick-xml >=0.41 and we bump the
+    # object_store/datafusion/parquet stack to match.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/crates/icegate-query/src/engine/core.rs
+++ b/crates/icegate-query/src/engine/core.rs
@@ -22,7 +22,7 @@ use object_store::ObjectStore;
 use tokio::sync::watch;
 
 use super::QueryEngineConfig;
-use super::provider::{IcegateCatalogProvider, WalQueryConfig};
+use super::provider::{IcegateCatalogProvider, REFERENCE_CATALOG_NAME, WalQueryConfig, reference_catalog};
 use crate::error::Result;
 
 /// Fixed DataFusion object store URL for WAL segments.
@@ -275,6 +275,16 @@ impl QueryEngine {
         let provider = self.get_provider().await?;
 
         session_ctx.register_catalog(&self.config.catalog_name, provider);
+
+        // Register the global (non-tenant) LLM pricing reference catalog. Kept out
+        // of the cached (Iceberg-only) provider and installed per session so the
+        // 15s background refresh cannot drop it, and so the Flight SQL tenant-scope
+        // decorator — which only re-registers `self.config.catalog_name` — never
+        // wraps it (a MemTable has no `tenant_id` column and would 500 if wrapped).
+        session_ctx.register_catalog(
+            REFERENCE_CATALOG_NAME,
+            reference_catalog().map_err(|e| crate::error::QueryError::Config(e.to_string()))?,
+        );
 
         Ok(session_ctx)
     }

--- a/crates/icegate-query/src/engine/provider/mod.rs
+++ b/crates/icegate-query/src/engine/provider/mod.rs
@@ -21,12 +21,14 @@
 mod catalog;
 mod expr_to_predicate;
 mod metrics;
+mod pricing;
 mod scan;
 mod schema;
 mod table;
 
 pub use catalog::IcegateCatalogProvider;
 pub use metrics::{SourceMetrics, extract_source_metrics};
+pub use pricing::{REFERENCE_CATALOG_NAME, reference_catalog};
 
 /// WAL-specific query configuration passed through the provider chain.
 ///

--- a/crates/icegate-query/src/engine/provider/pricing.rs
+++ b/crates/icegate-query/src/engine/provider/pricing.rs
@@ -1,0 +1,208 @@
+//! Global (non-tenant) LLM pricing reference table.
+//!
+//! Registers `reference.llm.pricing` as an in-memory DataFusion catalog so
+//! Flight SQL queries can JOIN `iceberg.icegate.operations` against per-model
+//! pricing. This catalog is NOT tenant-scoped: pricing is global reference
+//! data, identical for every tenant, and carries no `tenant_id` column (so it
+//! must never be registered under the tenant-wrapped `iceberg` catalog).
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Float64Array, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider, MemorySchemaProvider, SchemaProvider};
+use datafusion::datasource::MemTable;
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::col;
+
+/// Catalog name for global reference data (never tenant-wrapped).
+pub const REFERENCE_CATALOG_NAME: &str = "reference";
+/// Schema (namespace) holding LLM reference tables.
+pub const REFERENCE_LLM_SCHEMA: &str = "llm";
+/// Pricing table name; FQN is `reference.llm.pricing`.
+pub const PRICING_TABLE_NAME: &str = "pricing";
+
+/// Arrow schema for `reference.llm.pricing`. Cache columns are nullable
+/// (not every model supports prompt caching); the rest are required.
+fn pricing_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("provider", DataType::Utf8, false),
+        Field::new("model", DataType::Utf8, false),
+        Field::new("input_usd_per_1m", DataType::Float64, false),
+        Field::new("output_usd_per_1m", DataType::Float64, false),
+        Field::new("cache_read_usd_per_1m", DataType::Float64, true),
+        Field::new("cache_write_usd_per_1m", DataType::Float64, true),
+        Field::new("currency", DataType::Utf8, false),
+    ]))
+}
+
+/// Build the seed `RecordBatch` of pricing rows. Illustrative public list rates
+/// (USD per 1M tokens) — replace with a maintained rate card. The
+/// `(provider, model)` pairs mirror every combination emitted by icegen's LLM
+/// trace generator (`otel-log-generator otel --signal traces`), so the synthetic
+/// `operations` rows it produces JOIN cleanly against this table. `provider`
+/// values MUST match icegate's normalized `operations.provider_name`
+/// (`gen_ai.provider.name` ‖ `gen_ai.system` ‖ `llm.system`), which icegate stores
+/// verbatim. `cache_*` rates are left NULL for models without published
+/// prompt-cache pricing, and `cache_write` is NULL for providers that charge no
+/// separate cache-write fee.
+///
+/// Rows are kept sorted by `(provider, model)` (enforced by
+/// `pricing_batch_is_sorted_by_provider_and_model`) so the reference table reads
+/// deterministically.
+///
+/// # Errors
+///
+/// Returns a `DataFusionError` if the columns do not line up with the schema.
+fn pricing_batch() -> DFResult<RecordBatch> {
+    let schema = pricing_schema();
+    let provider = StringArray::from(vec![
+        "anthropic",
+        "anthropic",
+        "anthropic",
+        "aws.bedrock",
+        "aws.bedrock",
+        "cohere",
+        "cohere",
+        "gcp.vertex_ai",
+        "gcp.vertex_ai",
+        "mistral_ai",
+        "mistral_ai",
+        "openai",
+        "openai",
+        "openai",
+        "openai",
+    ]);
+    let model = StringArray::from(vec![
+        "claude-3-5-haiku",
+        "claude-3-5-sonnet",
+        "claude-opus-4",
+        "amazon.titan-text",
+        "anthropic.claude-3-5-sonnet",
+        "command-r",
+        "command-r-plus",
+        "gemini-1.5-pro",
+        "gemini-2.0-flash",
+        "mistral-large",
+        "mistral-small",
+        "gpt-4.1",
+        "gpt-4o",
+        "gpt-4o-mini",
+        "o3",
+    ]);
+    let input = Float64Array::from(vec![
+        0.8, 3.0, 15.0, 0.2, 3.0, 0.15, 2.5, 1.25, 0.1, 2.0, 0.2, 2.0, 2.5, 0.15, 2.0,
+    ]);
+    let output = Float64Array::from(vec![
+        4.0, 15.0, 75.0, 0.6, 15.0, 0.6, 10.0, 5.0, 0.4, 6.0, 0.6, 8.0, 10.0, 0.6, 8.0,
+    ]);
+    let cache_read = Float64Array::from(vec![
+        Some(0.08),
+        Some(0.3),
+        Some(1.5),
+        None,
+        Some(0.3),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(0.5),
+        Some(1.25),
+        Some(0.075),
+        Some(0.5),
+    ]);
+    let cache_write = Float64Array::from(vec![
+        Some(1.0),
+        Some(3.75),
+        Some(18.75),
+        None,
+        Some(3.75),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ]);
+    let currency = StringArray::from(vec!["USD"; 15]);
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(provider),
+            Arc::new(model),
+            Arc::new(input),
+            Arc::new(output),
+            Arc::new(cache_read),
+            Arc::new(cache_write),
+            Arc::new(currency),
+        ],
+    )
+    .map_err(Into::into)
+}
+
+/// Build the `reference` catalog provider containing `llm.pricing`.
+///
+/// The table is declared sorted by `(provider, model)` ascending, matching the
+/// seed batch (see [`pricing_batch`]), so the planner can elide an
+/// `ORDER BY provider, model`. The declaration is a promise the planner trusts;
+/// `pricing_batch_is_sorted_by_provider_and_model` keeps that promise true.
+///
+/// # Errors
+///
+/// Returns a `DataFusionError` if the seed batch, `MemTable`, or registration
+/// fails.
+pub fn reference_catalog() -> DFResult<Arc<dyn CatalogProvider>> {
+    let schema = pricing_schema();
+    let table = MemTable::try_new(schema, vec![vec![pricing_batch()?]])?.with_sort_order(vec![vec![
+        col("provider").sort(true, false),
+        col("model").sort(true, false),
+    ]]);
+    let llm_schema = MemorySchemaProvider::new();
+    llm_schema.register_table(PRICING_TABLE_NAME.to_string(), Arc::new(table))?;
+    let catalog = MemoryCatalogProvider::new();
+    catalog.register_schema(REFERENCE_LLM_SCHEMA, Arc::new(llm_schema) as Arc<dyn SchemaProvider>)?;
+    Ok(Arc::new(catalog))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::Array;
+
+    use super::*;
+
+    #[test]
+    fn pricing_batch_matches_schema_and_has_rows() {
+        let batch = pricing_batch().expect("batch builds");
+        assert_eq!(batch.schema(), pricing_schema());
+        assert_eq!(batch.num_rows(), 15);
+    }
+
+    #[test]
+    fn pricing_batch_is_sorted_by_provider_and_model() {
+        let batch = pricing_batch().expect("batch builds");
+        let providers = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("provider is Utf8");
+        let models = batch.column(1).as_any().downcast_ref::<StringArray>().expect("model is Utf8");
+        let keys: Vec<(&str, &str)> = (0..batch.num_rows()).map(|i| (providers.value(i), models.value(i))).collect();
+        let mut expected = keys.clone();
+        expected.sort_unstable();
+        assert_eq!(keys, expected, "pricing rows must be sorted by (provider, model)");
+    }
+
+    #[test]
+    fn reference_catalog_exposes_llm_pricing() {
+        let catalog = reference_catalog().expect("catalog builds");
+        let schema = catalog.schema(REFERENCE_LLM_SCHEMA).expect("llm schema present");
+        assert!(schema.table_exist(PRICING_TABLE_NAME));
+    }
+}

--- a/crates/icegate-query/tests/flight_sql/mod.rs
+++ b/crates/icegate-query/tests/flight_sql/mod.rs
@@ -2,6 +2,7 @@
 
 mod harness;
 mod metadata;
+mod pricing;
 mod read_only;
 mod smoke;
 mod tenant;

--- a/crates/icegate-query/tests/flight_sql/pricing.rs
+++ b/crates/icegate-query/tests/flight_sql/pricing.rs
@@ -1,0 +1,53 @@
+//! Cross-catalog reachability: the global non-tenant `reference.llm.pricing`
+//! table is visible AND joinable to the tenant-scoped `iceberg` catalog in a
+//! single plan, driven through the real Flight SQL endpoint (not a bare
+//! `SessionContext`). This is the make-or-break guarantee the whole
+//! conversation-cost feature depends on.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use icegate_common::{ICEGATE_NAMESPACE, LOGS_TABLE};
+
+use super::harness::{TestServer, count_from_batches, execute_sql, write_test_logs_for_tenant};
+
+#[tokio::test]
+async fn standalone_select_on_reference_pricing_works() -> Result<(), Box<dyn std::error::Error>> {
+    let (server, _catalog) = TestServer::start().await?;
+    let mut client = server.client(Some("tenant-alpha"));
+    let batches = execute_sql(&mut client, "SELECT count(*) FROM reference.llm.pricing").await?;
+    assert_eq!(count_from_batches(&batches), 3);
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn cross_catalog_join_plans_and_executes() -> Result<(), Box<dyn std::error::Error>> {
+    let (server, catalog) = TestServer::start().await?;
+
+    // Seed tenant-alpha logs whose service_name matches a pricing `model` row,
+    // so the join produces matches. (logs is the table the harness can write;
+    // the join reachability is independent of which iceberg table we pick.)
+    let ident = iceberg::TableIdent::from_strs([ICEGATE_NAMESPACE, LOGS_TABLE])?;
+    let table = catalog.load_table(&ident).await?;
+    write_test_logs_for_tenant(&table, &catalog, "tenant-alpha", "claude-opus-4", "Alpha").await?;
+
+    let mut client = server.client(Some("tenant-alpha"));
+    let batches = execute_sql(
+        &mut client,
+        "SELECT count(*) FROM iceberg.icegate.logs l \
+         JOIN reference.llm.pricing p ON l.service_name = p.model",
+    )
+    .await?;
+    assert_eq!(count_from_batches(&batches), 3);
+
+    // The cross-catalog plan is valid (references both catalogs).
+    let explain = execute_sql(
+        &mut client,
+        "EXPLAIN SELECT l.body, p.input_usd_per_1m FROM iceberg.icegate.logs l \
+         JOIN reference.llm.pricing p ON l.service_name = p.model",
+    )
+    .await?;
+    assert!(!explain.is_empty());
+
+    server.shutdown().await;
+    Ok(())
+}

--- a/crates/icegate-query/tests/flight_sql/pricing.rs
+++ b/crates/icegate-query/tests/flight_sql/pricing.rs
@@ -14,7 +14,7 @@ async fn standalone_select_on_reference_pricing_works() -> Result<(), Box<dyn st
     let (server, _catalog) = TestServer::start().await?;
     let mut client = server.client(Some("tenant-alpha"));
     let batches = execute_sql(&mut client, "SELECT count(*) FROM reference.llm.pricing").await?;
-    assert_eq!(count_from_batches(&batches), 3);
+    assert_eq!(count_from_batches(&batches), 15);
     server.shutdown().await;
     Ok(())
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared, global reference dataset containing LLM pricing data to the query engine.
  * Pricing is now queryable via `reference.llm.pricing`.
  * Enabled cross-catalog querying, including joining tenant-scoped data with the shared pricing dataset.
* **Tests**
  * Added Flight SQL integration tests to verify pricing table visibility and correct results.
  * Added coverage for join behavior between tenant-scoped tables and the global pricing dataset, including non-empty query plan output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->