### PR TITLE
Add tracing to maintain

### DIFF
--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -148,8 +148,10 @@ services:
       AWS_SECRET_ACCESS_KEY: rustfsadmin
       AWS_REGION: us-east-1
       RUST_LOG: "info,icegate_maintain=debug,jobmanager=debug,icegate_common=debug,aws_sdk_s3=warn,aws_smithy_runtime=warn"
-      # `maintain run` initialises tracing and refuses to start without an OTLP endpoint.
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      # The OTLP endpoint lives in `maintain.yaml` (`tracing.otlp_endpoint`), which
+      # wins over `OTEL_EXPORTER_OTLP_ENDPOINT`; setting both here would leave a
+      # second, silently-ignored source of truth. `OTEL_SERVICE_NAME` stays: it is
+      # read by the SDK's resource detector, not by the config file.
       OTEL_SERVICE_NAME: icegate-maintain
     healthcheck:
       test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/localhost/9091' || exit 1"]

--- a/config/docker/maintain.yaml
+++ b/config/docker/maintain.yaml
@@ -105,3 +105,11 @@ metrics:
   host: 0.0.0.0
   port: 9091
   path: /metrics
+
+# OpenTelemetry tracing for the long-running `maintain run` service; the
+# one-shot `migrate` commands share this file but never read this block.
+# Fields and their defaults: `icegate_common::TracingConfig`.
+tracing:
+  enabled: true
+  otlp_endpoint: http://jaeger:4317
+  sample_ratio: 1.0

--- a/config/helm/icegate/templates/configmap-maintain.yaml
+++ b/config/helm/icegate/templates/configmap-maintain.yaml
@@ -99,4 +99,13 @@ data:
       host: "0.0.0.0"
       port: {{ .Values.maintain.metrics.port }}
       path: {{ .Values.maintain.metrics.path | quote }}
+    tracing:
+      enabled: {{ .Values.maintain.tracing.enabled }}
+      {{- if .Values.maintain.tracing.enabled }}
+      {{/* Guarded rather than optional (as in configmap-ingest): the run service
+           refuses to start without an endpoint, so a missing one is better caught
+           at `helm install` than as a CrashLoopBackOff. */}}
+      otlp_endpoint: {{ required "maintain.tracing.otlpEndpoint is required when maintain.tracing.enabled is true: the maintain run service refuses to start without an OTLP endpoint" .Values.maintain.tracing.otlpEndpoint | quote }}
+      {{- end }}
+      sample_ratio: {{ .Values.maintain.tracing.sampleRatio }}
 {{- end }}

--- a/config/helm/icegate/templates/deployment-maintain.yaml
+++ b/config/helm/icegate/templates/deployment-maintain.yaml
@@ -55,11 +55,6 @@ spec:
               value: {{ .Values.maintain.rustLog | quote }}
             - name: OTEL_SERVICE_NAME
               value: icegate-maintain
-            # The `maintain run` service always initialises tracing and refuses to
-            # start without an OTLP endpoint (it carries no tracing config block),
-            # so this env var is required whenever compaction is enabled.
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: {{ required "maintain.tracing.otlpEndpoint is required when maintain.enabled is true: the maintain run service refuses to start without an OTLP endpoint" .Values.maintain.tracing.otlpEndpoint | quote }}
             {{- with .Values.maintain.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/config/helm/icegate/values.yaml
+++ b/config/helm/icegate/values.yaml
@@ -517,9 +517,10 @@ migrate:
 ## unreferenced S3 objects). Runs as a Deployment; each sub-feature loops on its
 ## own `jobsmanager.scanIntervalSecs`.
 ##
-## Disabled by default: the `maintain run` binary always initialises tracing and
-## refuses to start without an OTLP endpoint, so enabling it REQUIRES setting
-## `maintain.tracing.otlpEndpoint` (a Helm `required` guard enforces it).
+## Disabled by default. With the default `maintain.tracing.enabled: true` the
+## `run` service refuses to start without an OTLP endpoint, so enabling it also
+## requires setting `maintain.tracing.otlpEndpoint` (a Helm `required` guard
+## enforces it) or turning `maintain.tracing.enabled` off.
 maintain:
   enabled: false
   ## Replicas may be scaled out. The jobmanager distributes rewrite tasks across
@@ -732,10 +733,13 @@ maintain:
     type: ClusterIP
     annotations: {}
 
-  ## OpenTelemetry tracing. The OTLP endpoint is mandatory (see note above):
-  ## it is exported as OTEL_EXPORTER_OTLP_ENDPOINT (gRPC, e.g. host:4317).
+  ## OpenTelemetry tracing, rendered into the maintain ConfigMap exactly as for
+  ## ingest and query. With tracing enabled the service refuses to start without
+  ## an endpoint, so set otlpEndpoint (gRPC, e.g. host:4317) or turn tracing off.
   tracing:
+    enabled: true
     otlpEndpoint: ""
+    sampleRatio: 1.0
 
   ## RUST_LOG level
   rustLog: "info"

--- a/config/kustomize/overlays/skaffold/values-icegate.yaml
+++ b/config/kustomize/overlays/skaffold/values-icegate.yaml
@@ -185,7 +185,9 @@ maintain:
         jobStateCodec: json
         requestTimeoutSecs: 5
   tracing:
+    enabled: true
     otlpEndpoint: http://otel-collector.observability.svc.cluster.local.:4317
+    sampleRatio: 1.0
   rustLog: "info,icegate_maintain=debug,jobmanager=debug,icegate_common=debug,opendal=debug,aws_sdk_s3=warn,aws_smithy_http=warn,aws_smithy_client=warn,aws_smithy_runtime=warn,aws_smithy_runtime_api=warn,opendal::services::s3::backend=info"
   resources:
     requests:

--- a/crates/icegate-common/src/tracing.rs
+++ b/crates/icegate-common/src/tracing.rs
@@ -615,6 +615,21 @@ mod tests {
         }
     }
 
+    /// The rule callers depend on: a traceparent is accepted only when it
+    /// resolves to a VALID `SpanContext`. Callers branch on the returned `bool`
+    /// (compaction logs the rejection and carries on rather than failing its
+    /// task), so both rejected shapes are pinned here: bytes that do not parse at
+    /// all, and a well-formed header whose all-zero ids the W3C spec defines as
+    /// invalid.
+    #[test]
+    fn add_span_link_rejects_malformed_and_zeroed_traceparents() {
+        assert!(!add_span_link("not-a-traceparent"));
+        assert!(!add_span_link(
+            "00-00000000000000000000000000000000-0000000000000000-01"
+        ));
+        assert!(add_span_link("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"));
+    }
+
     /// Sanity check: the always-present keys (`timestamp`, `level`,
     /// `target`, `fields`, `threadId`) survive the rewrite, and a log
     /// outside any span has neither a `span` object nor any trace

--- a/crates/icegate-maintain/src/cli/commands/run.rs
+++ b/crates/icegate-maintain/src/cli/commands/run.rs
@@ -16,21 +16,30 @@ use crate::{compact::Compactor, config::MaintainConfig, error::MaintainError, gc
 
 /// Execute the run command.
 ///
-/// Loads the maintain configuration, starts the Prometheus metrics server (when
-/// `metrics.enabled`), builds the Iceberg catalog, starts the compaction
-/// service and (when enabled) the orphan-file GC service and the LLM pricing
-/// crawler, then blocks until a shutdown signal arrives. On shutdown all
-/// worker pools are drained and the metrics server is stopped before
+/// Loads the maintain configuration, initialises tracing, starts the Prometheus
+/// metrics server (when `metrics.enabled`), builds the Iceberg catalog, starts
+/// the compaction service and (when enabled) the orphan-file GC service and the
+/// LLM pricing crawler, then blocks until a shutdown signal arrives. On shutdown
+/// all worker pools are drained and the metrics server is stopped before
 /// returning.
 ///
 /// # Errors
 ///
-/// Returns [`MaintainError`] if the configuration cannot be loaded, the metrics
-/// runtime cannot be built, the catalog cannot be built, the compactor, GC
-/// runner, or pricing crawler cannot start, or any worker pool stops with an
-/// error during shutdown.
+/// Returns [`MaintainError`] if the configuration cannot be loaded, the tracing
+/// block is invalid or its subscriber cannot be initialised, the metrics runtime
+/// cannot be built, the catalog cannot be built, the compactor, GC runner, or
+/// pricing crawler cannot start, or any worker pool stops with an error during
+/// shutdown.
 pub async fn execute(config_path: PathBuf) -> Result<(), MaintainError> {
     let config = MaintainConfig::from_file(&config_path).map_err(|e| MaintainError::Config(e.to_string()))?;
+
+    // Tracing first: everything below logs, and the subscriber must be installed
+    // before the first event so no startup line is dropped. `MaintainConfig` does
+    // not validate this block (see its `validate` doc), so validate it here — the
+    // sample ratio and the endpoint requirement are checked before any exporter is
+    // built. The guard flushes pending spans when it drops at end of scope.
+    config.tracing.validate()?;
+    let _tracing_guard = icegate_common::init_tracing(&config.tracing)?;
 
     // Initialise metrics BEFORE building the compactor: `MetricsRuntime::new`
     // installs the global meter provider, and the compactor's `CompactMetrics`

--- a/crates/icegate-maintain/src/compact/README.md
+++ b/crates/icegate-maintain/src/compact/README.md
@@ -31,6 +31,16 @@ catalog (so concurrent ingest commits are tolerated). `compact_plan` also fans
 out one `compact_manifest` task, gated on those rewrites, that repacks the
 manifests they leave behind.
 
+Every fanned-out task opens its OWN trace and joins the planner's by a **span
+link**, not by parent-child: a link is the only relation that spans two traces,
+and the tasks genuinely are separate traces (see
+[`tasks::link_planning_span`](tasks.rs)). The link graph is a star centred on
+PLAN — both REWRITE and MANIFEST link to PLAN, and no `rewrite → manifest` edge
+is built even though the dependency exists: a REWRITE task's output is empty, so
+the repack would have to read every dependency's job state purely for telemetry.
+Tasks queued before the payload field existed (and any run with tracing disabled)
+simply carry no link.
+
 #### Job scheme
 ```mermaid
 flowchart TD

--- a/crates/icegate-maintain/src/compact/data/rewrite.rs
+++ b/crates/icegate-maintain/src/compact/data/rewrite.rs
@@ -69,6 +69,12 @@ pub struct RewriteInput {
     pub partition_key: String,
     /// Input data-file paths, in sorted order (position = index).
     pub input_file_paths: Vec<String>,
+    /// W3C traceparent of the PLAN span that fanned this rewrite out; the REWRITE
+    /// task links its span back to it (see [`crate::compact::tasks`]). `None` when
+    /// the planner ran with no active trace context (tracing disabled) or the
+    /// payload predates the field.
+    #[serde(default)]
+    pub trace_context: Option<String>,
 }
 
 /// Outcome of executing one REWRITE task.
@@ -170,12 +176,26 @@ impl CompactFilesExecutor {
         // Step 1: load the table FRESH. The transaction commit reloads it again
         // and guards concurrency itself, so this load only needs to be recent
         // enough to plan the merge against the live data files.
-        let table = self.catalog.load_table(&table_ident).await?;
+        let table = self
+            .catalog
+            .load_table(&table_ident)
+            .instrument(info_span!("compact_load_table", table = input.table.as_str()))
+            .await?;
 
         // Step 2: enumerate the partition's live data files and match the planned
         // input paths. A missing input means a sibling compactor already took it;
         // abort before doing any merge/write work.
-        let Some(matched) = self.match_inputs(&table, &input.partition_key, &input.input_file_paths).await? else {
+        let match_span = info_span!(
+            "compact_match_inputs",
+            table = input.table.as_str(),
+            partition = input.partition_key.as_str(),
+            input_files = input.input_file_paths.len()
+        );
+        let Some(matched) = self
+            .match_inputs(&table, &input.partition_key, &input.input_file_paths)
+            .instrument(match_span)
+            .await?
+        else {
             self.metrics.record_commit_aborted(&input.table);
             return Ok(RewriteOutcome::Aborted);
         };
@@ -192,7 +212,18 @@ impl CompactFilesExecutor {
         // parquet. `added` is committed verbatim (the transaction's internal
         // retry replays it without re-merging).
         let merged_stream = self.build_merge_stream(&table, &matched, cancel)?;
-        let written = write_record_batches_to_parquet(table.clone(), self.write_cfg, merged_stream, cancel).await?;
+        // The merge itself is lazy: it runs inside the write pipeline as it pulls
+        // batches, so this span covers read + merge + encode together — the bulk
+        // of a REWRITE task's wall clock.
+        let write_span = info_span!(
+            "compact_merge_write",
+            table = input.table.as_str(),
+            partition = input.partition_key.as_str(),
+            input_files = matched.len()
+        );
+        let written = write_record_batches_to_parquet(table.clone(), self.write_cfg, merged_stream, cancel)
+            .instrument(write_span)
+            .await?;
         let output_files = written.data_files.len();
         let rows = written.rows_written;
         let added = written.data_files;
@@ -470,5 +501,44 @@ async fn cleanup_orphaned_outputs(file_io: &FileIO, paths: &[String]) {
                 "failed to delete orphaned compaction output after a failed rewrite"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RewriteInput;
+
+    /// REWRITE payloads outlive the process that wrote them: a task queued
+    /// before `trace_context` existed is still sitting in S3 job-state when the
+    /// upgraded binary picks it up. Parsing it MUST succeed with no context
+    /// rather than failing the task on an unknown-shape payload.
+    #[test]
+    fn rewrite_payload_without_trace_context_parses_with_none() {
+        let legacy = r#"{"table":"logs","partition_key":"tenant-a/2026-01-01","input_file_paths":["a.parquet"]}"#;
+
+        let input: RewriteInput = serde_json::from_str(legacy).expect("payload predating trace_context must parse");
+
+        assert_eq!(input.table, "logs");
+        assert_eq!(input.input_file_paths, vec!["a.parquet".to_string()]);
+        assert_eq!(input.trace_context, None);
+    }
+
+    /// The traceparent is what joins a fanned-out REWRITE back to its PLAN, so
+    /// it has to survive the serialize -> job-state -> deserialize hop verbatim.
+    #[test]
+    fn rewrite_payload_round_trips_trace_context() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let input = RewriteInput {
+            table: "spans".to_string(),
+            partition_key: "tenant-b/2026-01-02".to_string(),
+            input_file_paths: vec!["b.parquet".to_string()],
+            trace_context: Some(traceparent.to_string()),
+        };
+
+        let encoded = serde_json::to_vec(&input).expect("serialize rewrite input");
+        let decoded: RewriteInput = serde_json::from_slice(&encoded).expect("deserialize rewrite input");
+
+        assert_eq!(decoded, input);
+        assert_eq!(decoded.trace_context.as_deref(), Some(traceparent));
     }
 }

--- a/crates/icegate-maintain/src/compact/manifest/rewrite.rs
+++ b/crates/icegate-maintain/src/compact/manifest/rewrite.rs
@@ -35,6 +35,12 @@ const MANIFEST_REWRITE_MARKER_VALUE: &str = "true";
 pub struct ManifestCompactInput {
     /// Table name within the `icegate` namespace (e.g. `logs`, `spans`).
     pub table: String,
+    /// W3C traceparent of the PLAN span that scheduled this repack; the MANIFEST
+    /// task links its span back to it (see [`crate::compact::tasks`]). `None` when
+    /// the planner ran with no active trace context (tracing disabled) or the
+    /// payload predates the field.
+    #[serde(default)]
+    pub trace_context: Option<String>,
 }
 
 /// Outcome of executing one `compact_manifest` task.
@@ -104,7 +110,11 @@ impl ManifestCompactExecutor {
         // Load the table FRESH. The transaction commit reloads it again and guards
         // concurrency itself, so this load only needs to be recent enough to plan
         // the repack against the live manifest list.
-        let table = self.catalog.load_table(&table_ident).await?;
+        let table = self
+            .catalog
+            .load_table(&table_ident)
+            .instrument(info_span!("compact_manifest_load_table", table = input.table.as_str()))
+            .await?;
 
         // Without a current snapshot there are no manifests to repack.
         if table.metadata().current_snapshot_id().is_none() {
@@ -115,7 +125,12 @@ impl ManifestCompactExecutor {
             return Ok(ManifestCompactOutcome::Skipped);
         }
 
-        let entries = list_manifest_entries(&table).await?;
+        let entries = list_manifest_entries(&table)
+            .instrument(info_span!(
+                "compact_manifest_list_entries",
+                table = input.table.as_str()
+            ))
+            .await?;
         let (partition_spec_id, selected) = match plan_manifest_compaction(
             &entries,
             self.target_manifest_size_bytes,
@@ -259,5 +274,41 @@ impl ManifestCompactExecutor {
         let manifests_after = list_manifest_entries(&table).await?.len();
         let carried = manifests_before.saturating_sub(input_manifests);
         Ok(manifests_after.saturating_sub(carried))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ManifestCompactInput;
+
+    /// A MANIFEST task queued before `trace_context` existed is still in S3
+    /// job-state when the upgraded binary picks it up, so the old payload shape
+    /// MUST keep parsing instead of failing the task.
+    #[test]
+    fn manifest_payload_without_trace_context_parses_with_none() {
+        let legacy = r#"{"table":"logs"}"#;
+
+        let input: ManifestCompactInput =
+            serde_json::from_str(legacy).expect("payload predating trace_context must parse");
+
+        assert_eq!(input.table, "logs");
+        assert_eq!(input.trace_context, None);
+    }
+
+    /// The traceparent links the repack back to the PLAN that scheduled it, so
+    /// it must survive the serialize -> job-state -> deserialize hop verbatim.
+    #[test]
+    fn manifest_payload_round_trips_trace_context() {
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let input = ManifestCompactInput {
+            table: "spans".to_string(),
+            trace_context: Some(traceparent.to_string()),
+        };
+
+        let encoded = serde_json::to_vec(&input).expect("serialize manifest compact input");
+        let decoded: ManifestCompactInput = serde_json::from_slice(&encoded).expect("deserialize");
+
+        assert_eq!(decoded, input);
+        assert_eq!(decoded.trace_context.as_deref(), Some(traceparent));
     }
 }

--- a/crates/icegate-maintain/src/compact/tasks.rs
+++ b/crates/icegate-maintain/src/compact/tasks.rs
@@ -10,6 +10,11 @@
 //! tasks IS a jobmanager operation, so [`PlanTaskRunner`] holds the planning
 //! I/O itself and delegates only the pure bin-packing to
 //! [`crate::compact::data::planner`].
+//!
+//! This layer also owns the trace handoff across the fan-out: PLAN puts its own
+//! W3C traceparent into every task payload, and the runner that picks the task up
+//! adds it to its span as a span link — see `link_planning_span` in this module
+//! for why a link, and not a parent, is what joins them.
 
 use std::sync::Arc;
 
@@ -68,7 +73,13 @@ impl PlanTaskRunner {
         manager: &dyn JobManager,
         cancel: &CancellationToken,
     ) -> std::result::Result<(), JobError> {
-        let span = info_span!("compact_plan", table = self.spec.table);
+        // `rewrite_groups` is only known once the planner has run; declare it
+        // empty and fill it in from `run_plan` via `Span::record`.
+        let span = info_span!(
+            "compact_plan",
+            table = self.spec.table,
+            rewrite_groups = tracing::field::Empty
+        );
         self.run_plan(task, manager, cancel).instrument(span).await
     }
 
@@ -93,6 +104,7 @@ impl PlanTaskRunner {
         let table = self
             .catalog
             .load_table(&table_ident)
+            .instrument(info_span!("compact_plan_load_table", table = self.spec.table))
             .await
             .map_err(|e| JobError::TaskExecution(format!("failed to load table '{}': {e}", self.spec.table)))?;
 
@@ -109,11 +121,13 @@ impl PlanTaskRunner {
 
         check_cancellation(cancel)?;
         let stats = list_data_files_with_stats(&table, self.spec.descriptor)
+            .instrument(info_span!("compact_plan_list_data_files", table = self.spec.table))
             .await
             .map_err(|e| JobError::TaskExecution(format!("failed to enumerate data files: {e}")))?;
 
         let outcome = plan_rewrite_groups(stats, &self.planner_limits);
         let group_count = outcome.groups.len();
+        tracing::Span::current().record("rewrite_groups", group_count);
         // PLAN telemetry: groups fanned out, plus the partition compacted/skipped
         // split. `usize -> u64` is lossless on every supported (<= 64-bit) target.
         self.metrics.record_plan(
@@ -126,6 +140,9 @@ impl PlanTaskRunner {
         // Ids of the REWRITE tasks fanned out this iteration; a `compact_manifest`
         // task depends on them so it runs only after data compaction settles.
         let mut rewrite_ids = Vec::new();
+        // Every task of this fan-out links back to the same `compact_plan` span,
+        // so the context is extracted once rather than per group.
+        let plan_trace_context = icegate_common::extract_current_trace_context();
         for group in outcome.groups {
             // Stop fanning out promptly on shutdown. Tasks already submitted stay
             // queued; the immutable PLAN task re-runs next cycle and re-derives the
@@ -149,6 +166,7 @@ impl PlanTaskRunner {
                 table: self.spec.table.to_string(),
                 partition_key,
                 input_file_paths,
+                trace_context: plan_trace_context.clone(),
             };
             let payload = serde_json::to_vec(&rewrite_input)
                 .map_err(|e| JobError::TaskExecution(format!("failed to serialize rewrite input: {e}")))?;
@@ -165,6 +183,7 @@ impl PlanTaskRunner {
 
         let manifest_input = ManifestCompactInput {
             table: self.spec.table.to_string(),
+            trace_context: plan_trace_context,
         };
         let payload = serde_json::to_vec(&manifest_input)
             .map_err(|e| JobError::TaskExecution(format!("failed to serialize manifest compact input: {e}")))?;
@@ -218,6 +237,7 @@ impl CompactFilesRunner {
         let input: RewriteInput = serde_json::from_slice(task.get_input())
             .map_err(|e| JobError::TaskExecution(format!("failed to parse rewrite input: {e}")))?;
         tracing::Span::current().record("partition", input.partition_key.as_str());
+        link_planning_span(input.trace_context.as_deref());
 
         let outcome = self
             .executor
@@ -289,6 +309,7 @@ impl CompactManifestRunner {
         check_cancellation(cancel)?;
         let input: ManifestCompactInput = serde_json::from_slice(task.get_input())
             .map_err(|e| JobError::TaskExecution(format!("failed to parse manifest compact input: {e}")))?;
+        link_planning_span(input.trace_context.as_deref());
 
         let outcome = self.executor.execute(&input, cancel).await.map_err(|e| {
             JobError::TaskExecution(format!("manifest compaction of table '{}' failed: {e}", self.table))
@@ -351,6 +372,21 @@ pub fn manifest_executor_fn(runner: Arc<CompactManifestRunner>) -> TaskExecutorF
     })
 }
 
+/// Link the current task span back to the PLAN span that fanned this task out.
+///
+/// A fanned-out task is picked up by a worker with no ambient trace context —
+/// possibly in another process — so it opens a NEW trace. The link is what joins
+/// the two in the trace backend. Silently does nothing when the planner carried
+/// no context (tracing disabled) or the traceparent is unparseable, since a task
+/// must never fail over telemetry.
+fn link_planning_span(trace_context: Option<&str>) {
+    if let Some(traceparent) = trace_context {
+        if !icegate_common::add_span_link(traceparent) {
+            tracing::debug!(traceparent, "compaction task carries an invalid plan traceparent");
+        }
+    }
+}
+
 /// Return a task error if `cancel` has been triggered, so a task stops at the
 /// next checkpoint on shutdown.
 ///
@@ -362,4 +398,23 @@ fn check_cancellation(cancel: &CancellationToken) -> std::result::Result<(), Job
         return Err(JobError::TaskExecution("compaction task cancelled".to_string()));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::link_planning_span;
+
+    /// The declared contract is "a task must never fail over telemetry", so the
+    /// only thing to prove here is that no payload shape aborts the task: an
+    /// absent context, unparseable bytes, and a well-formed traceparent whose
+    /// all-zero ids make the `SpanContext` invalid all return normally. There is
+    /// nothing to assert on — the function returns `()`; which traceparents are
+    /// rejected is `add_span_link`'s rule and is tested where it lives
+    /// (`icegate_common::tracing`).
+    #[test]
+    fn link_planning_span_never_fails_the_task() {
+        link_planning_span(None);
+        link_planning_span(Some("not-a-traceparent"));
+        link_planning_span(Some("00-00000000000000000000000000000000-0000000000000000-01"));
+    }
 }

--- a/crates/icegate-maintain/src/config.rs
+++ b/crates/icegate-maintain/src/config.rs
@@ -5,7 +5,7 @@
 
 use std::path::Path;
 
-use icegate_common::{CatalogConfig, MetricsConfig, StorageConfig};
+use icegate_common::{CatalogConfig, MetricsConfig, StorageConfig, TracingConfig};
 use serde::{Deserialize, Serialize};
 
 use crate::compact::config::CompactionConfig;
@@ -41,6 +41,12 @@ pub struct MaintainConfig {
     /// compactor's `CompactMetrics` record) and serves `/metrics`.
     #[serde(default)]
     pub metrics: MetricsConfig,
+    /// `OpenTelemetry` tracing for the long-running `run` service, which
+    /// initialises the subscriber from this block once the config is loaded. The
+    /// one-shot `migrate` commands never reach it: they install a plain JSON
+    /// logger in `main` before any config file is read.
+    #[serde(default)]
+    pub tracing: TracingConfig,
 }
 
 impl MaintainConfig {
@@ -58,15 +64,16 @@ impl MaintainConfig {
     /// Validate the always-required shared configuration: catalog, storage, and
     /// the (optional) metrics endpoint.
     ///
-    /// The component-specific `compaction`, `gc`, and `pricing` blocks are
-    /// deliberately NOT validated here. Each carries required job-state storage
-    /// that the one-shot `migrate` commands never set — those commands share
-    /// this `MaintainConfig` but use only `catalog` + `storage`. Each block is
-    /// instead validated when its background loop is constructed in the `run`
-    /// service (`Compactor::new` / `GcRunner::new` / `PricingRunner::new`), so a
-    /// `migrate` config that omits the `gc`/`compaction`/`pricing` block still
-    /// loads. (Validating `gc` here previously broke `migrate create` on the
-    /// minimal migrate config.)
+    /// The component-specific `compaction`, `gc`, `pricing`, and `tracing`
+    /// blocks are deliberately NOT validated here. Each carries requirements the
+    /// one-shot `migrate` commands never satisfy — job-state storage for the
+    /// first three, an OTLP endpoint for `tracing`, whose default is enabled —
+    /// and those commands share this `MaintainConfig` while using only the
+    /// `catalog` and `storage` blocks. Each is instead validated where the `run`
+    /// service consumes it (`Compactor::new` / `GcRunner::new` /
+    /// `PricingRunner::new`, and the tracing init in the `run` command), so a
+    /// `migrate` config that omits them still loads. (Validating `gc` here
+    /// previously broke `migrate create` on the minimal migrate config.)
     ///
     /// # Errors
     ///
@@ -107,6 +114,101 @@ storage:
         config
             .validate()
             .expect("migrate-style config (no gc/compaction) must validate");
+        // `TracingConfig` defaults to enabled, and its own validator rejects
+        // "enabled with no endpoint". A migrate config carries no `tracing`
+        // block and no OTLP endpoint, so `validate` must not reach that check —
+        // only the `run` command does, once it is about to build the exporter.
+        assert!(config.tracing.enabled, "the tracing default is enabled");
+        assert_eq!(config.tracing.otlp_endpoint, None);
+    }
+
+    /// Serde drops unknown keys in silence, so a chart-rendered `tracing` block
+    /// that does not match the struct would leave the service on defaults —
+    /// exporting nowhere while the `ConfigMap` says otherwise. Parse the block in
+    /// the shape `configmap-maintain.yaml` renders it, down to the scalar type:
+    /// Helm renders the chart's `sampleRatio: 1.0` as the integer `1`, so this is
+    /// also what proves an integer scalar reaches an `f64` field.
+    #[test]
+    fn the_tracing_block_the_chart_renders_lands_on_the_config() {
+        let yaml = r#"
+catalog:
+  backend: !rest
+    uri: http://nessie:19120/iceberg
+  warehouse: s3://warehouse/
+storage:
+  backend: !s3
+    bucket: warehouse
+    region: us-east-1
+    endpoint: http://localhost:9000
+tracing:
+  enabled: true
+  otlp_endpoint: "http://jaeger:4317"
+  sample_ratio: 1
+"#;
+        let config: MaintainConfig = serde_yaml::from_str(yaml).expect("parse chart-style tracing config");
+
+        assert!(config.tracing.enabled);
+        assert_eq!(config.tracing.otlp_endpoint.as_deref(), Some("http://jaeger:4317"));
+        assert!((config.tracing.sample_ratio - 1.0).abs() < f64::EPSILON);
+        config.tracing.validate().expect("a configured endpoint validates");
+    }
+
+    /// The chart's other branch: with `maintain.tracing.enabled=false` the
+    /// `ConfigMap` renders no `otlp_endpoint` at all (the `required` guard sits
+    /// inside the enabled branch). That shape must load AND validate, since
+    /// `run` validates the block before building any exporter — the endpoint
+    /// requirement only applies while tracing is enabled.
+    #[test]
+    fn the_disabled_tracing_block_the_chart_renders_validates_without_an_endpoint() {
+        let yaml = r"
+catalog:
+  backend: !rest
+    uri: http://nessie:19120/iceberg
+  warehouse: s3://warehouse/
+storage:
+  backend: !s3
+    bucket: warehouse
+    region: us-east-1
+    endpoint: http://localhost:9000
+tracing:
+  enabled: false
+  sample_ratio: 1
+";
+        let config: MaintainConfig = serde_yaml::from_str(yaml).expect("parse chart-style disabled tracing config");
+
+        assert!(!config.tracing.enabled);
+        assert_eq!(config.tracing.otlp_endpoint, None);
+        config
+            .tracing
+            .validate()
+            .expect("disabled tracing needs no endpoint to validate");
+    }
+
+    /// A fractional ratio reaches the config only when an operator overrides the
+    /// chart's default `1.0`, which Helm renders as the integer `1` — so the
+    /// fractional scalar is a path of its own, covered here rather than in the
+    /// chart-shape test above.
+    #[test]
+    fn fractional_sample_ratio_parses() {
+        let yaml = r"
+catalog:
+  backend: !rest
+    uri: http://nessie:19120/iceberg
+  warehouse: s3://warehouse/
+storage:
+  backend: !s3
+    bucket: warehouse
+    region: us-east-1
+    endpoint: http://localhost:9000
+tracing:
+  enabled: true
+  otlp_endpoint: http://jaeger:4317
+  sample_ratio: 0.5
+";
+        let config: MaintainConfig = serde_yaml::from_str(yaml).expect("parse fractional sample_ratio");
+
+        assert!((config.tracing.sample_ratio - 0.5).abs() < f64::EPSILON);
+        config.tracing.validate().expect("0.5 is within [0.0, 1.0]");
     }
 
     /// Serde ignores unknown keys, so a `ConfigMap` key with no matching field

--- a/crates/icegate-maintain/src/gc/sweep.rs
+++ b/crates/icegate-maintain/src/gc/sweep.rs
@@ -11,6 +11,7 @@ use iceberg::Catalog;
 use icegate_common::{StorageConfig, create_object_store, icegate_table_ident};
 use object_store::path::Path as ObjectPath;
 use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, info_span};
 
 use crate::error::MaintainError;
 use crate::gc::config::GcOrphansConfig;
@@ -62,10 +63,19 @@ pub async fn run_sweep(
     cancel: &CancellationToken,
 ) -> Result<SweepSummary, MaintainError> {
     let ident = icegate_table_ident(table);
-    let loaded = catalog.load_table(&ident).await?;
+    let loaded = catalog
+        .load_table(&ident)
+        .instrument(info_span!("gc_load_table", table))
+        .await?;
 
     // FAIL-CLOSED: a partial referenced set must never drive a delete.
-    let referenced = match collect_referenced_paths(&loaded).await {
+    // The reference set walks every snapshot's manifest list and every manifest
+    // in it, so on a table with deep history it dominates the sweep; its own span
+    // separates that cost from the object listing below.
+    let referenced = match collect_referenced_paths(&loaded)
+        .instrument(info_span!("gc_reference_set", table))
+        .await
+    {
         Ok(set) => set,
         Err(error) => {
             metrics.record_reference_set_build_failed(table);
@@ -88,53 +98,63 @@ pub async fn run_sweep(
     // larger structure, is the live set.
     let mut orphans: Vec<(ObjectPath, u64, ObjectClass)> = Vec::new();
 
-    loop {
-        // Race the list page against cancellation so a slow or stuck storage
-        // call cannot keep shutdown blocked until the future resolves.
-        let item = tokio::select! {
-            biased;
-            () = cancel.cancelled() => {
-                return Err(MaintainError::Storage(format!("gc sweep of table '{table}' cancelled")));
-            }
-            item = stream.next() => item,
-        };
-        let Some(item) = item else { break };
-        let meta = item.map_err(|e| MaintainError::Storage(format!("gc list error for table '{table}': {e}")))?;
-        summary.scanned += 1;
-        // `meta.location` is already a bucket-relative object key; the referenced
-        // set holds the same keys (Iceberg's absolute URIs parsed via
-        // decide::parse_object_key), so the two compare directly as `ObjectPath`.
-        match Decision::classify(
-            &meta.location,
-            &prefix,
-            &referenced,
-            meta.last_modified,
-            cutoff,
-            cfg.include_metadata,
-        ) {
-            Decision::Referenced => summary.referenced += 1,
-            Decision::TooYoung => summary.too_young += 1,
-            Decision::SkipMetadataDisabled | Decision::SkipUnknownLayout => {}
-            Decision::Delete(class) => {
-                match class {
-                    ObjectClass::Data => summary.found_data += 1,
-                    ObjectClass::Metadata => summary.found_metadata += 1,
+    // The list-and-classify pass runs as an instrumented async block rather than
+    // an extracted function: it touches every local this function holds, which a
+    // helper would have to take as a parameter list far past the workspace's
+    // argument budget.
+    async {
+        loop {
+            // Race the list page against cancellation so a slow or stuck storage
+            // call cannot keep shutdown blocked until the future resolves.
+            let item = tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    return Err(MaintainError::Storage(format!("gc sweep of table '{table}' cancelled")));
                 }
-                metrics.record_orphan_found(table, class);
-                // A dry run returns before deletion, so retaining the path would
-                // only grow memory across a large backlog scan without use.
-                if !cfg.dry_run {
-                    orphans.push((meta.location, meta.size, class));
+                item = stream.next() => item,
+            };
+            let Some(item) = item else { break };
+            let meta = item.map_err(|e| MaintainError::Storage(format!("gc list error for table '{table}': {e}")))?;
+            summary.scanned += 1;
+            // `meta.location` is already a bucket-relative object key; the referenced
+            // set holds the same keys (Iceberg's absolute URIs parsed via
+            // decide::parse_object_key), so the two compare directly as `ObjectPath`.
+            match Decision::classify(
+                &meta.location,
+                &prefix,
+                &referenced,
+                meta.last_modified,
+                cutoff,
+                cfg.include_metadata,
+            ) {
+                Decision::Referenced => summary.referenced += 1,
+                Decision::TooYoung => summary.too_young += 1,
+                Decision::SkipMetadataDisabled | Decision::SkipUnknownLayout => {}
+                Decision::Delete(class) => {
+                    match class {
+                        ObjectClass::Data => summary.found_data += 1,
+                        ObjectClass::Metadata => summary.found_metadata += 1,
+                    }
+                    metrics.record_orphan_found(table, class);
+                    // A dry run returns before deletion, so retaining the path would
+                    // only grow memory across a large backlog scan without use.
+                    if !cfg.dry_run {
+                        orphans.push((meta.location, meta.size, class));
+                    }
                 }
             }
         }
+        Ok(())
     }
+    .instrument(info_span!("gc_list_objects", table))
+    .await?;
 
     if cfg.dry_run {
         metrics.record_scan(table, summary.scanned, summary.too_young);
         return Ok(summary);
     }
 
+    let delete_span = info_span!("gc_delete_orphans", table, orphans = orphans.len());
     let mut deletions = futures::stream::iter(orphans.into_iter().map(|(path, size, class)| {
         let store = Arc::clone(&store);
         async move {
@@ -146,30 +166,35 @@ pub async fn run_sweep(
     }))
     .buffer_unordered(cfg.delete_concurrency.max(1));
 
-    loop {
-        // Keep the delete drain cancellation-aware too, so shutdown short-circuits
-        // promptly instead of waiting on the next in-flight deletion.
-        let result = tokio::select! {
-            biased;
-            () = cancel.cancelled() => {
-                return Err(MaintainError::Storage(format!("gc sweep of table '{table}' cancelled")));
-            }
-            result = deletions.next() => result,
-        };
-        let Some(result) = result else { break };
-        match result {
-            Ok((size, class)) => {
-                summary.deleted += 1;
-                summary.bytes_reclaimed += size;
-                metrics.record_orphan_deleted(table, class, size);
-            }
-            Err((path, class, error)) => {
-                summary.delete_failed += 1;
-                metrics.record_orphan_delete_failed(table, class);
-                tracing::warn!(table, path = %path, kind = ?class, error = %error, "failed to delete orphan object");
+    async {
+        loop {
+            // Keep the delete drain cancellation-aware too, so shutdown short-circuits
+            // promptly instead of waiting on the next in-flight deletion.
+            let result = tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    return Err(MaintainError::Storage(format!("gc sweep of table '{table}' cancelled")));
+                }
+                result = deletions.next() => result,
+            };
+            let Some(result) = result else { break };
+            match result {
+                Ok((size, class)) => {
+                    summary.deleted += 1;
+                    summary.bytes_reclaimed += size;
+                    metrics.record_orphan_deleted(table, class, size);
+                }
+                Err((path, class, error)) => {
+                    summary.delete_failed += 1;
+                    metrics.record_orphan_delete_failed(table, class);
+                    tracing::warn!(table, path = %path, kind = ?class, error = %error, "failed to delete orphan object");
+                }
             }
         }
+        Ok(())
     }
+    .instrument(delete_span)
+    .await?;
 
     metrics.record_scan(table, summary.scanned, summary.too_young);
     Ok(summary)

--- a/crates/icegate-maintain/src/main.rs
+++ b/crates/icegate-maintain/src/main.rs
@@ -22,13 +22,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse CLI arguments first so tracing can be gated on the subcommand.
     let cli = Cli::parse();
 
-    // The one-shot `migrate` commands keep tracing disabled (they report via
-    // their own stdout/stderr output), while the long-running `run` service
-    // must enable tracing so its spans and logs are emitted.
-    let _guard = init_tracing(&TracingConfig {
-        enabled: matches!(cli.command, Commands::Run { .. }),
-        ..TracingConfig::default()
-    })?;
+    // Exhaustive on purpose: a new subcommand must decide where its subscriber
+    // comes from, and the compiler is what forces that decision — an
+    // uninstrumented binary logs nothing and fails silently.
+    let _guard = match &cli.command {
+        // The one-shot `migrate` commands carry no `tracing` config block and
+        // report via their own stdout/stderr output, so they get the plain JSON
+        // logger here (tracing disabled = no OTLP exporter).
+        Commands::Migrate { .. } => Some(init_tracing(&TracingConfig {
+            enabled: false,
+            ..TracingConfig::default()
+        })?),
+        // The long-running `run` service initialises the subscriber from
+        // `MaintainConfig::tracing` once it has read its config file, mirroring
+        // ingest and query — nothing is installed here: the first `init_tracing`
+        // call wins.
+        Commands::Run { .. } => None,
+    };
 
     // Execute command
     if let Err(e) = cli.execute().await {

--- a/crates/icegate-maintain/src/pricing/mod.rs
+++ b/crates/icegate-maintain/src/pricing/mod.rs
@@ -300,7 +300,9 @@ async fn run_crawl(
     metrics: &metrics::PricingMetrics,
     now: DateTime<Utc>,
 ) -> Result<()> {
-    let live = read::read_live_rates(catalog).await?;
+    let live = read::read_live_rates(catalog)
+        .instrument(info_span!("pricing_read_live_rates"))
+        .await?;
     let ctx = CrawlContext {
         live: &live,
         config,
@@ -308,10 +310,16 @@ async fn run_crawl(
         now,
     };
 
-    let fetched = futures::future::join_all(sources.iter().map(|s| async move {
-        let started = std::time::Instant::now();
-        let result = s.fetch_rates(client, now).await;
-        (s.as_ref(), started.elapsed().as_secs_f64(), result)
+    // One span per source: the fetches run concurrently, so a slow or hanging
+    // feed is only distinguishable from a slow crawl when each has its own span.
+    let fetched = futures::future::join_all(sources.iter().map(|s| {
+        let span = info_span!("pricing_fetch_source", source = s.name());
+        async move {
+            let started = std::time::Instant::now();
+            let result = s.fetch_rates(client, now).await;
+            (s.as_ref(), started.elapsed().as_secs_f64(), result)
+        }
+        .instrument(span)
     }))
     .await;
 
@@ -363,7 +371,9 @@ async fn run_crawl(
         return Ok(());
     }
 
-    writer::append_prices(catalog, &diff_outcome.to_append).await?;
+    writer::append_prices(catalog, &diff_outcome.to_append)
+        .instrument(info_span!("pricing_append", rows = diff_outcome.to_append.len()))
+        .await?;
     for rate in &diff_outcome.to_append {
         metrics.record_appended(&rate.source, 1);
     }

--- a/crates/icegate-maintain/tests/compaction_e2e_it.rs
+++ b/crates/icegate-maintain/tests/compaction_e2e_it.rs
@@ -763,6 +763,7 @@ async fn compactor_repacks_manifests_without_touching_data() {
         .execute(
             &ManifestCompactInput {
                 table: TABLE.to_string(),
+                trace_context: None,
             },
             &CancellationToken::new(),
         )
@@ -885,6 +886,7 @@ async fn manifest_compaction_reports_actual_output_count() {
         .execute(
             &ManifestCompactInput {
                 table: TABLE.to_string(),
+                trace_context: None,
             },
             &CancellationToken::new(),
         )

--- a/crates/icegate-maintain/tests/rewrite_it.rs
+++ b/crates/icegate-maintain/tests/rewrite_it.rs
@@ -344,6 +344,7 @@ async fn rewrite_executor_compacts_partition_preserving_rows_and_order() {
         table: TABLE.to_string(),
         partition_key,
         input_file_paths,
+        trace_context: None,
     };
 
     let cancel = CancellationToken::new();
@@ -466,6 +467,7 @@ async fn rewrite_carries_wal_offset_property_forward() {
         table: TABLE.to_string(),
         partition_key,
         input_file_paths,
+        trace_context: None,
     };
     let cancel = CancellationToken::new();
     let outcome = executor.execute(&rewrite_input, &cancel).await.expect("execute rewrite");


### PR DESCRIPTION
Brings the maintain service up to the tracing setup ingest already has.

- MaintainConfig gains a `tracing` block, so the OTLP endpoint, sample ratio and the on/off switch come from the config file instead of relying on the OTEL_EXPORTER_OTLP_ENDPOINT env var alone. `run` initialises the subscriber once its config is loaded (as ingest and query do) while `migrate` keeps the plain JSON logger. The block is validated in `run`, not in MaintainConfig::validate, so migrate configs that omit it still load.

- Compaction PLAN fans REWRITE/MANIFEST tasks out to workers that pick them up with no ambient context and therefore open their own traces. Task payloads now carry the PLAN span's W3C traceparent and each task adds it as a span link, so the whole fan-out reads as one connected trace. The field is serde-optional: payloads queued before the upgrade still parse.

- Spans added for the steps that dominate wall clock: table load, data-file and manifest enumeration, merge+write, GC reference-set build, object listing and orphan deletion, pricing live-rate read, per-source fetch and append.

- Deployment configs updated on both sides (Docker Compose and Helm). The maintain OTLP endpoint moves from a pod env var into the ConfigMap, and the `required` guard now fires only when tracing is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable OpenTelemetry tracing for the long-running maintenance service.
  * Enabled Jaeger OTLP export with full sampling by default.
  * Added trace propagation across compaction planning, rewriting, manifest processing, garbage collection, and pricing workflows.
  * Added validation requiring an OTLP endpoint when tracing is enabled.
* **Documentation**
  * Documented compaction trace relationships and tracing configuration requirements.
* **Bug Fixes**
  * Preserved compatibility with legacy task payloads and safely handled invalid or missing trace contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->