### PR TITLE
fix: Lone name projection on spans

### DIFF
--- a/crates/icegate-query/src/flight_sql/tenant_catalog.rs
+++ b/crates/icegate-query/src/flight_sql/tenant_catalog.rs
@@ -41,9 +41,24 @@
 //! key.
 //!
 //! The inner scan is asked for the visible columns *plus* `tenant_id`
-//! (needed to evaluate the row-level filter); the trailing `tenant_id`
-//! column is then dropped by a [`ProjectionExec`] so the batches handed
-//! back match the advertised schema exactly.
+//! (needed to evaluate the row-level filter), in ascending schema order;
+//! a [`ProjectionExec`] then drops `tenant_id` and restores the caller's
+//! column order, so the batches handed back match the advertised schema
+//! exactly.
+//!
+//! ## Why the inner projection is sorted
+//!
+//! Asking in schema order is load-bearing, not tidiness. A
+//! `TableProvider` may emit a projection in *schema* order rather than the
+//! order it was asked for: the Iceberg reader relabels the batch instead
+//! of reordering it whenever the two orders differ but the projected
+//! columns line up positionally by Arrow type and nullability. A wrapper
+//! that appended `tenant_id` last would then evaluate the tenant
+//! predicate against whichever column landed in that slot, and every row
+//! would silently disappear — `SELECT name FROM spans` returned nothing
+//! while `count(*)` returned the full row count, because `name` and
+//! `tenant_id` are both non-nullable strings. Requesting ascending order
+//! leaves no provider anything to reorder.
 
 use std::any::Any;
 use std::sync::Arc;
@@ -172,7 +187,7 @@ struct TenantScopedTableProvider {
     /// corresponding original-schema index. Used to translate
     /// projections before delegating to `inner.scan(...)`.
     index_map: Arc<[usize]>,
-    /// Original-schema index of the `tenant_id` column, appended to the
+    /// Original-schema index of the `tenant_id` column, merged into the
     /// inner projection so the row-level filter can reference it.
     tenant_col_idx: usize,
     /// Pre-built `tenant_id = '<t>'` predicate, reused for both the
@@ -285,13 +300,16 @@ impl TableProvider for TenantScopedTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        // Visible columns the caller wants, expressed in the inner
-        // provider's original schema (`tenant_id` excluded — it's hidden).
-        let mut scan_projection = self.translate_projection(projection)?;
-        let visible_len = scan_projection.len();
-        // Append `tenant_id` so the row-level filter below can reference
-        // it; it occupies the trailing slot of the inner scan's output.
+        // Visible columns the caller wants, in the caller's order,
+        // expressed in the inner provider's original schema (`tenant_id`
+        // excluded — it's hidden).
+        let visible_columns = self.translate_projection(projection)?;
+        // Add `tenant_id` so the row-level filter below can reference it,
+        // then sort: the inner scan must be asked in schema order (see the
+        // module docs), never in the caller's order.
+        let mut scan_projection = visible_columns.clone();
         scan_projection.push(self.tenant_col_idx);
+        scan_projection.sort_unstable();
 
         // Push the tenant predicate down too, so partition / row-group
         // pruning still skips other tenants' files (Iceberg identity
@@ -314,17 +332,24 @@ impl TableProvider for TenantScopedTableProvider {
         let predicate = state.create_physical_expr(self.tenant_filter.clone(), &df_schema)?;
         let filtered: Arc<dyn ExecutionPlan> = Arc::new(FilterExec::try_new(predicate, inner_plan)?);
 
-        // Drop the trailing `tenant_id` column so the output matches the
-        // advertised (N-1 column) schema. The visible columns occupy
-        // indices `0..visible_len` in the filtered plan.
-        let filtered_schema = filtered.schema();
-        let projection_exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = (0..visible_len)
-            .map(|i| {
-                let name = filtered_schema.field(i).name().clone();
-                let expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new(&name, i));
-                (expr, name)
+        // Drop `tenant_id` and put the visible columns back in the caller's
+        // order, so the output matches the advertised (N-1 column) schema.
+        // Each column's slot in the sorted inner output is found by its
+        // original-schema index.
+        let scan_schema = filtered.schema();
+        let projection_exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = visible_columns
+            .iter()
+            .map(|original_idx| {
+                let slot = scan_projection.binary_search(original_idx).map_err(|_| {
+                    DataFusionError::Internal(format!(
+                        "column {original_idx} is missing from the tenant-scoped scan projection"
+                    ))
+                })?;
+                let name = scan_schema.field(slot).name().clone();
+                let expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new(&name, slot));
+                Ok((expr, name))
             })
-            .collect();
+            .collect::<DataFusionResult<_>>()?;
         let projected: Arc<dyn ExecutionPlan> = Arc::new(ProjectionExec::try_new(projection_exprs, filtered)?);
 
         // Re-apply the caller's limit above the tenant filter.
@@ -359,14 +384,18 @@ impl TableProvider for TenantScopedTableProvider {
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-    use std::sync::Arc;
+    use std::any::Any;
+    use std::sync::{Arc, Mutex};
 
+    use async_trait::async_trait;
     use datafusion::arrow::array::{Array, StringArray};
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::arrow::record_batch::RecordBatch;
-    use datafusion::catalog::{MemorySchemaProvider, SchemaProvider, TableProvider};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+    use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
+    use datafusion::catalog::{MemorySchemaProvider, SchemaProvider, Session, TableProvider};
     use datafusion::datasource::MemTable;
-    use datafusion::physical_plan::collect;
+    use datafusion::error::Result as DataFusionResult;
+    use datafusion::logical_expr::{Expr, TableType};
+    use datafusion::physical_plan::{ExecutionPlan, collect};
     use datafusion::prelude::SessionContext;
     use icegate_common::schema::COL_TENANT_ID;
     use icegate_common::{GLOBAL_TABLES, LOGS_TABLE, PRICES_TABLE};
@@ -486,6 +515,177 @@ mod tests {
         // The decorator projects tenant_id back out of the advertised schema.
         assert_eq!(table.schema().fields().len(), 1);
         assert!(table.schema().field_with_name("tenant_id").is_err());
+    }
+
+    /// Inner provider that emits projected columns in SCHEMA order while
+    /// advertising them in the order it was asked for.
+    ///
+    /// This is the production Iceberg reader's behaviour: when the requested
+    /// order differs from schema order but the projected columns line up
+    /// positionally by Arrow type and nullability, it relabels the batch
+    /// instead of reordering it. A caller that asks in schema order never
+    /// meets the case, because the two orders then coincide.
+    #[derive(Debug)]
+    struct SchemaOrderTableProvider {
+        schema: SchemaRef,
+        batch: RecordBatch,
+        /// Projections received, in call order, so a test can assert what the
+        /// wrapper *asked for* and not only what came back.
+        requests: Mutex<Vec<Vec<usize>>>,
+    }
+
+    #[async_trait]
+    impl TableProvider for SchemaOrderTableProvider {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn schema(&self) -> SchemaRef {
+            Arc::clone(&self.schema)
+        }
+
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+
+        async fn scan(
+            &self,
+            state: &dyn Session,
+            projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+            let requested: Vec<usize> =
+                projection.cloned().unwrap_or_else(|| (0..self.schema.fields().len()).collect());
+            self.requests.lock().unwrap().push(requested.clone());
+
+            let mut schema_order = requested.clone();
+            schema_order.sort_unstable();
+            let columns = schema_order.iter().map(|&i| Arc::clone(self.batch.column(i))).collect();
+
+            let advertised = Arc::new(self.schema.project(&requested)?);
+            let options = RecordBatchOptions::new().with_match_field_names(false);
+            let batch = RecordBatch::try_new_with_options(Arc::clone(&advertised), columns, &options)?;
+            MemTable::try_new(advertised, vec![vec![batch]])?
+                .scan(state, None, &[], None)
+                .await
+        }
+    }
+
+    /// Rows for two tenants where every column is, like `tenant_id`, a
+    /// non-nullable string.
+    ///
+    /// That uniformity is the point: it is exactly the condition under which
+    /// the reader relabels rather than reorders, so any permutation of these
+    /// columns is indistinguishable from the right one by Arrow type alone.
+    /// `spans` has this shape — `name` and `tenant_id` are both required
+    /// strings — and it is the only column of `spans` that reproduced the
+    /// defect.
+    fn spans_shaped_table() -> Arc<SchemaOrderTableProvider> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(COL_TENANT_ID, DataType::Utf8, false),
+            Field::new("name", DataType::Utf8, false),
+            Field::new("level", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec!["tenant-a", "tenant-b", "tenant-a"])),
+                Arc::new(StringArray::from(vec!["lookup", "insert", "commit"])),
+                Arc::new(StringArray::from(vec!["debug", "warn", "info"])),
+            ],
+        )
+        .unwrap();
+        Arc::new(SchemaOrderTableProvider {
+            schema,
+            batch,
+            requests: Mutex::new(Vec::new()),
+        })
+    }
+
+    /// Values of one string column across all batches, in row order.
+    fn string_column(batches: &[RecordBatch], index: usize) -> Vec<Option<String>> {
+        batches
+            .iter()
+            .flat_map(|batch| {
+                let array = batch.column(index).as_any().downcast_ref::<StringArray>().unwrap();
+                (0..array.len())
+                    .map(|i| array.is_valid(i).then(|| array.value(i).to_string()))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn projecting_a_lone_non_nullable_string_column_returns_its_rows() {
+        // Regression: the wrapper appended `tenant_id` *after* the visible
+        // columns, so the inner scan was asked for [name, tenant_id] — an
+        // order the Iceberg reader does not honour. The tenant filter then
+        // read `name` as the tenancy key and dropped every row, which is why
+        // `SELECT name FROM spans` came back empty while `count(*)` reported
+        // the full table.
+        let inner = spans_shaped_table();
+        let provider =
+            TenantScopedTableProvider::new(Arc::clone(&inner) as Arc<dyn TableProvider>, "tenant-a").unwrap();
+
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let plan = provider.scan(&state, Some(&vec![0]), &[], None).await.unwrap();
+        let batches = collect(plan, ctx.task_ctx()).await.unwrap();
+
+        assert_eq!(
+            string_column(&batches, 0),
+            vec![Some("lookup".to_string()), Some("commit".to_string())],
+            "projecting `name` alone must return tenant-a's two rows, never an empty result"
+        );
+    }
+
+    #[tokio::test]
+    async fn inner_scan_is_asked_for_columns_in_ascending_schema_order() {
+        // The wrapper must not require the inner provider to reorder columns.
+        let inner = spans_shaped_table();
+        let provider =
+            TenantScopedTableProvider::new(Arc::clone(&inner) as Arc<dyn TableProvider>, "tenant-a").unwrap();
+
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        // Visible schema is [name, level]; ask for them back to front.
+        provider.scan(&state, Some(&vec![1, 0]), &[], None).await.unwrap();
+
+        let requests = inner.requests.lock().unwrap().clone();
+        assert_eq!(requests.len(), 1, "one scan must issue exactly one inner projection");
+        assert_eq!(
+            requests[0],
+            vec![0, 1, 2],
+            "inner projection must list tenant_id plus the visible columns in ascending schema order"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_output_follows_the_caller_projection_order() {
+        // Sorting the inner projection must not leak into the output: the
+        // caller still gets its columns in the order it asked for.
+        let inner = spans_shaped_table();
+        let provider =
+            TenantScopedTableProvider::new(Arc::clone(&inner) as Arc<dyn TableProvider>, "tenant-a").unwrap();
+
+        let ctx = SessionContext::new();
+        let state = ctx.state();
+        let plan = provider.scan(&state, Some(&vec![1, 0]), &[], None).await.unwrap();
+        assert_eq!(
+            plan.schema().fields().iter().map(|f| f.name().clone()).collect::<Vec<_>>(),
+            vec!["level".to_string(), "name".to_string()]
+        );
+
+        let batches = collect(plan, ctx.task_ctx()).await.unwrap();
+        assert_eq!(
+            string_column(&batches, 0),
+            vec![Some("debug".to_string()), Some("info".to_string())]
+        );
+        assert_eq!(
+            string_column(&batches, 1),
+            vec![Some("lookup".to_string()), Some("commit".to_string())]
+        );
     }
 
     #[tokio::test]

--- a/crates/icegate-query/tests/flight_sql/harness.rs
+++ b/crates/icegate-query/tests/flight_sql/harness.rs
@@ -272,60 +272,74 @@ pub async fn write_spans_file(
     // canonical schema's fields.
     let mut by_name: std::collections::HashMap<&str, ArrayRef> = std::collections::HashMap::new();
     by_name.insert(
-        "tenant_id",
+        schema::COL_TENANT_ID,
         Arc::new(StringArray::from(spans.iter().map(|(t, _)| *t).collect::<Vec<_>>())),
     );
     by_name.insert(
-        "service_name",
+        schema::COL_SERVICE_NAME,
         Arc::new(StringArray::from(vec![Some("svc"); row_count])),
     );
-    by_name.insert("trace_id", Arc::new(trace_id_builder.finish()));
-    by_name.insert("span_id", Arc::new(span_id_builder.finish()));
+    by_name.insert(schema::COL_TRACE_ID, Arc::new(trace_id_builder.finish()));
+    by_name.insert(schema::COL_SPAN_ID, Arc::new(span_id_builder.finish()));
     by_name.insert(
-        "parent_span_id",
+        schema::COL_PARENT_SPAN_ID,
         Arc::new(FixedSizeBinaryArray::try_from_sparse_iter_with_size(
             std::iter::repeat_n(None::<&[u8]>, row_count),
             8,
         )?),
     );
     by_name.insert(
-        "timestamp",
+        schema::COL_TIMESTAMP,
         Arc::new(TimestampMicrosecondArray::from(timestamps.clone())),
     );
-    by_name.insert("end_timestamp", Arc::new(TimestampMicrosecondArray::from(timestamps)));
     by_name.insert(
-        "ingested_timestamp",
+        schema::COL_END_TIMESTAMP,
+        Arc::new(TimestampMicrosecondArray::from(timestamps)),
+    );
+    by_name.insert(
+        schema::COL_INGESTED_TIMESTAMP,
         Arc::new(TimestampMicrosecondArray::from(vec![now_micros; row_count])),
     );
-    by_name.insert("duration_micros", Arc::new(Int64Array::from(vec![1_000i64; row_count])));
     by_name.insert(
-        "trace_state",
+        schema::COL_DURATION_MICROS,
+        Arc::new(Int64Array::from(vec![1_000i64; row_count])),
+    );
+    by_name.insert(
+        schema::COL_TRACE_STATE,
         Arc::new(StringArray::from(vec![None::<&str>; row_count])),
     );
     by_name.insert(
-        "name",
+        schema::COL_NAME,
         Arc::new(StringArray::from(spans.iter().map(|(_, n)| *n).collect::<Vec<_>>())),
     );
-    by_name.insert("kind", Arc::new(Int32Array::from(vec![Some(2); row_count])));
-    by_name.insert("status_code", Arc::clone(&zeros));
+    by_name.insert(schema::COL_KIND, Arc::new(Int32Array::from(vec![Some(2); row_count])));
+    by_name.insert(schema::COL_STATUS_CODE, Arc::clone(&zeros));
     by_name.insert(
-        "status_message",
+        schema::COL_STATUS_MESSAGE,
         Arc::new(StringArray::from(vec![None::<&str>; row_count])),
     );
     by_name.insert(
-        "resource_attributes",
-        build_attribute_map(&arrow_schema, "resource_attributes", &attribute_rows)?,
+        schema::COL_RESOURCE_ATTRIBUTES,
+        build_attribute_map(&arrow_schema, schema::COL_RESOURCE_ATTRIBUTES, &attribute_rows)?,
     );
     by_name.insert(
-        "span_attributes",
-        build_attribute_map(&arrow_schema, "span_attributes", &attribute_rows)?,
+        schema::COL_SPAN_ATTRIBUTES,
+        build_attribute_map(&arrow_schema, schema::COL_SPAN_ATTRIBUTES, &attribute_rows)?,
     );
+    // `icegate_common::schema` exports no `COL_*` constant for these four, so
+    // they stay literals; the emptiness assertion below still catches drift.
     by_name.insert("flags", Arc::clone(&zeros));
     by_name.insert("dropped_attributes_count", Arc::clone(&zeros));
     by_name.insert("dropped_events_count", Arc::clone(&zeros));
     by_name.insert("dropped_links_count", zeros);
-    by_name.insert("events", empty_list_array(&arrow_schema, "events", row_count));
-    by_name.insert("links", empty_list_array(&arrow_schema, "links", row_count));
+    by_name.insert(
+        schema::COL_EVENTS,
+        empty_list_array(&arrow_schema, schema::COL_EVENTS, row_count),
+    );
+    by_name.insert(
+        schema::COL_LINKS,
+        empty_list_array(&arrow_schema, schema::COL_LINKS, row_count),
+    );
 
     let columns: Vec<ArrayRef> = arrow_schema
         .fields()

--- a/crates/icegate-query/tests/flight_sql/harness.rs
+++ b/crates/icegate-query/tests/flight_sql/harness.rs
@@ -19,9 +19,10 @@ use std::time::Duration;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::sql::client::FlightSqlServiceClient;
 use datafusion::arrow::array::{
-    ArrayRef, FixedSizeBinaryBuilder, MapBuilder, MapFieldNames, RecordBatch, StringArray, StringBuilder,
-    TimestampMicrosecondArray,
+    ArrayRef, FixedSizeBinaryArray, FixedSizeBinaryBuilder, Int32Array, Int64Array, ListArray, MapBuilder,
+    MapFieldNames, RecordBatch, StringArray, StringBuilder, TimestampMicrosecondArray,
 };
+use datafusion::arrow::buffer::OffsetBuffer;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::parquet::file::properties::WriterProperties;
 use futures::TryStreamExt;
@@ -229,6 +230,197 @@ pub fn count_from_batches(batches: &[RecordBatch]) -> i64 {
     arr.value(0)
 }
 
+/// Write one span row per `(tenant_id, name)` entry into a SINGLE Parquet
+/// data file and commit it.
+///
+/// `spans` is the table that exposes projection-order bugs: `name` and the
+/// hidden `tenant_id` are both non-nullable strings, so a projection handed
+/// to the Iceberg reader out of schema order comes back relabelled rather
+/// than reordered, and nothing in the Arrow types gives that away. Callers
+/// supply `name` per row so a test can assert the exact values a projection
+/// returns, not merely a row count.
+///
+/// Deliberately narrow, in the spirit of [`write_logs_file`]: every column
+/// the schema requires is populated, but attributes, events, and links carry
+/// only enough content to be valid. `crates/icegate-query/tests/tempo` owns
+/// the richer span fixture used for trace formatting.
+pub async fn write_spans_file(
+    table: &Table,
+    catalog: &Arc<dyn Catalog>,
+    spans: &[(&str, &str)],
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let row_count = spans.len();
+    let now_micros = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_micros() as i64;
+    let arrow_schema = Arc::new(iceberg::arrow::schema_to_arrow_schema(
+        table.metadata().current_schema(),
+    )?);
+
+    let mut trace_id_builder = FixedSizeBinaryBuilder::new(16);
+    let mut span_id_builder = FixedSizeBinaryBuilder::new(8);
+    for i in 0..row_count {
+        trace_id_builder.append_value((i as u128).to_le_bytes())?;
+        span_id_builder.append_value((i as u64).to_le_bytes())?;
+    }
+
+    let attribute_rows: Vec<&[(&str, &str)]> = vec![&[("http.method", "GET")]; row_count];
+    let timestamps: Vec<i64> = (0..row_count).map(|i| now_micros - (i as i64) * 1000).collect();
+    let zeros: ArrayRef = Arc::new(Int32Array::from(vec![Some(0); row_count]));
+
+    // Assemble by name so the fixture survives any reordering of the
+    // canonical schema's fields.
+    let mut by_name: std::collections::HashMap<&str, ArrayRef> = std::collections::HashMap::new();
+    by_name.insert(
+        "tenant_id",
+        Arc::new(StringArray::from(spans.iter().map(|(t, _)| *t).collect::<Vec<_>>())),
+    );
+    by_name.insert(
+        "service_name",
+        Arc::new(StringArray::from(vec![Some("svc"); row_count])),
+    );
+    by_name.insert("trace_id", Arc::new(trace_id_builder.finish()));
+    by_name.insert("span_id", Arc::new(span_id_builder.finish()));
+    by_name.insert(
+        "parent_span_id",
+        Arc::new(FixedSizeBinaryArray::try_from_sparse_iter_with_size(
+            std::iter::repeat_n(None::<&[u8]>, row_count),
+            8,
+        )?),
+    );
+    by_name.insert(
+        "timestamp",
+        Arc::new(TimestampMicrosecondArray::from(timestamps.clone())),
+    );
+    by_name.insert("end_timestamp", Arc::new(TimestampMicrosecondArray::from(timestamps)));
+    by_name.insert(
+        "ingested_timestamp",
+        Arc::new(TimestampMicrosecondArray::from(vec![now_micros; row_count])),
+    );
+    by_name.insert("duration_micros", Arc::new(Int64Array::from(vec![1_000i64; row_count])));
+    by_name.insert(
+        "trace_state",
+        Arc::new(StringArray::from(vec![None::<&str>; row_count])),
+    );
+    by_name.insert(
+        "name",
+        Arc::new(StringArray::from(spans.iter().map(|(_, n)| *n).collect::<Vec<_>>())),
+    );
+    by_name.insert("kind", Arc::new(Int32Array::from(vec![Some(2); row_count])));
+    by_name.insert("status_code", Arc::clone(&zeros));
+    by_name.insert(
+        "status_message",
+        Arc::new(StringArray::from(vec![None::<&str>; row_count])),
+    );
+    by_name.insert(
+        "resource_attributes",
+        build_attribute_map(&arrow_schema, "resource_attributes", &attribute_rows)?,
+    );
+    by_name.insert(
+        "span_attributes",
+        build_attribute_map(&arrow_schema, "span_attributes", &attribute_rows)?,
+    );
+    by_name.insert("flags", Arc::clone(&zeros));
+    by_name.insert("dropped_attributes_count", Arc::clone(&zeros));
+    by_name.insert("dropped_events_count", Arc::clone(&zeros));
+    by_name.insert("dropped_links_count", zeros);
+    by_name.insert("events", empty_list_array(&arrow_schema, "events", row_count));
+    by_name.insert("links", empty_list_array(&arrow_schema, "links", row_count));
+
+    let columns: Vec<ArrayRef> = arrow_schema
+        .fields()
+        .iter()
+        .map(|f| {
+            by_name
+                .remove(f.name().as_str())
+                .unwrap_or_else(|| panic!("spans fixture is missing column `{}`", f.name()))
+        })
+        .collect();
+    assert!(
+        by_name.is_empty(),
+        "spans fixture builds columns the schema does not have: {:?}",
+        by_name.keys()
+    );
+
+    let batch = RecordBatch::try_new(arrow_schema, columns)?;
+    commit_data_file(table, catalog, batch, &format!("spans-{now_micros}")).await
+}
+
+/// A `LIST` column where every row is an empty list.
+fn empty_list_array(schema: &datafusion::arrow::datatypes::Schema, name: &str, length: usize) -> ArrayRef {
+    let field = schema.field_with_name(name).expect("list column present in schema");
+    let DataType::List(inner_field) = field.data_type() else {
+        panic!("expected a List column for `{name}`");
+    };
+    // length+1 zero offsets: every row spans values[0..0), i.e. an empty list.
+    let offsets = OffsetBuffer::new(vec![0i32; length + 1].into());
+    let values = datafusion::arrow::array::new_empty_array(inner_field.data_type());
+    Arc::new(ListArray::new(Arc::clone(inner_field), offsets, values, None))
+}
+
+/// Build a `MAP<STRING,STRING>` column from per-row key/value pairs.
+fn build_attribute_map(
+    schema: &datafusion::arrow::datatypes::Schema,
+    name: &str,
+    rows: &[&[(&str, &str)]],
+) -> Result<ArrayRef, Box<dyn std::error::Error>> {
+    let field = schema.field_with_name(name).expect("map column present in schema");
+    let (key_field, value_field) = match field.data_type() {
+        DataType::Map(entries_field, _) => match entries_field.data_type() {
+            DataType::Struct(fields) => (fields[0].clone(), fields[1].clone()),
+            other => panic!("expected Struct entries for `{name}`, got {other:?}"),
+        },
+        other => panic!("expected a Map column for `{name}`, got {other:?}"),
+    };
+    let field_names = MapFieldNames {
+        entry: "key_value".to_string(),
+        key: "key".to_string(),
+        value: "value".to_string(),
+    };
+    let mut builder = MapBuilder::new(Some(field_names), StringBuilder::new(), StringBuilder::new())
+        .with_keys_field(key_field)
+        .with_values_field(value_field);
+    for row in rows {
+        for (key, value) in *row {
+            builder.keys().append_value(*key);
+            builder.values().append_value(*value);
+        }
+        builder.append(true)?;
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+/// Write one batch as a single Parquet data file and commit it to `table`.
+async fn commit_data_file(
+    table: &Table,
+    catalog: &Arc<dyn Catalog>,
+    batch: RecordBatch,
+    file_suffix: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let location_generator = DefaultLocationGenerator::new(table.metadata().clone())?;
+    let file_name_generator = DefaultFileNameGenerator::new(file_suffix.to_string(), None, DataFileFormat::Parquet);
+    let parquet_writer_builder = ParquetWriterBuilder::new(
+        WriterProperties::builder().build(),
+        table.metadata().current_schema().clone(),
+    );
+    let rolling_file_writer_builder = RollingFileWriterBuilder::new_with_default_file_size(
+        parquet_writer_builder,
+        table.file_io().clone(),
+        location_generator,
+        file_name_generator,
+    );
+    let data_file_writer_builder = DataFileWriterBuilder::new(rolling_file_writer_builder);
+    let mut data_file_writer = data_file_writer_builder.build(None).await?;
+    data_file_writer.write(batch).await?;
+    let data_files = data_file_writer.close().await?;
+
+    let tx = Transaction::new(table);
+    let action = tx.fast_append().add_data_files(data_files);
+    let tx = action.apply(Transaction::new(table))?;
+    tx.commit(&**catalog).await?;
+    Ok(())
+}
+
 /// Write three rows of log data for the given tenant.
 ///
 /// Thin wrapper over [`write_logs_file`] for the common single-tenant
@@ -361,26 +553,5 @@ pub async fn write_logs_file(
         ],
     )?;
 
-    let location_generator = DefaultLocationGenerator::new(table.metadata().clone())?;
-    let file_name_generator = DefaultFileNameGenerator::new(unique_suffix, None, DataFileFormat::Parquet);
-    let parquet_writer_builder = ParquetWriterBuilder::new(
-        WriterProperties::builder().build(),
-        table.metadata().current_schema().clone(),
-    );
-    let rolling_file_writer_builder = RollingFileWriterBuilder::new_with_default_file_size(
-        parquet_writer_builder,
-        table.file_io().clone(),
-        location_generator,
-        file_name_generator,
-    );
-    let data_file_writer_builder = DataFileWriterBuilder::new(rolling_file_writer_builder);
-    let mut data_file_writer = data_file_writer_builder.build(None).await?;
-    data_file_writer.write(batch).await?;
-    let data_files = data_file_writer.close().await?;
-
-    let tx = Transaction::new(table);
-    let action = tx.fast_append().add_data_files(data_files);
-    let tx = action.apply(Transaction::new(table))?;
-    tx.commit(&**catalog).await?;
-    Ok(())
+    commit_data_file(table, catalog, batch, &unique_suffix).await
 }

--- a/crates/icegate-query/tests/flight_sql/mod.rs
+++ b/crates/icegate-query/tests/flight_sql/mod.rs
@@ -3,6 +3,7 @@
 mod harness;
 mod metadata;
 mod pricing;
+mod projection;
 mod read_only;
 mod smoke;
 mod tenant;

--- a/crates/icegate-query/tests/flight_sql/projection.rs
+++ b/crates/icegate-query/tests/flight_sql/projection.rs
@@ -1,0 +1,95 @@
+//! Column projection through the tenant-scoped table provider.
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::print_stdout,
+    clippy::uninlined_format_args
+)]
+
+use datafusion::arrow::array::{Array, RecordBatch, StringArray};
+use icegate_common::{ICEGATE_NAMESPACE, SPANS_TABLE};
+
+use super::harness::{TestServer, count_from_batches, execute_sql, write_spans_file};
+
+/// Every value of one string column, sorted — the projection contract is the
+/// row multiset, not its order (no `ORDER BY` is issued).
+fn sorted_strings(batches: &[RecordBatch], column: usize) -> Vec<String> {
+    let mut values: Vec<String> = batches
+        .iter()
+        .flat_map(|batch| {
+            let array = batch
+                .column(column)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("string column");
+            (0..array.len())
+                .map(|i| {
+                    assert!(array.is_valid(i), "spans.name is non-nullable");
+                    array.value(i).to_string()
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    values.sort();
+    values
+}
+
+/// Projecting `spans.name` on its own must return the same rows `count(*)`
+/// reports.
+///
+/// `name` and the hidden `tenant_id` are both non-nullable strings. When the
+/// wrapper appended `tenant_id` after the visible columns, the Iceberg reader
+/// received `[name, tenant_id]` — an order it does not honour — and relabelled
+/// the batch instead of reordering it, so the injected tenant predicate was
+/// evaluated against span names. Every row was discarded: `SELECT name`
+/// returned nothing while `count(*)` returned the full table.
+#[tokio::test]
+async fn projecting_name_alone_returns_the_same_rows_as_count() -> Result<(), Box<dyn std::error::Error>> {
+    let (server, catalog) = TestServer::start().await?;
+
+    // All three rows land in ONE data file, so the file's `tenant_id`
+    // statistics span both tenants and isolation can only come from the
+    // wrapper's row-level filter — the same layout as a WAL hot segment.
+    let table_ident = iceberg::TableIdent::from_strs([ICEGATE_NAMESPACE, SPANS_TABLE])?;
+    let table = catalog.load_table(&table_ident).await?;
+    write_spans_file(
+        &table,
+        &catalog,
+        &[
+            ("tenant-alpha", "GET /health"),
+            ("tenant-beta", "POST /orders"),
+            ("tenant-alpha", "db query"),
+        ],
+    )
+    .await?;
+
+    let mut client_alpha = server.client(Some("tenant-alpha"));
+    let counted =
+        count_from_batches(&execute_sql(&mut client_alpha, "SELECT count(*) FROM iceberg.icegate.spans").await?);
+    assert_eq!(counted, 2, "tenant-alpha wrote two spans");
+
+    // Expected values are listed in ASCII order ('G' < 'd') to match the
+    // canonicalising sort in `sorted_strings`.
+    let expected = vec!["GET /health".to_string(), "db query".to_string()];
+
+    let batches = execute_sql(&mut client_alpha, "SELECT name FROM iceberg.icegate.spans").await?;
+    assert_eq!(
+        sorted_strings(&batches, 0),
+        expected,
+        "a lone `name` projection must return every row `count(*)` counted"
+    );
+
+    // Adding a second column always worked, even while the lone projection
+    // was broken; it must keep returning the same names.
+    let batches = execute_sql(&mut client_alpha, "SELECT span_id, name FROM iceberg.icegate.spans").await?;
+    assert_eq!(sorted_strings(&batches, 1), expected);
+
+    // Cross-tenant negative: tenant-beta sees only its own span name, never
+    // tenant-alpha's rows from the same file.
+    let mut client_beta = server.client(Some("tenant-beta"));
+    let batches = execute_sql(&mut client_beta, "SELECT name FROM iceberg.icegate.spans").await?;
+    assert_eq!(sorted_strings(&batches, 0), vec!["POST /orders".to_string()]);
+
+    server.shutdown().await;
+    Ok(())
+}

--- a/crates/icegate-query/tests/flight_sql/projection.rs
+++ b/crates/icegate-query/tests/flight_sql/projection.rs
@@ -1,10 +1,5 @@
 //! Column projection through the tenant-scoped table provider.
-#![allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::print_stdout,
-    clippy::uninlined_format_args
-)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use datafusion::arrow::array::{Array, RecordBatch, StringArray};
 use icegate_common::{ICEGATE_NAMESPACE, SPANS_TABLE};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tenant-scoped queries with projected columns returning incorrect or missing results.
  * Preserved the requested column order while applying tenant filtering.
  * Ensured tenant isolation remains correct when multiple tenants share the same data file.

* **Tests**
  * Added coverage for single-column projections, multi-column projections, column ordering, and tenant-specific results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->