### PR TITLE
(feat) Add claude_code operation convention

### DIFF
--- a/crates/icegate-ingest/src/transform/attributes.rs
+++ b/crates/icegate-ingest/src/transform/attributes.rs
@@ -111,6 +111,63 @@ fn any_value_to_json(value: &AnyValue) -> Option<serde_json::Value> {
     })
 }
 
+/// Serialize every attribute of a span event into a JSON object string keyed by
+/// attribute name (output order follows the input).
+///
+/// Returns `None` when there are no serializable attributes. Used to project a
+/// span event's full payload (e.g. Claude Code's `tool.output` event) into a
+/// single JSON content column. On a duplicate attribute key the first value wins.
+pub(crate) fn serialize_all_attrs_to_json_object(attrs: &[KeyValue]) -> Option<String> {
+    let mut object = serde_json::Map::new();
+    for kv in attrs {
+        if object.contains_key(&kv.key) {
+            continue;
+        }
+        if let Some(value) = kv.value.as_ref().and_then(any_value_to_json) {
+            object.insert(kv.key.clone(), value);
+        }
+    }
+    if object.is_empty() {
+        return None;
+    }
+    serde_json::to_string(&object).ok()
+}
+
+/// Serialize the named attribute `keys` present in `attrs` into a JSON object
+/// string keyed by attribute name (output order follows `keys`).
+///
+/// Returns `None` when none of the keys are present. Used to project a selected
+/// set of flat span attributes (e.g. a tool call's `full_command` / `file_path`
+/// input) into a single JSON content column. On a duplicate key the first wins.
+pub(crate) fn serialize_attrs_to_json_object(attrs: &[KeyValue], keys: &[&str]) -> Option<String> {
+    let mut object = serde_json::Map::new();
+    for &key in keys {
+        if object.contains_key(key) {
+            continue;
+        }
+        if let Some(kv) = attrs.iter().find(|kv| kv.key == key) {
+            if let Some(value) = kv.value.as_ref().and_then(any_value_to_json) {
+                object.insert(key.to_string(), value);
+            }
+        }
+    }
+    if object.is_empty() {
+        return None;
+    }
+    serde_json::to_string(&object).ok()
+}
+
+/// Serialize a single chat message into the `[{"role": role, "content": content}]`
+/// JSON array shape that the message content columns (`input_messages` /
+/// `output_messages`) use.
+///
+/// Used for SDKs (e.g. Claude Code) that emit a bare prompt/response string
+/// rather than a structured messages array; consumers reconstruct a conversation
+/// by parsing this column as an array of role/content messages.
+pub(crate) fn serialize_message_to_json_array(role: &str, content: &str) -> Option<String> {
+    serde_json::to_string(&serde_json::json!([{ "role": role, "content": content }])).ok()
+}
+
 /// Checks if a byte slice is all zeros.
 pub(crate) fn is_zero_bytes(bytes: &[u8]) -> bool {
     bytes.iter().all(|&b| b == 0)
@@ -1042,5 +1099,72 @@ mod tests {
             })),
         };
         assert!(extract_string_list(Some(&mixed), "ctx").is_err());
+    }
+
+    #[test]
+    fn serialize_all_attrs_to_json_object_includes_every_attribute() {
+        let attrs = vec![
+            KeyValue {
+                key: "output".to_string(),
+                value: Some(AnyValue {
+                    value: Some(Value::StringValue("done".to_string())),
+                }),
+            },
+            KeyValue {
+                key: "bash_command".to_string(),
+                value: Some(AnyValue {
+                    value: Some(Value::StringValue("ls".to_string())),
+                }),
+            },
+        ];
+
+        // Every attribute is included, keyed by its name.
+        let json = serialize_all_attrs_to_json_object(&attrs).expect("some");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed["output"], "done");
+        assert_eq!(parsed["bash_command"], "ls");
+
+        // No attributes -> None (a NULL content column, not "{}").
+        assert!(serialize_all_attrs_to_json_object(&[]).is_none());
+    }
+
+    #[test]
+    fn serialize_attrs_to_json_object_selects_named_keys() {
+        let attrs = vec![
+            KeyValue {
+                key: "full_command".to_string(),
+                value: Some(AnyValue {
+                    value: Some(Value::StringValue("ls -la".to_string())),
+                }),
+            },
+            KeyValue {
+                key: "tool_name".to_string(),
+                value: Some(AnyValue {
+                    value: Some(Value::StringValue("Bash".to_string())),
+                }),
+            },
+        ];
+
+        // Only the requested, present key is included (keyed by name); an absent
+        // requested key and unrequested attributes are excluded.
+        let json = serialize_attrs_to_json_object(&attrs, &["full_command", "file_path"]).expect("some");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed["full_command"], "ls -la");
+        assert!(parsed.get("file_path").is_none());
+        assert!(parsed.get("tool_name").is_none());
+
+        // No requested key present -> None.
+        assert!(serialize_attrs_to_json_object(&attrs, &["file_path"]).is_none());
+    }
+
+    #[test]
+    fn serialize_message_to_json_array_wraps_role_and_content() {
+        // Produces the [{"role","content"}] array shape conversation views parse,
+        // with content correctly JSON-escaped.
+        let json = serialize_message_to_json_array("user", "hello \"world\"").expect("some");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert!(parsed.is_array());
+        assert_eq!(parsed[0]["role"], "user");
+        assert_eq!(parsed[0]["content"], "hello \"world\"");
     }
 }

--- a/crates/icegate-ingest/src/transform/operations/claude_code.rs
+++ b/crates/icegate-ingest/src/transform/operations/claude_code.rs
@@ -1,0 +1,281 @@
+//! Claude Code semantic-convention adapter.
+
+use super::convention::OperationConvention;
+use super::projection::{AttributeView, OperationField};
+use crate::transform::attributes::extract_string_value;
+
+/// Claude Code (`service.name = claude-code`) semantic-convention adapter.
+///
+/// Claude Code spans are named `claude_code.<span.type>` and only the
+/// `llm_request` span carries `gen_ai.*` markers; `interaction`, `tool`,
+/// `tool.execution`, and `tool.blocked_on_user` carry none. Qualification is
+/// therefore by span-name prefix (`claude_code.`), not by a marker attribute.
+///
+/// Sources Claude Code's flat, vendor-specific keys: token counts
+/// (`input_tokens`/`output_tokens`/`cache_creation_tokens`/`cache_read_tokens`),
+/// `tool_name`, the millisecond-native `ttft_ms`, the flat agent/workflow
+/// spellings (`agent_id`/`workflow.name`/`subagent_type`), tool-call arguments
+/// (`full_command`/`file_path`), and the interaction's `user_prompt` input
+/// message. Provider, model,
+/// response id, finish reasons, tool-call id, conversation id, and user id are
+/// already sourced by the OTEL/`OpenInference` adapters from the `gen_ai.*` /
+/// `session.id` / `user.id` keys these spans also carry. Registered last, so it
+/// only fills fields the earlier adapters did not.
+pub(crate) struct ClaudeCode;
+
+impl OperationConvention for ClaudeCode {
+    fn marker_keys(&self) -> &'static [&'static str] {
+        // Claude Code qualifies by span name (see `name_prefixes`), not by an
+        // attribute marker, so it contributes nothing to the marker union.
+        &[]
+    }
+
+    fn name_prefixes(&self) -> &'static [&'static str] {
+        &["claude_code."]
+    }
+
+    fn field_keys(&self, field: OperationField) -> &'static [&'static str] {
+        match field {
+            OperationField::InputTokens => &["input_tokens"],
+            OperationField::OutputTokens => &["output_tokens"],
+            OperationField::CacheCreationInputTokens => &["cache_creation_tokens"],
+            OperationField::CacheReadInputTokens => &["cache_read_tokens"],
+            OperationField::ToolName => &["tool_name"],
+            // Millisecond-native; the `_ms` suffix tells the driver's unit-aware
+            // resolver not to scale it (unlike OTEL's seconds-based key).
+            OperationField::TimeToFirstChunkMs => &["ttft_ms"],
+            // Claude Code's flat agent/workflow spellings (vs OTEL's
+            // `gen_ai.agent.*` / `gen_ai.workflow.name`). `subagent_type` names the
+            // dispatched subagent on `invoke_subagent` tool spans. All three are
+            // gated/context-conditional, so best-effort like every other field.
+            OperationField::AgentId => &["agent_id"],
+            OperationField::WorkflowName => &["workflow.name"],
+            OperationField::AgentName => &["subagent_type"],
+            _ => &[],
+        }
+    }
+
+    fn object_field_keys(&self, field: OperationField) -> &'static [&'static str] {
+        // The tool's input arguments are flat span attributes — `full_command`
+        // (Bash) or `file_path` (Read/Edit) — projected as one JSON object keyed
+        // by attribute name, e.g. `{"full_command": "…"}`.
+        match field {
+            OperationField::ToolCallArguments => &["full_command", "file_path"],
+            _ => &[],
+        }
+    }
+
+    fn event_field_names(&self, field: OperationField) -> &'static [&'static str] {
+        // The whole `tool.output` span event (gated by OTEL_LOG_TOOL_CONTENT) is
+        // the tool's result: its echoed input (bash_command / file_path) and its
+        // output payload (output / content) together form the output object. The
+        // tool's *input arguments* come from the span attributes (see field_keys).
+        match field {
+            OperationField::ToolCallResult => &["tool.output"],
+            _ => &[],
+        }
+    }
+
+    fn message_field_keys(&self, field: OperationField) -> &'static [(&'static str, &'static str)] {
+        // The interaction span's `user_prompt` is a bare prompt string; wrap it as
+        // a single `user` message so conversation views (which expect a
+        // `[{"role","content"}]` array) render it.
+        match field {
+            OperationField::InputMessages => &[("user_prompt", "user")],
+            _ => &[],
+        }
+    }
+
+    fn classify_operation(&self, span_name: &str, attrs: &AttributeView) -> Option<String> {
+        // Claude Code names every span `claude_code.<span.type>`; classify by
+        // exact name, or by the `tool` prefix for the tool family.
+        let name = span_name.strip_prefix("claude_code.")?;
+        let operation = match name {
+            "llm_request" => "chat",
+            "interaction" => "invoke_agent",
+            // `tool`, `tool.execution`, `tool.blocked_on_user`. Only the parent
+            // `tool` span carries `tool_name`; the `Agent` dispatcher is a nested
+            // agent invocation, kept distinct from a plain tool run.
+            _ if name == "tool" || name.starts_with("tool.") => {
+                match extract_string_value(attrs.get("tool_name")).as_deref() {
+                    Some("Agent") => "invoke_subagent",
+                    _ => "execute_tool",
+                }
+            }
+            _ => "other",
+        };
+        Some(operation.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value::Value};
+
+    use super::*;
+
+    fn kv_str(key: &str, value: &str) -> KeyValue {
+        KeyValue {
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(value.to_string())),
+            }),
+        }
+    }
+
+    /// Classify by span name with the given attributes.
+    fn classify(span_name: &str, attrs: &[KeyValue]) -> Option<String> {
+        let view = AttributeView::new(attrs);
+        ClaudeCode.classify_operation(span_name, &view)
+    }
+
+    #[test]
+    fn qualifies_by_claude_code_name_prefix() {
+        assert_eq!(ClaudeCode.name_prefixes(), &["claude_code."]);
+    }
+
+    #[test]
+    fn declares_no_attribute_markers() {
+        // Claude Code qualifies by span name, not by an attribute marker, so it
+        // must not widen the attribute-marker union filter.
+        assert_eq!(ClaudeCode.marker_keys(), &[] as &[&str]);
+    }
+
+    #[test]
+    fn token_fields_source_flat_claude_code_keys() {
+        assert_eq!(ClaudeCode.field_keys(OperationField::InputTokens), &["input_tokens"]);
+        assert_eq!(ClaudeCode.field_keys(OperationField::OutputTokens), &["output_tokens"]);
+        assert_eq!(
+            ClaudeCode.field_keys(OperationField::CacheCreationInputTokens),
+            &["cache_creation_tokens"]
+        );
+        assert_eq!(
+            ClaudeCode.field_keys(OperationField::CacheReadInputTokens),
+            &["cache_read_tokens"]
+        );
+    }
+
+    #[test]
+    fn tool_name_sources_flat_tool_name_key() {
+        assert_eq!(ClaudeCode.field_keys(OperationField::ToolName), &["tool_name"]);
+    }
+
+    #[test]
+    fn time_to_first_chunk_sources_ttft_ms() {
+        assert_eq!(ClaudeCode.field_keys(OperationField::TimeToFirstChunkMs), &["ttft_ms"]);
+    }
+
+    #[test]
+    fn agent_and_workflow_fields_source_flat_claude_code_keys() {
+        // Claude Code uses flat spellings (agent_id / workflow.name / subagent_type),
+        // not the OTEL gen_ai.agent.* / gen_ai.workflow.name keys.
+        assert_eq!(ClaudeCode.field_keys(OperationField::AgentId), &["agent_id"]);
+        assert_eq!(ClaudeCode.field_keys(OperationField::WorkflowName), &["workflow.name"]);
+        assert_eq!(ClaudeCode.field_keys(OperationField::AgentName), &["subagent_type"]);
+    }
+
+    #[test]
+    fn tool_call_arguments_object_from_full_command_and_file_path() {
+        // Tool input arguments are assembled into a JSON object from these flat
+        // span attributes (keyed by name), not resolved as a scalar field_keys value.
+        assert_eq!(
+            ClaudeCode.object_field_keys(OperationField::ToolCallArguments),
+            &["full_command", "file_path"]
+        );
+        assert_eq!(ClaudeCode.field_keys(OperationField::ToolCallArguments), &[] as &[&str]);
+    }
+
+    #[test]
+    fn input_messages_wraps_user_prompt_as_user_message() {
+        // user_prompt is wrapped into a `[{"role":"user","content":…}]` message
+        // array, not resolved as a scalar field_keys value.
+        assert_eq!(
+            ClaudeCode.message_field_keys(OperationField::InputMessages),
+            &[("user_prompt", "user")]
+        );
+        assert_eq!(ClaudeCode.field_keys(OperationField::InputMessages), &[] as &[&str]);
+    }
+
+    #[test]
+    fn tool_call_result_sources_the_whole_tool_output_event() {
+        // The entire tool.output event is the result; arguments are NOT
+        // event-sourced (they come from span attributes).
+        assert_eq!(
+            ClaudeCode.event_field_names(OperationField::ToolCallResult),
+            &["tool.output"]
+        );
+        assert_eq!(
+            ClaudeCode.event_field_names(OperationField::ToolCallArguments),
+            &[] as &[&str]
+        );
+    }
+
+    #[test]
+    fn non_tool_output_fields_declare_no_event_sources() {
+        assert_eq!(
+            ClaudeCode.event_field_names(OperationField::InputMessages),
+            &[] as &[&str]
+        );
+    }
+
+    #[test]
+    fn unsourced_field_returns_empty() {
+        assert_eq!(ClaudeCode.field_keys(OperationField::Temperature), &[] as &[&str]);
+    }
+
+    #[test]
+    fn llm_request_classifies_as_chat() {
+        assert_eq!(classify("claude_code.llm_request", &[]), Some("chat".to_string()));
+    }
+
+    #[test]
+    fn interaction_classifies_as_invoke_agent() {
+        assert_eq!(
+            classify("claude_code.interaction", &[]),
+            Some("invoke_agent".to_string())
+        );
+    }
+
+    #[test]
+    fn tool_with_agent_tool_name_classifies_as_invoke_subagent() {
+        // The subagent dispatcher is a nested agent invocation, kept distinct
+        // from the top-level interaction and from plain tool runs.
+        assert_eq!(
+            classify("claude_code.tool", &[kv_str("tool_name", "Agent")]),
+            Some("invoke_subagent".to_string())
+        );
+    }
+
+    #[test]
+    fn tool_with_other_tool_name_classifies_as_execute_tool() {
+        assert_eq!(
+            classify("claude_code.tool", &[kv_str("tool_name", "Bash")]),
+            Some("execute_tool".to_string())
+        );
+    }
+
+    #[test]
+    fn tool_subspans_classify_as_execute_tool() {
+        // tool.execution / tool.blocked_on_user carry no tool_name and fall to
+        // execute_tool via the `claude_code.tool` prefix.
+        assert_eq!(
+            classify("claude_code.tool.execution", &[]),
+            Some("execute_tool".to_string())
+        );
+        assert_eq!(
+            classify("claude_code.tool.blocked_on_user", &[]),
+            Some("execute_tool".to_string())
+        );
+    }
+
+    #[test]
+    fn unknown_claude_code_span_classifies_as_other() {
+        assert_eq!(classify("claude_code.future_kind", &[]), Some("other".to_string()));
+    }
+
+    #[test]
+    fn non_claude_code_name_is_not_classified() {
+        // A span whose name is not claude_code.* is left for other adapters.
+        assert_eq!(classify("op", &[kv_str("tool_name", "Agent")]), None);
+    }
+}

--- a/crates/icegate-ingest/src/transform/operations/convention.rs
+++ b/crates/icegate-ingest/src/transform/operations/convention.rs
@@ -2,6 +2,7 @@
 
 use std::sync::OnceLock;
 
+use super::claude_code::ClaudeCode;
 use super::openinference::OpenInference;
 use super::otel::OtelGenAi;
 use super::projection::{AttributeView, OperationField};
@@ -18,19 +19,58 @@ pub(crate) trait OperationConvention: Send + Sync {
     /// the union of every adapter's markers.
     fn marker_keys(&self) -> &'static [&'static str];
 
+    /// Span-name prefixes that qualify a span for this convention even when no
+    /// marker attribute is present. Name-based SDKs (e.g. Claude Code, whose
+    /// non-LLM spans carry no `gen_ai.*` marker) opt in here; attribute-marker
+    /// conventions inherit the empty default. Kept separate from
+    /// [`Self::marker_keys`] so name-based qualification does not widen the
+    /// attribute-marker union filter.
+    fn name_prefixes(&self) -> &'static [&'static str] {
+        &[]
+    }
+
     /// Ordered candidate attribute keys this convention offers for `field`
     /// (most-specific first). Empty slice when this convention does not source
     /// the field.
     fn field_keys(&self, field: OperationField) -> &'static [&'static str];
 
-    /// Classifies this convention's span-kind into a canonical `operation_name`,
-    /// or `None` when this convention cannot decide (the next adapter then tries).
-    fn classify_operation(&self, attrs: &AttributeView) -> Option<String>;
+    /// Attribute keys this convention assembles into a JSON object for a content
+    /// `field`, keyed by attribute name — used when the field is a set of flat
+    /// attributes rather than a single value (e.g. a tool call's flat input
+    /// arguments). Resolved after the scalar [`Self::field_keys`] and before
+    /// event objects ([`Self::event_field_names`]). Default: none.
+    fn object_field_keys(&self, _field: OperationField) -> &'static [&'static str] {
+        &[]
+    }
+
+    /// Span *event* names whose full attribute set this convention projects into
+    /// `field` as a single JSON object keyed by attribute name — used when a
+    /// field's value lives in a span event rather than an attribute (e.g. a tool
+    /// result). Attribute sources ([`Self::field_keys`]) are resolved first and
+    /// win. Default: no event-sourced fields.
+    fn event_field_names(&self, _field: OperationField) -> &'static [&'static str] {
+        &[]
+    }
+
+    /// `(attribute_key, role)` sources this convention wraps into a single-message
+    /// JSON array `[{"role": role, "content": <value>}]` for a message content
+    /// `field` — used when an SDK emits a bare prompt/response string rather than
+    /// a structured messages array (the shape conversation UIs parse). Resolved
+    /// after the scalar, object, and event modes. Default: none.
+    fn message_field_keys(&self, _field: OperationField) -> &'static [(&'static str, &'static str)] {
+        &[]
+    }
+
+    /// Classifies a span into a canonical `operation_name` from its `span_name`
+    /// and attributes, or `None` when this convention cannot decide (the next
+    /// adapter then tries). `span_name` is the OTLP span name, letting name-based
+    /// conventions classify by exact name or prefix.
+    fn classify_operation(&self, span_name: &str, attrs: &AttributeView) -> Option<String>;
 }
 
 /// Precedence-ordered convention registry: earlier wins on shared keys. This
 /// slice is the whole extension surface — append an adapter to add an SDK.
-pub(crate) static CONVENTIONS: &[&dyn OperationConvention] = &[&OtelGenAi, &OpenInference, &Traceloop];
+pub(crate) static CONVENTIONS: &[&dyn OperationConvention] = &[&OtelGenAi, &OpenInference, &Traceloop, &ClaudeCode];
 
 /// Flattens every convention's `field_keys(field)` into a single
 /// precedence-ordered vector, preserving registry order. Pulled out as a free
@@ -173,7 +213,7 @@ mod tests {
             }
         }
 
-        fn classify_operation(&self, _attrs: &AttributeView) -> Option<String> {
+        fn classify_operation(&self, _span_name: &str, _attrs: &AttributeView) -> Option<String> {
             None
         }
     }
@@ -194,7 +234,7 @@ mod tests {
             }
         }
 
-        fn classify_operation(&self, _attrs: &AttributeView) -> Option<String> {
+        fn classify_operation(&self, _span_name: &str, _attrs: &AttributeView) -> Option<String> {
             None
         }
     }
@@ -260,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn input_tokens_precedence_is_otel_then_oi_then_traceloop() {
+    fn input_tokens_precedence_is_otel_then_oi_then_traceloop_then_claude_code() {
         let keys: Vec<&str> = field_precedence(OperationField::InputTokens)
             .expect("precedence available")
             .to_vec();
@@ -269,7 +309,8 @@ mod tests {
             vec![
                 "gen_ai.usage.input_tokens",
                 "llm.token_count.prompt",
-                "gen_ai.usage.prompt_tokens"
+                "gen_ai.usage.prompt_tokens",
+                "input_tokens"
             ]
         );
     }

--- a/crates/icegate-ingest/src/transform/operations/mod.rs
+++ b/crates/icegate-ingest/src/transform/operations/mod.rs
@@ -6,6 +6,7 @@
 //! precedence-ordered registry of per-SDK convention adapters
 //! ([`convention::CONVENTIONS`]), plus the thin Arrow driver below.
 
+mod claude_code;
 mod convention;
 mod openinference;
 mod otel;

--- a/crates/icegate-ingest/src/transform/operations/openinference.rs
+++ b/crates/icegate-ingest/src/transform/operations/openinference.rs
@@ -29,7 +29,7 @@ impl OperationConvention for OpenInference {
         }
     }
 
-    fn classify_operation(&self, attrs: &AttributeView) -> Option<String> {
+    fn classify_operation(&self, _span_name: &str, attrs: &AttributeView) -> Option<String> {
         let kind = extract_string_value(attrs.get("openinference.span.kind"))?;
         // Normalization map per spec section 4. PROMPT and any unrecognized kind
         // collapse to "other" via the catch-all.
@@ -67,7 +67,7 @@ mod tests {
     fn classify(kind: &str) -> Option<String> {
         let attrs = vec![kv_str("openinference.span.kind", kind)];
         let view = AttributeView::new(&attrs);
-        OpenInference.classify_operation(&view)
+        OpenInference.classify_operation("op", &view)
     }
 
     #[test]
@@ -125,6 +125,6 @@ mod tests {
     fn classify_is_none_without_span_kind() {
         let attrs = vec![kv_str("llm.system", "openai")];
         let view = AttributeView::new(&attrs);
-        assert_eq!(OpenInference.classify_operation(&view), None);
+        assert_eq!(OpenInference.classify_operation("op", &view), None);
     }
 }

--- a/crates/icegate-ingest/src/transform/operations/otel.rs
+++ b/crates/icegate-ingest/src/transform/operations/otel.rs
@@ -70,7 +70,7 @@ impl OperationConvention for OtelGenAi {
         }
     }
 
-    fn classify_operation(&self, attrs: &AttributeView) -> Option<String> {
+    fn classify_operation(&self, _span_name: &str, attrs: &AttributeView) -> Option<String> {
         // Verbatim, lowercased: preserves text_completion / generate_content /
         // invoke_workflow / plan without special-casing (spec section 4).
         extract_string_value(attrs.get("gen_ai.operation.name")).map(|name| name.to_lowercase())
@@ -136,13 +136,16 @@ mod tests {
     fn classify_operation_returns_lowercased_verbatim() {
         let attrs = vec![kv_str("gen_ai.operation.name", "Text_Completion")];
         let view = AttributeView::new(&attrs);
-        assert_eq!(OtelGenAi.classify_operation(&view), Some("text_completion".to_string()));
+        assert_eq!(
+            OtelGenAi.classify_operation("op", &view),
+            Some("text_completion".to_string())
+        );
     }
 
     #[test]
     fn classify_operation_is_none_without_operation_name() {
         let attrs = vec![kv_str("gen_ai.system", "openai")];
         let view = AttributeView::new(&attrs);
-        assert_eq!(OtelGenAi.classify_operation(&view), None);
+        assert_eq!(OtelGenAi.classify_operation("op", &view), None);
     }
 }

--- a/crates/icegate-ingest/src/transform/operations/projection.rs
+++ b/crates/icegate-ingest/src/transform/operations/projection.rs
@@ -8,13 +8,14 @@
 use std::collections::HashMap;
 
 use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope, KeyValue};
-use opentelemetry_proto::tonic::trace::v1::Span;
+use opentelemetry_proto::tonic::trace::v1::{Span, span::Event};
 
 use super::convention::{CONVENTIONS, field_precedence};
 use crate::error::Result;
 use crate::transform::attributes::{
     extract_bool, extract_f64, extract_i64, extract_string_list, extract_string_value, is_zero_bytes, nanos_to_micros,
-    serialize_any_value_to_json, u32_count_to_i32,
+    serialize_all_attrs_to_json_object, serialize_any_value_to_json, serialize_attrs_to_json_object,
+    serialize_message_to_json_array, u32_count_to_i32,
 };
 
 /// Borrowing view over a span's attribute list. Built once per span and shared
@@ -405,6 +406,92 @@ fn resolve_json(view: &AttributeView, field: OperationField) -> Result<Option<St
     Ok(None)
 }
 
+/// Resolve a content field from span *events*: for the first registered
+/// convention that names an event source for `field`, serialize the first
+/// matching event's full attribute set into one JSON object. Returns `None` when
+/// no convention sources `field` from events, or no such event is present.
+fn resolve_json_from_events(events: &[Event], field: OperationField) -> Option<String> {
+    for convention in CONVENTIONS {
+        let event_names = convention.event_field_names(field);
+        if event_names.is_empty() {
+            continue;
+        }
+        for event in events {
+            if event_names.contains(&event.name.as_str()) {
+                if let Some(json) = serialize_all_attrs_to_json_object(&event.attributes) {
+                    return Some(json);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Resolve a content field as a JSON object of the convention-declared flat span
+/// attributes present on the span, keyed by attribute name. Returns `None` when
+/// no convention declares object attributes for `field`, or none are present.
+fn resolve_json_object_from_attrs(attrs: &[KeyValue], field: OperationField) -> Option<String> {
+    for convention in CONVENTIONS {
+        let keys = convention.object_field_keys(field);
+        if keys.is_empty() {
+            continue;
+        }
+        if let Some(json) = serialize_attrs_to_json_object(attrs, keys) {
+            return Some(json);
+        }
+    }
+    None
+}
+
+/// Resolve a message content field as a single-message JSON array
+/// `[{"role": role, "content": <value>}]` from the first present
+/// convention-declared `(attribute_key, role)` source. Returns `None` when no
+/// convention declares a message source for `field`, or none is present.
+fn resolve_message_array_from_attrs(attrs: &[KeyValue], field: OperationField) -> Option<String> {
+    for convention in CONVENTIONS {
+        for &(key, role) in convention.message_field_keys(field) {
+            let content = attrs
+                .iter()
+                .find(|kv| kv.key == key)
+                .and_then(|kv| extract_string_value(kv.value.as_ref()));
+            if let Some(content) = content {
+                if let Some(json) = serialize_message_to_json_array(role, &content) {
+                    return Some(json);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Resolve a content field through the modes in precedence order: a scalar
+/// attribute value ([`resolve_json`]), a JSON object of flat attributes
+/// ([`resolve_json_object_from_attrs`]), a single-message JSON array
+/// ([`resolve_message_array_from_attrs`]), then a JSON object from a span event
+/// ([`resolve_json_from_events`]). The first mode to produce a value wins.
+///
+/// # Errors
+///
+/// Returns `IngestError::Validation` if the field's precedence slice is
+/// unavailable (see [`field_precedence`]).
+fn resolve_json_incl_events(
+    view: &AttributeView,
+    attrs: &[KeyValue],
+    events: &[Event],
+    field: OperationField,
+) -> Result<Option<String>> {
+    if let Some(json) = resolve_json(view, field)? {
+        return Ok(Some(json));
+    }
+    if let Some(json) = resolve_json_object_from_attrs(attrs, field) {
+        return Ok(Some(json));
+    }
+    if let Some(json) = resolve_message_array_from_attrs(attrs, field) {
+        return Ok(Some(json));
+    }
+    Ok(resolve_json_from_events(events, field))
+}
+
 /// Resolve `input_tokens`-style counts via strict `i64` parse.
 ///
 /// # Errors
@@ -419,6 +506,56 @@ fn resolve_token(view: &AttributeView, field: OperationField, context: &'static 
         ))),
         other => Ok(other),
     }
+}
+
+/// Resolve `time_to_first_chunk_ms`, normalizing the source to milliseconds.
+///
+/// The source unit is inferred from the matched attribute key: a key whose name
+/// ends in `_ms` (e.g. Claude Code's `ttft_ms`) is already milliseconds and is
+/// kept as-is; every other key (OTEL's seconds-based
+/// `gen_ai.response.time_to_first_chunk`) is seconds and scaled by 1000. The
+/// value is validated non-negative and must fit the `i64` millisecond column
+/// after conversion (D6); finiteness is already guaranteed by [`extract_f64`].
+///
+/// Resolves against the first present key in precedence order, matching the
+/// other `resolve_*` helpers.
+///
+/// # Errors
+///
+/// Returns `IngestError::Validation` when a present value fails strict parsing,
+/// is negative, or overflows the `i64` millisecond column.
+fn resolve_time_to_first_chunk_ms(view: &AttributeView) -> Result<Option<i64>> {
+    for &key in field_precedence(OperationField::TimeToFirstChunkMs)? {
+        let Some(value) = view.get(key) else {
+            continue;
+        };
+        let Some(raw) = extract_f64(Some(value), "time_to_first_chunk_ms")? else {
+            return Ok(None);
+        };
+        // A direct `as i64` cast would turn a negative duration into a nonsense
+        // latency, so reject it before converting.
+        if raw < 0.0 {
+            return Err(crate::error::IngestError::Validation(format!(
+                "time_to_first_chunk_ms must be a finite non-negative duration: {raw}"
+            )));
+        }
+        // `_ms` source keys are already milliseconds; every other key is seconds.
+        let millis = if key.ends_with("_ms") { raw } else { raw * 1000.0 };
+        // `i64::MAX as f64` rounds to 2^63; `>=` rejects anything that would
+        // overflow the truncating cast below (including a `*1000.0` that pushed a
+        // large-but-finite value to infinity).
+        #[allow(clippy::cast_precision_loss)]
+        let max_millis = i64::MAX as f64;
+        if millis >= max_millis {
+            return Err(crate::error::IngestError::Validation(format!(
+                "time_to_first_chunk_ms out of range: {raw}"
+            )));
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        let millis = millis as i64;
+        return Ok(Some(millis));
+    }
+    Ok(None)
 }
 
 /// Project one OTLP span (+ scope + tenant) into an optional operations row.
@@ -444,9 +581,10 @@ pub(crate) fn project_operation_row(
 ) -> Result<Option<OperationRow>> {
     let view = AttributeView::new(&span.attributes);
 
-    let qualifies = CONVENTIONS
-        .iter()
-        .any(|conv| conv.marker_keys().iter().any(|key| view.has(key)));
+    let qualifies = CONVENTIONS.iter().any(|conv| {
+        conv.marker_keys().iter().any(|key| view.has(key))
+            || conv.name_prefixes().iter().any(|prefix| span.name.starts_with(prefix))
+    });
     if !qualifies {
         return Ok(None);
     }
@@ -460,7 +598,7 @@ pub(crate) fn project_operation_row(
 
     let operation_name = CONVENTIONS
         .iter()
-        .find_map(|conv| conv.classify_operation(&view))
+        .find_map(|conv| conv.classify_operation(&span.name, &view))
         .unwrap_or_else(|| "other".to_string());
 
     let timestamp = nanos_to_micros(span.start_time_unix_nano);
@@ -499,34 +637,7 @@ pub(crate) fn project_operation_row(
         None => None,
     };
 
-    // A finite, non-negative duration is the only valid input; a direct `as i64`
-    // cast would otherwise turn NaN into 0 and saturate infinities/overflow into
-    // nonsense latencies, so validate before converting seconds to millis.
-    let time_to_first_chunk_ms = match resolve_f64(&view, OperationField::TimeToFirstChunkMs, "time_to_first_chunk_ms")?
-    {
-        Some(seconds) if !seconds.is_finite() || seconds < 0.0 => {
-            return Err(crate::error::IngestError::Validation(format!(
-                "time_to_first_chunk_ms must be a finite non-negative duration: {seconds}"
-            )));
-        }
-        Some(seconds) => {
-            let millis = seconds * 1000.0;
-            // `i64::MAX as f64` rounds to 2^63; `>=` rejects anything that would
-            // overflow the truncating cast below (including a `*1000.0` that
-            // pushed a large-but-finite value to infinity).
-            #[allow(clippy::cast_precision_loss)]
-            let max_millis = i64::MAX as f64;
-            if millis >= max_millis {
-                return Err(crate::error::IngestError::Validation(format!(
-                    "time_to_first_chunk_ms out of range: {seconds}"
-                )));
-            }
-            #[allow(clippy::cast_possible_truncation)]
-            let millis = millis as i64;
-            Some(millis)
-        }
-        None => None,
-    };
+    let time_to_first_chunk_ms = resolve_time_to_first_chunk_ms(&view)?;
 
     Ok(Some(OperationRow {
         tenant_id: tenant_id.to_string(),
@@ -588,19 +699,44 @@ pub(crate) fn project_operation_row(
         agent_version: resolve_str(&view, OperationField::AgentVersion)?,
         agent_description: resolve_str(&view, OperationField::AgentDescription)?,
         workflow_name: resolve_str(&view, OperationField::WorkflowName)?,
-        input_messages: resolve_json(&view, OperationField::InputMessages)?,
-        output_messages: resolve_json(&view, OperationField::OutputMessages)?,
-        system_instructions: resolve_json(&view, OperationField::SystemInstructions)?,
-        tool_definitions: resolve_json(&view, OperationField::ToolDefinitions)?,
-        tool_call_arguments: resolve_json(&view, OperationField::ToolCallArguments)?,
-        tool_call_result: resolve_json(&view, OperationField::ToolCallResult)?,
+        input_messages: resolve_json_incl_events(&view, &span.attributes, &span.events, OperationField::InputMessages)?,
+        output_messages: resolve_json_incl_events(
+            &view,
+            &span.attributes,
+            &span.events,
+            OperationField::OutputMessages,
+        )?,
+        system_instructions: resolve_json_incl_events(
+            &view,
+            &span.attributes,
+            &span.events,
+            OperationField::SystemInstructions,
+        )?,
+        tool_definitions: resolve_json_incl_events(
+            &view,
+            &span.attributes,
+            &span.events,
+            OperationField::ToolDefinitions,
+        )?,
+        tool_call_arguments: resolve_json_incl_events(
+            &view,
+            &span.attributes,
+            &span.events,
+            OperationField::ToolCallArguments,
+        )?,
+        tool_call_result: resolve_json_incl_events(
+            &view,
+            &span.attributes,
+            &span.events,
+            OperationField::ToolCallResult,
+        )?,
     }))
 }
 
 #[cfg(test)]
 mod tests {
     use opentelemetry_proto::tonic::common::v1::{AnyValue, ArrayValue, KeyValue, any_value::Value};
-    use opentelemetry_proto::tonic::trace::v1::{Span, Status};
+    use opentelemetry_proto::tonic::trace::v1::{Span, Status, span::Event};
 
     use super::*;
 
@@ -940,5 +1076,354 @@ mod tests {
         span.end_time_unix_nano = 1_000_000_000;
         let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
         assert_eq!(row.duration_micros, 0);
+    }
+
+    /// Build a Claude Code span with the given name and attributes.
+    fn claude_span(name: &str, attributes: Vec<KeyValue>) -> Span {
+        let mut span = span_with(attributes);
+        span.name = name.to_string();
+        span
+    }
+
+    /// Build a `tool.output` span event carrying the given attributes.
+    fn tool_output_event(attributes: Vec<KeyValue>) -> Event {
+        Event {
+            time_unix_nano: 1_500_000_000,
+            name: "tool.output".to_string(),
+            attributes,
+            dropped_attributes_count: 0,
+        }
+    }
+
+    /// Build a Claude Code span with the given name, attributes, and events.
+    fn claude_span_with_events(name: &str, attributes: Vec<KeyValue>, events: Vec<Event>) -> Span {
+        let mut span = claude_span(name, attributes);
+        span.events = events;
+        span
+    }
+
+    #[test]
+    fn claude_code_llm_request_projects_tokens_and_chat() {
+        // Real captured `claude_code.llm_request` attributes (values stringified,
+        // as Claude Code emits them). Tokens must land (previously NULL), ttft_ms
+        // must stay milliseconds, and provider/model/ids resolve via OTEL/OI.
+        let span = claude_span(
+            "claude_code.llm_request",
+            vec![
+                kv_str("gen_ai.request.model", "claude-opus-4-8[1m]"),
+                kv_str("gen_ai.system", "anthropic"),
+                kv_str("gen_ai.response.id", "req_011Ccznc3e9DSqCxko4AaReK"),
+                kv_str("input_tokens", "94"),
+                kv_str("output_tokens", "83"),
+                kv_str("cache_creation_tokens", "10062"),
+                kv_str("cache_read_tokens", "146256"),
+                kv_str("ttft_ms", "1305"),
+                kv_str("session.id", "c82374f6-6c77-451b-94d1-5fd472cccf1a"),
+                kv_str(
+                    "user.id",
+                    "f1ec8a18ce99fb0e68706cfbb735351381c5c1d945928a5cd0b56a2fbbd2f055",
+                ),
+                kv_str("span.type", "llm_request"),
+            ],
+        );
+
+        let row = project_operation_row(&span, None, "tenant-a", Some("claude-code"), 1)
+            .expect("projection ok")
+            .expect("llm span -> row");
+
+        assert_eq!(row.operation_name, "chat");
+        assert_eq!(row.request_model.as_deref(), Some("claude-opus-4-8[1m]"));
+        assert_eq!(row.provider_name.as_deref(), Some("anthropic"));
+        assert_eq!(row.response_id.as_deref(), Some("req_011Ccznc3e9DSqCxko4AaReK"));
+        assert_eq!(row.input_tokens, Some(94));
+        assert_eq!(row.output_tokens, Some(83));
+        assert_eq!(row.cache_creation_input_tokens, Some(10_062));
+        assert_eq!(row.cache_read_input_tokens, Some(146_256));
+        // `ttft_ms` is already milliseconds and must NOT be scaled by 1000.
+        assert_eq!(row.time_to_first_chunk_ms, Some(1305));
+        assert_eq!(
+            row.conversation_id.as_deref(),
+            Some("c82374f6-6c77-451b-94d1-5fd472cccf1a")
+        );
+        assert_eq!(
+            row.user_id.as_deref(),
+            Some("f1ec8a18ce99fb0e68706cfbb735351381c5c1d945928a5cd0b56a2fbbd2f055")
+        );
+    }
+
+    #[test]
+    fn claude_code_interaction_qualifies_by_name_without_gen_ai_marker() {
+        // interaction carries no gen_ai.* marker, so it qualifies purely by the
+        // `claude_code.` span-name prefix.
+        let span = claude_span(
+            "claude_code.interaction",
+            vec![
+                kv_str("session.id", "c82374f6"),
+                kv_str("user.id", "f1ec8a18"),
+                kv_str("span.type", "interaction"),
+            ],
+        );
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("interaction span -> row");
+
+        assert_eq!(row.operation_name, "invoke_agent");
+        assert_eq!(row.conversation_id.as_deref(), Some("c82374f6"));
+        assert_eq!(row.user_id.as_deref(), Some("f1ec8a18"));
+    }
+
+    #[test]
+    fn claude_code_agent_tool_projects_invoke_subagent() {
+        let span = claude_span(
+            "claude_code.tool",
+            vec![
+                kv_str("tool_name", "Agent"),
+                kv_str("subagent_type", "code-reviewer"),
+                kv_str("gen_ai.tool.call.id", "toolu_015wNSz"),
+                kv_str("span.type", "tool"),
+            ],
+        );
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("tool span -> row");
+
+        assert_eq!(row.operation_name, "invoke_subagent");
+        assert_eq!(row.tool_name.as_deref(), Some("Agent"));
+        assert_eq!(row.tool_call_id.as_deref(), Some("toolu_015wNSz"));
+        // subagent_type names WHICH subagent was dispatched.
+        assert_eq!(row.agent_name.as_deref(), Some("code-reviewer"));
+    }
+
+    #[test]
+    fn claude_code_llm_request_projects_agent_id_and_workflow_name() {
+        // agent_id / workflow.name are Claude Code's flat spellings; they populate
+        // the agent_id / workflow_name columns OTEL only sources from gen_ai.* keys.
+        let span = claude_span(
+            "claude_code.llm_request",
+            vec![
+                kv_str("gen_ai.system", "anthropic"),
+                kv_str("agent_id", "agent-7"),
+                kv_str("workflow.name", "code-review"),
+            ],
+        );
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("row");
+
+        assert_eq!(row.operation_name, "chat");
+        assert_eq!(row.agent_id.as_deref(), Some("agent-7"));
+        assert_eq!(row.workflow_name.as_deref(), Some("code-review"));
+    }
+
+    #[test]
+    fn claude_code_bash_tool_projects_execute_tool() {
+        let span = claude_span(
+            "claude_code.tool",
+            vec![kv_str("tool_name", "Bash"), kv_str("span.type", "tool")],
+        );
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("tool span -> row");
+
+        assert_eq!(row.operation_name, "execute_tool");
+        assert_eq!(row.tool_name.as_deref(), Some("Bash"));
+    }
+
+    #[test]
+    fn claude_code_bash_tool_projects_full_command_as_arguments() {
+        let span = claude_span(
+            "claude_code.tool",
+            vec![
+                kv_str("tool_name", "Bash"),
+                kv_str("full_command", "git status --short"),
+                kv_str("span.type", "tool"),
+            ],
+        );
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("tool span -> row");
+
+        // Arguments are a JSON object keyed by the attribute name.
+        let args: serde_json::Value =
+            serde_json::from_str(row.tool_call_arguments.as_deref().expect("args present")).expect("args is json");
+        assert_eq!(args["full_command"], "git status --short");
+    }
+
+    #[test]
+    fn claude_code_read_tool_projects_file_path_as_arguments() {
+        // The file_path key covers Read/Edit tools that carry no full_command.
+        let span = claude_span(
+            "claude_code.tool",
+            vec![
+                kv_str("tool_name", "Read"),
+                kv_str("file_path", "/repo/src/main.rs"),
+                kv_str("span.type", "tool"),
+            ],
+        );
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("tool span -> row");
+
+        let args: serde_json::Value =
+            serde_json::from_str(row.tool_call_arguments.as_deref().expect("args present")).expect("args is json");
+        assert_eq!(args["file_path"], "/repo/src/main.rs");
+    }
+
+    #[test]
+    fn claude_code_interaction_projects_user_prompt_as_input_messages() {
+        let span = claude_span(
+            "claude_code.interaction",
+            vec![
+                kv_str("span.type", "interaction"),
+                kv_str("user_prompt", "/code-review"),
+            ],
+        );
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("interaction span -> row");
+
+        assert_eq!(row.operation_name, "invoke_agent");
+        // The conversation UI requires input_messages to be a JSON array of
+        // {role, content} messages, so user_prompt is wrapped as a user message.
+        let messages: serde_json::Value =
+            serde_json::from_str(row.input_messages.as_deref().expect("input_messages present")).expect("json array");
+        assert!(messages.is_array(), "input_messages must be a JSON array");
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[0]["content"], "/code-review");
+    }
+
+    #[test]
+    fn otel_time_to_first_chunk_seconds_scales_to_millis() {
+        // OTEL's `gen_ai.response.time_to_first_chunk` is seconds; the resolver
+        // scales it x1000. Guards the unit-aware resolver's seconds branch.
+        let span = span_with(vec![
+            kv_str("gen_ai.operation.name", "chat"),
+            kv_dbl("gen_ai.response.time_to_first_chunk", 1.3),
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("row");
+        assert_eq!(row.time_to_first_chunk_ms, Some(1300));
+    }
+
+    #[test]
+    fn claude_code_negative_input_tokens_drops_row() {
+        // Claude Code's flat token keys inherit the same strict non-negative
+        // contract as every other adapter: a negative count drops the row (D6).
+        let span = claude_span("claude_code.llm_request", vec![kv_str("input_tokens", "-5")]);
+        assert!(project_operation_row(&span, None, "t", None, 1).is_err());
+    }
+
+    #[test]
+    fn claude_code_negative_ttft_ms_drops_row() {
+        // Exercises the unit-aware resolver's negative guard on the `_ms` path.
+        let span = claude_span("claude_code.llm_request", vec![kv_str("ttft_ms", "-1")]);
+        assert!(project_operation_row(&span, None, "t", None, 1).is_err());
+    }
+
+    #[test]
+    fn claude_code_tool_execution_subspan_projects_execute_tool() {
+        // tool.execution carries no gen_ai marker and no tool_name; it qualifies
+        // by the `claude_code.` name prefix and classifies via the tool family.
+        let span = claude_span(
+            "claude_code.tool.execution",
+            vec![
+                kv_str("gen_ai.tool.call.id", "toolu_015wNSz"),
+                kv_str("span.type", "tool.execution"),
+            ],
+        );
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("tool.execution span -> row");
+        assert_eq!(row.operation_name, "execute_tool");
+        assert_eq!(row.tool_call_id.as_deref(), Some("toolu_015wNSz"));
+    }
+
+    #[test]
+    fn claude_code_bash_tool_output_event_is_the_result() {
+        // The whole tool.output event is the tool's result (echoed command +
+        // output); arguments come from span attributes, not the event.
+        let span = claude_span_with_events(
+            "claude_code.tool",
+            vec![kv_str("tool_name", "Bash"), kv_str("span.type", "tool")],
+            vec![tool_output_event(vec![
+                kv_str("bash_command", "git status --short"),
+                kv_str("output", "M src/main.rs"),
+            ])],
+        );
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("tool span -> row");
+
+        // Result is the whole event, including the echoed command.
+        let result: serde_json::Value =
+            serde_json::from_str(row.tool_call_result.as_deref().expect("result present")).expect("result is json");
+        assert_eq!(result["output"], "M src/main.rs");
+        assert_eq!(result["bash_command"], "git status --short");
+
+        // No full_command span attribute and no event->arguments source -> None.
+        assert!(row.tool_call_arguments.is_none());
+    }
+
+    #[test]
+    fn claude_code_read_tool_output_event_is_the_result() {
+        let span = claude_span_with_events(
+            "claude_code.tool",
+            vec![kv_str("tool_name", "Read"), kv_str("span.type", "tool")],
+            vec![tool_output_event(vec![
+                kv_str("file_path", "/repo/main.rs"),
+                kv_str("content", "fn main() {}"),
+            ])],
+        );
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("tool span -> row");
+
+        let result: serde_json::Value =
+            serde_json::from_str(row.tool_call_result.as_deref().expect("result present")).expect("result is json");
+        assert_eq!(result["content"], "fn main() {}");
+        assert_eq!(result["file_path"], "/repo/main.rs");
+
+        assert!(row.tool_call_arguments.is_none());
+    }
+
+    #[test]
+    fn claude_code_tool_arguments_come_from_span_attributes_not_the_event() {
+        // full_command (span attribute) is the input; the tool.output event is the
+        // result. The two are independent sources.
+        let span = claude_span_with_events(
+            "claude_code.tool",
+            vec![
+                kv_str("tool_name", "Bash"),
+                kv_str("full_command", "ls -la"),
+                kv_str("span.type", "tool"),
+            ],
+            vec![tool_output_event(vec![
+                kv_str("bash_command", "ls -la"),
+                kv_str("output", "a\nb"),
+            ])],
+        );
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("tool span -> row");
+
+        // Arguments come from the span attribute (input), as a JSON object.
+        let args: serde_json::Value =
+            serde_json::from_str(row.tool_call_arguments.as_deref().expect("args present")).expect("args is json");
+        assert_eq!(args["full_command"], "ls -la");
+        // Result comes from the event (output).
+        let result: serde_json::Value =
+            serde_json::from_str(row.tool_call_result.as_deref().expect("result present")).expect("result is json");
+        assert_eq!(result["output"], "a\nb");
     }
 }

--- a/crates/icegate-ingest/src/transform/operations/traceloop.rs
+++ b/crates/icegate-ingest/src/transform/operations/traceloop.rs
@@ -28,7 +28,7 @@ impl OperationConvention for Traceloop {
         }
     }
 
-    fn classify_operation(&self, attrs: &AttributeView) -> Option<String> {
+    fn classify_operation(&self, _span_name: &str, attrs: &AttributeView) -> Option<String> {
         let kind = extract_string_value(attrs.get("traceloop.span.kind"))?;
         let normalized = match kind.as_str() {
             "workflow" | "task" => "chain",
@@ -59,7 +59,7 @@ mod tests {
     fn classify(kind: &str) -> Option<String> {
         let attrs = vec![kv_str("traceloop.span.kind", kind)];
         let view = AttributeView::new(&attrs);
-        Traceloop.classify_operation(&view)
+        Traceloop.classify_operation("op", &view)
     }
 
     #[test]
@@ -117,6 +117,6 @@ mod tests {
     fn classify_is_none_without_span_kind() {
         let attrs = vec![kv_str("traceloop.workflow.name", "my_flow")];
         let view = AttributeView::new(&attrs);
-        assert_eq!(Traceloop.classify_operation(&view), None);
+        assert_eq!(Traceloop.classify_operation("op", &view), None);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing and projecting Claude Code operations.
  * Added JSON serialization for span attributes, tool data, and chat messages.
  * Added support for content sourced from span events, including tool results.
  * Added span-name-based operation recognition and improved field mapping.

* **Bug Fixes**
  * Improved time-to-first-chunk conversion across seconds- and milliseconds-based values.
  * Added validation to reject invalid negative or out-of-range measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->