### PR TITLE
GH-165: add iceberg snapshots expiration support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,19 @@ Running rules:
   `cargo test <name>` for the code you touched.
 - Format only the affected crate: `cargo +nightly fmt -p <crate>` (plain `cargo fmt` ignores `rustfmt.toml`).
 
+### Docs
+
+- **A convention is only what is documented** in these three files. The mere presence of a pattern
+  in the code is **NOT** a convention — someone may have committed junk. Do not justify a decision
+  with "the existing code does X"; cite the documented rule, or propose adding one if it is missing.
+- How a thing behaves is documented in **its own doc comment**, next to the code. `missing_docs` is
+  denied, so this is enforced. Do not restate that behavior here or in the README — two copies drift.
+- `README.md` explains the crate to someone using it; `CONTRIBUTING.md` explains how to build, test,
+  and commit. Do not copy commands or contracts between them.
+- `docs/` holds only cross-cutting policy ([tests.md](docs/tests.md)).
+  Never add a `docs/<module>.md` — a deep-dive for a subsystem goes in a README beside its code.
+- Design notes, specs, and plans are working artifacts: keep them in `.tmp/`, not in `docs/`.
+
 ## Crates and where code goes
 
 Place a change in the crate that owns its responsibility; shared infrastructure
@@ -35,7 +48,7 @@ goes in `icegate-common`, never copied into a component.
 | `icegate-queue`      | Generic WAL data queue on object storage: durable-before-ack, exactly-once, per-topic offsets. | [README](crates/icegate-queue/README.md)                                                                 |
 | `icegate-ingest`     | OTLP receivers (gRPC/HTTP), transform, WAL write.                                              | per-tenant task model [README](crates/icegate-ingest/README.md)                                                   |
 | `icegate-query`      | Query APIs (Loki/Prometheus/Tempo), query engine, LogQL, query CLI.                            | [README](crates/icegate-query/README.md), LogQL [logql/README](crates/icegate-query/src/logql/README.md) |
-| `icegate-maintain`   | Background maintenance: compaction, GC, schema migration, maintain CLI.                        | compaction [compact/README](crates/icegate-maintain/src/compact/README.md)                               |
+| `icegate-maintain`   | Background maintenance: compaction, GC, schema migration, maintain CLI.                        | [README](crates/icegate-maintain/README.md), compaction [compact/README](crates/icegate-maintain/src/compact/README.md), retention [migrate/README](crates/icegate-maintain/src/migrate/README.md) |
 
 ### Dependency rules
 - `icegate-common` is the foundation and depends on no other workspace crate;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=3fadce564546f7f40ff57b16b4d62a8398c9bc9b#3fadce564546f7f40ff57b16b4d62a8398c9bc9b"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -3856,6 +3856,7 @@ dependencies = [
  "serde_with",
  "strum",
  "tokio",
+ "tracing",
  "typed-builder",
  "typetag",
  "url",
@@ -3866,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=3fadce564546f7f40ff57b16b4d62a8398c9bc9b#3fadce564546f7f40ff57b16b4d62a8398c9bc9b"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3882,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=3fadce564546f7f40ff57b16b4d62a8398c9bc9b#3fadce564546f7f40ff57b16b4d62a8398c9bc9b"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3902,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-s3tables"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=3fadce564546f7f40ff57b16b4d62a8398c9bc9b#3fadce564546f7f40ff57b16b4d62a8398c9bc9b"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3915,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=3fadce564546f7f40ff57b16b4d62a8398c9bc9b#3fadce564546f7f40ff57b16b4d62a8398c9bc9b"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3931,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=3fadce564546f7f40ff57b16b4d62a8398c9bc9b#3fadce564546f7f40ff57b16b4d62a8398c9bc9b"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,7 +3813,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=c3183a49e97d7d11500cce2b655b3317febe088c#c3183a49e97d7d11500cce2b655b3317febe088c"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -3867,7 +3867,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=c3183a49e97d7d11500cce2b655b3317febe088c#c3183a49e97d7d11500cce2b655b3317febe088c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=c3183a49e97d7d11500cce2b655b3317febe088c#c3183a49e97d7d11500cce2b655b3317febe088c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3903,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-s3tables"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=c3183a49e97d7d11500cce2b655b3317febe088c#c3183a49e97d7d11500cce2b655b3317febe088c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=c3183a49e97d7d11500cce2b655b3317febe088c#c3183a49e97d7d11500cce2b655b3317febe088c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3932,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "iceberg-storage-opendal"
 version = "0.9.0"
-source = "git+https://github.com/icegatetech/iceberg-rust?rev=0c079645eb719f6d9eed1d230e97e92b6b21d725#0c079645eb719f6d9eed1d230e97e92b6b21d725"
+source = "git+https://github.com/icegatetech/iceberg-rust?rev=c3183a49e97d7d11500cce2b655b3317febe088c#c3183a49e97d7d11500cce2b655b3317febe088c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,12 +86,12 @@ antlr4rust = "0.5"
 # Sourced from the icegatetech/iceberg-rust fork (0.9.0 base).
 # Pinned to an immutable rev (not a branch) for reproducible builds; bump the SHA
 # deliberately when adopting fork updates rather than letting `develop` float.
-iceberg = { git = "https://github.com/icegatetech/iceberg-rust", rev = "3fadce564546f7f40ff57b16b4d62a8398c9bc9b" }
-iceberg-catalog-rest = { git = "https://github.com/icegatetech/iceberg-rust", rev = "3fadce564546f7f40ff57b16b4d62a8398c9bc9b" }
-iceberg-catalog-s3tables = { git = "https://github.com/icegatetech/iceberg-rust", rev = "3fadce564546f7f40ff57b16b4d62a8398c9bc9b" }
-iceberg-catalog-glue = { git = "https://github.com/icegatetech/iceberg-rust", rev = "3fadce564546f7f40ff57b16b4d62a8398c9bc9b" }
-iceberg-storage-opendal = { git = "https://github.com/icegatetech/iceberg-rust", rev = "3fadce564546f7f40ff57b16b4d62a8398c9bc9b", features = ["opendal-s3"] }
-iceberg-datafusion = { git = "https://github.com/icegatetech/iceberg-rust", rev = "3fadce564546f7f40ff57b16b4d62a8398c9bc9b" }
+iceberg = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725" }
+iceberg-catalog-rest = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725" }
+iceberg-catalog-s3tables = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725" }
+iceberg-catalog-glue = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725" }
+iceberg-storage-opendal = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725", features = ["opendal-s3"] }
+iceberg-datafusion = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725" }
 
 # DataFusion
 datafusion = "52.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,12 +86,12 @@ antlr4rust = "0.5"
 # Sourced from the icegatetech/iceberg-rust fork (0.9.0 base).
 # Pinned to an immutable rev (not a branch) for reproducible builds; bump the SHA
 # deliberately when adopting fork updates rather than letting `develop` float.
-iceberg = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725" }
-iceberg-catalog-rest = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725" }
-iceberg-catalog-s3tables = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725" }
-iceberg-catalog-glue = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725" }
-iceberg-storage-opendal = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725", features = ["opendal-s3"] }
-iceberg-datafusion = { git = "https://github.com/icegatetech/iceberg-rust", rev = "0c079645eb719f6d9eed1d230e97e92b6b21d725" }
+iceberg = { git = "https://github.com/icegatetech/iceberg-rust", rev = "c3183a49e97d7d11500cce2b655b3317febe088c" }
+iceberg-catalog-rest = { git = "https://github.com/icegatetech/iceberg-rust", rev = "c3183a49e97d7d11500cce2b655b3317febe088c" }
+iceberg-catalog-s3tables = { git = "https://github.com/icegatetech/iceberg-rust", rev = "c3183a49e97d7d11500cce2b655b3317febe088c" }
+iceberg-catalog-glue = { git = "https://github.com/icegatetech/iceberg-rust", rev = "c3183a49e97d7d11500cce2b655b3317febe088c" }
+iceberg-storage-opendal = { git = "https://github.com/icegatetech/iceberg-rust", rev = "c3183a49e97d7d11500cce2b655b3317febe088c", features = ["opendal-s3"] }
+iceberg-datafusion = { git = "https://github.com/icegatetech/iceberg-rust", rev = "c3183a49e97d7d11500cce2b655b3317febe088c" }
 
 # DataFusion
 datafusion = "52.2"

--- a/RUST.md
+++ b/RUST.md
@@ -48,9 +48,18 @@ Before completing a task, perform an additional optimization pass to verify the 
 
 ## Documentation
 
-- **MUST** give every public item a doc comment stating its contract; a method whose body is self-evident needs one line, not a paragraph
-- Keep comments up to date with code changes
-- Include examples in doc comments for complex functions
+`missing_docs` is denied, so every public item carries a doc comment. Write it as a contract.
+
+- A doc comment on a `pub` item states **guarantees, errors, and invariants**, not a trace of the
+  implementation. A method whose body is self-evident needs one line, not a paragraph.
+- Document what the caller cannot see: what happens under concurrency, what is *not* durable yet,
+  what is validated later rather than here, what a returned empty value actually means.
+- `# Arguments` / `# Returns` blocks are required only when a name or signature is genuinely
+  ambiguous; do not pad self-evident parameters.
+- Include a doc example for a public entry point whose usage is not obvious from its signature.
+  Doc code is formatted (`format_code_in_doc_comments = true`) and compiled — keep it building.
+- Keep comments up to date with the code they describe.
+- Never write in the comments the exact values of constants that duplicate the code.
 
 ### Comment why, not what
 

--- a/config/docker/maintain.yaml
+++ b/config/docker/maintain.yaml
@@ -18,6 +18,20 @@ storage:
     region: us-east-1
     endpoint: http://s3:9000
 
+# Snapshot-retention policy stamped into the properties of every table
+# `migrate create` creates; the long-running services never read this block.
+# Expiration then rides along on every commit those services make, off the
+# table's own properties. Demo values match the chart defaults: the window must
+# outlive the query engine's provider cache (`engine.max_age_secs`, which
+# query.yaml leaves at the `icegate-query` default), and gc.orphans.min_age_secs
+# below must exceed that same cache age. Nothing checks this pair outside the
+# Helm chart, so the Compose stack relies on these two files staying ordered.
+snapshot_expiration:
+  enabled: true
+  min_snapshots_to_keep: 100
+  max_snapshot_age_ms: 1800000
+  metadata_previous_versions_max: 200
+
 # Compaction config for the long-running `compact` service (`maintain run`).
 # Ignored by the one-shot `migrate create` command, which shares this file.
 compaction:

--- a/config/helm/icegate/templates/_helpers.tpl
+++ b/config/helm/icegate/templates/_helpers.tpl
@@ -175,6 +175,104 @@ backend: !s3
 {{- end }}
 
 {{/*
+Fail the render when the retention window, the query provider cache, and the GC
+grace period are not ordered so that a query can never plan against files that
+are already gone:
+
+  query.engine.maxAgeSecs * 1000 < migrate.snapshotExpiration.maxSnapshotAgeMs
+  query.engine.maxAgeSecs        < maintain.gc.orphans.minAgeSecs
+
+A snapshot must outlive every cached reference to it, and a file must be
+unreferenced for longer than a provider can be cached before the sweep may take
+it. The three values belong to three components with three config files; this
+chart is the only place all of them exist at once, so it is the only place the
+ordering can be checked ahead of a query failing at runtime. See
+`crates/icegate-maintain/README.md`.
+
+The first ordering is checked only while `migrate.snapshotExpiration.enabled`:
+with the policy stamped off, no snapshot is ever dropped and the two magnitudes
+constrain nothing. The second is checked whatever that policy says, matching
+`MaintainConfig::validate` — a grace period of zero also exposes a compaction
+output written but not yet referenced by a manifest, and the tables of the
+deployment carry the policy they were created with, not the one in these values.
+
+Alongside the ordering, each value is checked against the bounds its own
+component's validator enforces (`SnapshotExpirationConfig::validate`,
+`QueryEngineConfig::validate`). Those bounds are not the chart's to invent, but
+leaving them to the pod is worse than duplicating them: `configmap-migrate.yaml`
+is a `pre-install,pre-upgrade` hook, so a block the migrate pod refuses to load
+fails the release after the render has already told the operator it is sound.
+
+One rule stays out of reach: `maxAgeSecs >= refreshIntervalSecs` is checked only
+when `refreshIntervalSecs` is set in values, since with it omitted the bound is
+the engine's own default, resolved in code. So the guarantee is bounded — every
+rule whose operands the chart holds is mirrored here, and nothing beyond that.
+
+`query.engine.maxAgeSecs` is `required` rather than defaulted: the engine's own
+default lives in `crates/icegate-query/src/engine/config.rs` and must not be
+restated here, and a nil value would make `int` yield 0 and pass the orderings
+below in silence. `values.yaml` declares it once, and the same value renders into
+`configmap-query.yaml`. The whole `query.engine` map is optional in Helm's eyes,
+hence `(.Values.query.engine).maxAgeSecs`: the parenthesised form yields nil for
+a missing or explicitly null map and reaches the message below, where the plain
+path aborts the render with a nil-pointer message that names none of the
+operator's own values. `required` passes a zero through — it rejects nil and the
+empty string only — so the positivity of the value is a check of its own.
+
+Invoked from every `ConfigMap` that carries one of these values, so the render is
+checked whichever components are enabled.
+
+Usage: include "icegate.validateRetentionWindow" .
+*/}}
+{{- define "icegate.validateRetentionWindow" -}}
+{{- if .Values.query.enabled }}
+{{- $queryMaxAgeSecs := required "query.engine.maxAgeSecs is required: the chart checks it against migrate.snapshotExpiration.maxSnapshotAgeMs and maintain.gc.orphans.minAgeSecs, and cannot restate the engine's own default" (.Values.query.engine).maxAgeSecs | int }}
+{{- if le $queryMaxAgeSecs 0 }}
+{{- fail (printf "query.engine.maxAgeSecs (%d) must be greater than zero: the query pod refuses to start on a non-positive provider cache age, and every retention ordering below is stated against it" $queryMaxAgeSecs) }}
+{{- end }}
+{{- with (.Values.query.engine).refreshIntervalSecs }}
+{{- if lt $queryMaxAgeSecs (int .) }}
+{{- fail (printf "query.engine.maxAgeSecs (%d) must be at least query.engine.refreshIntervalSecs (%d): a provider would be stale before the background refresh that replaces it has run" $queryMaxAgeSecs (int .)) }}
+{{- end }}
+{{- end }}
+{{- if and .Values.migrate.enabled .Values.migrate.snapshotExpiration.enabled }}
+{{/* Both sides in milliseconds: flooring the window to whole seconds would
+     reject a 30001ms window against a 30s cache, which the ordering allows. */}}
+{{- $snapshotAgeMs := .Values.migrate.snapshotExpiration.maxSnapshotAgeMs | int }}
+{{- if ge (mul $queryMaxAgeSecs 1000) $snapshotAgeMs }}
+{{- fail (printf "query.engine.maxAgeSecs (%d) must be below migrate.snapshotExpiration.maxSnapshotAgeMs (%dms): a cached catalog provider would outlive the snapshot it planned against, and the sweep may already have collected that snapshot's files" $queryMaxAgeSecs $snapshotAgeMs) }}
+{{- end }}
+{{- end }}
+{{- if and .Values.maintain.enabled .Values.maintain.gc.enabled .Values.maintain.gc.orphans.enabled }}
+{{- if le (.Values.maintain.gc.orphans.minAgeSecs | int) $queryMaxAgeSecs }}
+{{- fail (printf "maintain.gc.orphans.minAgeSecs (%d) must exceed query.engine.maxAgeSecs (%d): the sweep would be free to delete a file while a cached catalog provider still plans reads against it" (.Values.maintain.gc.orphans.minAgeSecs | int) $queryMaxAgeSecs) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and .Values.maintain.enabled .Values.maintain.gc.enabled .Values.maintain.gc.orphans.enabled }}
+{{- if eq (.Values.maintain.gc.orphans.minAgeSecs | int) 0 }}
+{{- fail "maintain.gc.orphans.minAgeSecs must be greater than zero: a swept file has to stay unreferenced for longer than query.engine.maxAgeSecs, which is positive by definition, and the grace period is also what keeps a compaction output not yet referenced by any manifest out of the sweep's reach" }}
+{{- end }}
+{{- end }}
+{{/* The bounds of `SnapshotExpirationConfig::validate`, which the migrate pod
+     applies to the whole block whatever `enabled` says — a policy stamped off
+     still has to be a well-formed one. */}}
+{{- if .Values.migrate.enabled }}
+{{- $minSnapshotsToKeep := .Values.migrate.snapshotExpiration.minSnapshotsToKeep | int }}
+{{- $metadataPreviousVersionsMax := .Values.migrate.snapshotExpiration.metadataPreviousVersionsMax | int }}
+{{- if le $minSnapshotsToKeep 0 }}
+{{- fail (printf "migrate.snapshotExpiration.minSnapshotsToKeep (%d) must be greater than zero: a table that keeps no ancestor of its current snapshot has no history for an in-flight reader or the WAL offset to sit in" $minSnapshotsToKeep) }}
+{{- end }}
+{{- if le (.Values.migrate.snapshotExpiration.maxSnapshotAgeMs | int) 0 }}
+{{- fail (printf "migrate.snapshotExpiration.maxSnapshotAgeMs (%d) must be greater than zero" (.Values.migrate.snapshotExpiration.maxSnapshotAgeMs | int)) }}
+{{- end }}
+{{- if lt $metadataPreviousVersionsMax $minSnapshotsToKeep }}
+{{- fail (printf "migrate.snapshotExpiration.metadataPreviousVersionsMax (%d) must be at least migrate.snapshotExpiration.minSnapshotsToKeep (%d): the table would drop metadata.json versions covering snapshots it is still required to keep, and the S3 catalog resolves a lost commit ack by finding its own metadata file in the head's metadata-log" $metadataPreviousVersionsMax $minSnapshotsToKeep) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Render AWS credential env vars from an existing Secret.
 Usage: include "icegate.awsEnv" .
 */}}

--- a/config/helm/icegate/templates/configmap-maintain.yaml
+++ b/config/helm/icegate/templates/configmap-maintain.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.maintain.enabled -}}
+{{/* The sweep's grace period is one of the three values the ordering is built
+     from, and it is rendered here — so the check runs even when neither query
+     nor migrate is enabled. */}}
+{{- include "icegate.validateRetentionWindow" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/config/helm/icegate/templates/configmap-migrate.yaml
+++ b/config/helm/icegate/templates/configmap-migrate.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.migrate.enabled -}}
+{{- include "icegate.validateRetentionWindow" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,4 +17,9 @@ data:
       {{- include "icegate.catalogYaml" . | nindent 6 }}
     storage:
       {{- include "icegate.storageYaml" . | nindent 6 }}
+    snapshot_expiration:
+      enabled: {{ .Values.migrate.snapshotExpiration.enabled }}
+      min_snapshots_to_keep: {{ .Values.migrate.snapshotExpiration.minSnapshotsToKeep }}
+      max_snapshot_age_ms: {{ .Values.migrate.snapshotExpiration.maxSnapshotAgeMs | int }}
+      metadata_previous_versions_max: {{ .Values.migrate.snapshotExpiration.metadataPreviousVersionsMax }}
 {{- end }}

--- a/config/helm/icegate/templates/configmap-query.yaml
+++ b/config/helm/icegate/templates/configmap-query.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.query.enabled -}}
+{{/* Also invoked from configmap-migrate and configmap-maintain: whichever
+     components are enabled, the ordering of cache age against retention and GC
+     grace is checked. */}}
+{{- include "icegate.validateRetentionWindow" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/config/helm/icegate/values.yaml
+++ b/config/helm/icegate/values.yaml
@@ -156,8 +156,14 @@ query:
     catalogName: iceberg
     ## Interval (seconds) between background catalog refreshes (default: 15)
     # refreshIntervalSecs: 15
-    ## Max age (seconds) before cached provider is considered stale (default: 30)
-    # maxAgeSecs: 30
+    ## Max age (seconds) before cached provider is considered stale.
+    ## Bounded on both sides by the retention contract: it must stay below
+    ## migrate.snapshotExpiration.maxSnapshotAgeMs and below
+    ## maintain.gc.orphans.minAgeSecs, or a cached provider can outlive the files
+    ## it plans against. The chart fails the render when it does not, and reads
+    ## this line to do it — so unlike the tunables around it, the value is set
+    ## rather than commented out, and unsetting it fails the render.
+    maxAgeSecs: 30
     ## Include WAL (hot) segments in query results (default: false).
     ## When false, queries only read committed Iceberg data.
     ## Note: does not affect /labels, /label_values, or /series — those are Iceberg-only.
@@ -491,6 +497,28 @@ migrate:
   activeDeadlineSeconds: 300
   hookDeletePolicy: before-hook-creation
 
+  ## Snapshot-retention policy written into the properties of every table
+  ## `migrate create` creates. Expiration itself runs on every writer's commit
+  ## (ingest shift, compaction, pricing) off those properties, so this block
+  ## reaches a table exactly once, when it is created — changing it later does
+  ## not re-stamp existing tables. Without a bounded history GC cannot reclaim
+  ## anything: a snapshot in `metadata.json` keeps its manifests and data files
+  ## referenced forever.
+  snapshotExpiration:
+    ## Whether created tables expire snapshots at all.
+    enabled: true
+    ## Newest ancestors of the current snapshot that always survive.
+    minSnapshotsToKeep: 100
+    ## Age (ms) past which a snapshot may be expired. Must stay above
+    ## query.engine.maxAgeSecs — see the chart's retention check.
+    maxSnapshotAgeMs: 1800000
+    ## Superseded metadata.json versions a table keeps. Twice the snapshot
+    ## window, and never below it (maintain rejects a shorter log): past the
+    ## window a stored metadata.json is not a restore point, since its
+    ## snapshots' files have been swept, but the log is also what the S3 catalog
+    ## reads to recognise a commit of its own whose ack was lost.
+    metadataPreviousVersionsMax: 200
+
   ## Wait for catalog and storage to be ready before migrating.
   ## Uses a busybox init container to poll the endpoints.
   waitForDependencies:
@@ -631,7 +659,9 @@ maintain:
       dryRun: false
       ## Grace period: an object is deletable only if its last_modified is older
       ## than this. Protects freshly written files and in-flight compaction
-      ## outputs not yet referenced by a manifest (default: 7 days).
+      ## outputs not yet referenced by a manifest (default: 7 days). Must be
+      ## above zero and above query.engine.maxAgeSecs; both the chart and
+      ## MaintainConfig::validate reject a zero.
       minAgeSecs: 604800
       ## Also sweep orphaned Iceberg metadata (manifests, snap-*.avro, superseded
       ## *.metadata.json); when false, only data/ files are swept.

--- a/crates/icegate-maintain/README.md
+++ b/crates/icegate-maintain/README.md
@@ -1,0 +1,74 @@
+# icegate-maintain
+
+Background maintenance for the IceGate tables: schema migration, Parquet and
+manifest compaction, orphan-file garbage collection, and the LLM pricing crawler.
+
+The crate has two entry points and they behave very differently:
+
+- the one-shot `migrate` commands, which create the tables and stamp their
+  properties, then exit;
+- the long-running `run` service, which drives compaction, GC, and pricing as
+  jobmanager tasks.
+
+## Structure
+
+| Path                              | Owns                                                                            | Deep dive                            |
+|-----------------------------------|---------------------------------------------------------------------------------|--------------------------------------|
+| [`migrate/`](src/migrate)         | Table creation, schema-drift report, the retention policy stamped onto new tables. | [README](src/migrate/README.md)      |
+| [`compact/`](src/compact)         | Data-file and manifest compaction jobs.                                          | [README](src/compact/README.md)      |
+| [`gc/`](src/gc)                   | Orphan-file sweep: reachable set, decision, delete.                              | module doc comments                  |
+| [`pricing/`](src/pricing)         | LLM rate-card crawler writing the `prices` table.                                | module doc comments                  |
+| [`cli/`](src/cli)                 | Argument parsing and the wiring of each entry point.                             | —                                    |
+
+## Configuration
+
+Both entry points load a single `MaintainConfig` ([`config.rs`](src/config.rs)),
+so one file can serve both, and each side reads only the blocks it owns. What a
+field means is documented on the field.
+
+Helm keys live under `migrate.*` and `maintain.*` in
+[`values.yaml`](../../config/helm/icegate/values.yaml); the Compose file is
+[`config/docker/maintain.yaml`](../../config/docker/maintain.yaml). The two
+deployments change together.
+
+## Deployment contract
+
+Values owned by three components have to stay ordered, and no single config file
+holds them all. `max_snapshot_age_ms` is in milliseconds and the other two in
+seconds, so the first ordering carries the conversion:
+
+```text
+query.engine.max_age_secs * 1000 < migrate.snapshot_expiration.max_snapshot_age_ms
+query.engine.max_age_secs        < maintain.gc.orphans.min_age_secs
+```
+
+The query engine caches a catalog provider — a fixed table state and the file
+list behind it — for `max_age_secs`. A snapshot must therefore outlive every
+cached reference to it, and a file must stay unreferenced for longer than a
+provider can be cached before the sweep may take it. Violate either and a query
+plans against a file the sweep has already deleted: a scan error, not wrong
+results.
+
+Who enforces what:
+
+- The **Helm chart** is the only place all three values exist at once, so it
+  checks the full ordering at render time (`icegate.validateRetentionWindow` in
+  [`_helpers.tpl`](../../config/helm/icegate/templates/_helpers.tpl)). It also
+  mirrors the per-value bounds of the component validators, because
+  `configmap-migrate.yaml` is a `pre-install,pre-upgrade` hook: a block only the
+  pod rejects fails the release after the render has already passed. That mirror
+  covers every rule whose operands are in values and no more — a bound stated
+  against a default resolved in code stays with the pod that owns it.
+- **`MaintainConfig::validate`** sees one file, so it checks what that file can
+  answer for: the whole `snapshot_expiration` block (window bounds, and the
+  metadata-log bound against the snapshot window), plus the single cross-component
+  case that does not need the query engine's value — `gc.orphans.min_age_secs` of
+  zero breaks the ordering whatever `max_age_secs` is set to, since that value is
+  positive by definition. Compose and hand-written configs get exactly these.
+- **Nothing enforces it at runtime.** The read path does not yet retry a query
+  whose file went missing (see the module docs of `icegate-query`
+  `engine/core.rs`).
+
+The retention window itself — where expiration runs, what it costs the operator,
+and what stops being recoverable once it is on — is in
+[`migrate/README.md`](src/migrate/README.md).

--- a/crates/icegate-maintain/src/cli/commands/migrate.rs
+++ b/crates/icegate-maintain/src/cli/commands/migrate.rs
@@ -35,7 +35,7 @@ async fn create(config_path: PathBuf, dry_run: bool) -> Result<(), MaintainError
         tracing::info!("Running in dry-run mode - no changes will be made");
     }
 
-    let ops = operations::create_tables(&catalog, dry_run).await?;
+    let ops = operations::create_tables(&catalog, &config.snapshot_expiration, dry_run).await?;
     report_operations(&ops, dry_run);
 
     Ok(())

--- a/crates/icegate-maintain/src/config.rs
+++ b/crates/icegate-maintain/src/config.rs
@@ -9,7 +9,9 @@ use icegate_common::{CatalogConfig, MetricsConfig, StorageConfig, TracingConfig}
 use serde::{Deserialize, Serialize};
 
 use crate::compact::config::CompactionConfig;
+use crate::error::MaintainError;
 use crate::gc::config::GcConfig;
+use crate::migrate::config::SnapshotExpirationConfig;
 
 /// Maintain binary configuration
 ///
@@ -35,6 +37,11 @@ pub struct MaintainConfig {
     /// Disabled by default; ignored by the one-shot `migrate` commands.
     #[serde(default)]
     pub pricing: crate::pricing::config::PricingConfig,
+    /// Snapshot-retention policy `migrate create` stamps onto the tables it
+    /// creates. Read only by the one-shot `migrate` commands: expiration itself
+    /// runs on every writer's commit, off the table's own properties.
+    #[serde(default)]
+    pub snapshot_expiration: SnapshotExpirationConfig,
     /// Prometheus metrics endpoint configuration for the long-running `run`
     /// service. Disabled by default and ignored by the one-shot `migrate`
     /// commands; when enabled, `run` installs the global meter provider (so the
@@ -75,14 +82,66 @@ impl MaintainConfig {
     /// `migrate` config that omits them still loads. (Validating `gc` here
     /// previously broke `migrate create` on the minimal migrate config.)
     ///
+    /// `snapshot_expiration` is the exception: it is the `migrate` commands' own
+    /// block, it requires nothing of the environment, and its values leave the
+    /// process as table properties every later writer resolves — a bad window
+    /// caught here is a failed `migrate`, the same window caught on a commit is
+    /// a failed ingest.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the catalog, storage, or metrics configuration is
-    /// invalid.
+    /// Returns an error if the catalog, storage, metrics, or snapshot-expiration
+    /// configuration is invalid, or if the orphan sweep would run with no grace
+    /// period (see [`Self::validate_orphan_grace_period`]).
     pub fn validate(&self) -> Result<(), Box<dyn std::error::Error>> {
         self.catalog.validate()?;
         self.storage.validate()?;
         self.metrics.validate()?;
+        self.snapshot_expiration.validate()?;
+        self.validate_orphan_grace_period()?;
+        Ok(())
+    }
+
+    /// Reject an orphan sweep that runs with no grace period.
+    ///
+    /// The deployment contract (`crates/icegate-maintain/README.md`) is
+    /// `query.engine.max_age_secs < gc.orphans.min_age_secs`: the query engine
+    /// caches a catalog provider — a fixed table state and the file list behind
+    /// it — for `max_age_secs`, so a file must stay unreferenced longer than
+    /// that before the sweep may take it.
+    ///
+    /// Maintain cannot check the full contract — `query.engine.max_age_secs`
+    /// lives in another component's config and is not visible here. A zero grace
+    /// period is the one case it can: `max_age_secs` is required to be positive
+    /// (`icegate-query` `engine/config.rs`), so zero violates the ordering
+    /// whatever that value is. The Helm chart checks the general case
+    /// (`icegate.validateRetentionWindow`); Compose and hand-written configs
+    /// have this and the `snapshot_expiration` bounds, nothing wider.
+    ///
+    /// The check does not read `snapshot_expiration`. That block says what
+    /// `migrate create` stamps onto new tables, not whether this deployment's
+    /// tables expire snapshots — an existing table keeps the policy it was
+    /// created with, and the `run` service is configured from a file
+    /// (`configmap-maintain.yaml`) that carries no `snapshot_expiration` block
+    /// at all. Nor is expiration the only source of the hazard: a grace period
+    /// of zero also lets the sweep take a compaction output written but not yet
+    /// referenced by any manifest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `gc` and `gc.orphans` are both enabled and
+    /// `gc.orphans.min_age_secs` is zero.
+    fn validate_orphan_grace_period(&self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.gc.enabled && self.gc.orphans.enabled && self.gc.orphans.min_age_secs == 0 {
+            return Err(Box::new(MaintainError::Config(
+                "gc.orphans.min_age_secs must be greater than zero: a swept file has to stay \
+                 unreferenced for longer than query.engine.max_age_secs (positive by definition) \
+                 so a cached catalog provider cannot plan a read against a file already deleted, \
+                 and the grace period is also what keeps a compaction output not yet referenced \
+                 by any manifest out of the sweep's reach"
+                    .to_string(),
+            )));
+        }
         Ok(())
     }
 }
@@ -209,6 +268,132 @@ tracing:
 
         assert!((config.tracing.sample_ratio - 0.5).abs() < f64::EPSILON);
         config.tracing.validate().expect("0.5 is within [0.0, 1.0]");
+    }
+
+    /// The `snapshot_expiration` block in the shape `configmap-migrate.yaml`
+    /// renders it. Serde drops unknown keys in silence, so a renamed field would
+    /// leave `migrate create` stamping the built-in defaults onto every table
+    /// while the `ConfigMap` claims otherwise — and the window a table is created
+    /// with is the window it keeps.
+    #[test]
+    fn the_snapshot_expiration_block_the_chart_renders_lands_on_the_config() {
+        let yaml = r"
+catalog:
+  backend: !rest
+    uri: http://nessie:19120/iceberg
+  warehouse: s3://warehouse/
+storage:
+  backend: !s3
+    bucket: warehouse
+    region: us-east-1
+    endpoint: http://localhost:9000
+snapshot_expiration:
+  enabled: true
+  min_snapshots_to_keep: 10
+  max_snapshot_age_ms: 600000
+  metadata_previous_versions_max: 20
+";
+        let config: MaintainConfig = serde_yaml::from_str(yaml).expect("parse chart-style expiration config");
+
+        assert!(config.snapshot_expiration.enabled);
+        assert_eq!(config.snapshot_expiration.min_snapshots_to_keep, 10);
+        assert_eq!(config.snapshot_expiration.max_snapshot_age_ms, 600_000);
+        assert_eq!(config.snapshot_expiration.metadata_previous_versions_max, 20);
+        config.validate().expect("the chart-rendered block must validate");
+    }
+
+    /// A window that cannot be satisfied must fail at load, where it is one
+    /// failed `migrate`, rather than reaching a table property and failing every
+    /// subsequent commit by every writer.
+    #[test]
+    fn a_config_with_an_impossible_retention_window_fails_to_validate() {
+        let yaml = r"
+catalog:
+  backend: !rest
+    uri: http://nessie:19120/iceberg
+  warehouse: s3://warehouse/
+storage:
+  backend: !s3
+    bucket: warehouse
+    region: us-east-1
+    endpoint: http://localhost:9000
+snapshot_expiration:
+  min_snapshots_to_keep: 0
+";
+        let config: MaintainConfig = serde_yaml::from_str(yaml).expect("parse config with a zero window");
+
+        assert!(config.validate().is_err());
+    }
+
+    /// A config whose sweep runs with no grace period. `enabled` is spelled out
+    /// in every block the check reads, so a default flipping later cannot make
+    /// the case pass by accident.
+    const ZERO_ORPHAN_GRACE_PERIOD: &str = r"
+catalog:
+  backend: !rest
+    uri: http://nessie:19120/iceberg
+  warehouse: s3://warehouse/
+storage:
+  backend: !s3
+    bucket: warehouse
+    region: us-east-1
+    endpoint: http://localhost:9000
+snapshot_expiration:
+  enabled: true
+gc:
+  enabled: true
+  orphans:
+    enabled: true
+    min_age_secs: 0
+";
+
+    /// Sweeping with no grace period deletes files a cached query provider may
+    /// still plan against, and `query.engine.max_age_secs` — the width of that
+    /// cache — is required to be positive, so the ordering is violated for any
+    /// value of it. The chart rejects this too; a Compose or hand-written config
+    /// reaches only here.
+    #[test]
+    fn a_zero_orphan_grace_period_is_rejected() {
+        let config: MaintainConfig =
+            serde_yaml::from_str(ZERO_ORPHAN_GRACE_PERIOD).expect("parse config with a zero grace period");
+
+        assert!(
+            config.validate().is_err(),
+            "a zero grace period must be rejected while the sweep is enabled"
+        );
+    }
+
+    /// The same zero grace period with expiration stamped off. The verdict must
+    /// not move: `snapshot_expiration` describes what `migrate create` writes
+    /// onto new tables, not the policy the tables of this deployment carry, and
+    /// the `run` service's own config file has no such block to read.
+    #[test]
+    fn a_zero_orphan_grace_period_is_rejected_with_expiration_disabled() {
+        let yaml = ZERO_ORPHAN_GRACE_PERIOD.replace(
+            "snapshot_expiration:\n  enabled: true",
+            "snapshot_expiration:\n  enabled: false",
+        );
+        let config: MaintainConfig = serde_yaml::from_str(&yaml).expect("parse config with expiration disabled");
+
+        assert!(!config.snapshot_expiration.enabled, "the replacement must have landed");
+        assert!(
+            config.validate().is_err(),
+            "the grace-period contract does not depend on what migrate stamps onto new tables"
+        );
+    }
+
+    /// The `run` service is configured from `configmap-maintain.yaml`, which
+    /// renders `gc` but no `snapshot_expiration` block — the shape that made the
+    /// earlier conditional check unreachable in Kubernetes. A positive grace
+    /// period is what that config needs to validate.
+    #[test]
+    fn a_positive_orphan_grace_period_validates_without_an_expiration_block() {
+        let yaml = ZERO_ORPHAN_GRACE_PERIOD
+            .replace("snapshot_expiration:\n  enabled: true\n", "")
+            .replace("min_age_secs: 0", "min_age_secs: 604800");
+        let config: MaintainConfig = serde_yaml::from_str(&yaml).expect("parse chart-style maintain config");
+
+        config.validate().expect("the sweep validates on a positive grace period");
     }
 
     /// Serde ignores unknown keys, so a `ConfigMap` key with no matching field

--- a/crates/icegate-maintain/src/gc/config.rs
+++ b/crates/icegate-maintain/src/gc/config.rs
@@ -16,8 +16,15 @@ pub struct GcOrphansConfig {
     pub dry_run: bool,
     /// Grace period in seconds: an object is eligible for deletion only if its
     /// `last_modified` is older than this. Protects freshly written files and
-    /// in-flight compaction outputs not yet referenced by a manifest. `0` means
-    /// no grace period.
+    /// in-flight compaction outputs not yet referenced by a manifest, and keeps
+    /// a file a cached query provider may still name out of the sweep's reach —
+    /// the deployment contract is
+    /// `query.engine.max_age_secs < gc.orphans.min_age_secs`.
+    ///
+    /// `0` disables the grace period and is rejected by
+    /// `MaintainConfig::validate` while the sweep is enabled: `max_age_secs` is
+    /// positive by definition, so zero breaks the ordering whatever it is set
+    /// to.
     pub min_age_secs: u64,
     /// When `true`, also sweep orphaned Iceberg metadata files (manifests,
     /// manifest lists, superseded `*.metadata.json`); when `false`, only data
@@ -48,7 +55,9 @@ impl GcOrphansConfig {
     /// # Errors
     ///
     /// Returns [`MaintainError::Config`] if `delete_concurrency` or
-    /// `sweep_timeout_secs` is zero. `min_age_secs` of `0` is allowed (no grace).
+    /// `sweep_timeout_secs` is zero. `min_age_secs` of `0` passes here — the
+    /// grace-period contract also involves the `gc.enabled` master switch, so it
+    /// is checked by `MaintainConfig::validate`, which sees both blocks.
     pub fn validate(&self) -> Result<(), MaintainError> {
         if self.delete_concurrency == 0 {
             return Err(MaintainError::Config(
@@ -204,9 +213,14 @@ mod tests {
         assert!(config.validate().is_err());
     }
 
+    /// `min_age_secs == 0` is the documented "no grace period" setting, and this
+    /// block cannot tell whether it is safe: that depends on whether the sweep
+    /// runs at all, which is the `gc.enabled` / `gc.orphans.enabled` pair only
+    /// `MaintainConfig` sees. With both on, zero also exposes a compaction
+    /// output written but not yet referenced by a manifest. The combined rule is
+    /// tested in `crate::config`.
     #[test]
-    fn validate_allows_zero_min_age() {
-        // `min_age_secs == 0` is the documented "no grace period" setting.
+    fn validate_allows_zero_min_age_on_its_own() {
         let mut config = valid_config();
         config.orphans.min_age_secs = 0;
         assert!(config.validate().is_ok());

--- a/crates/icegate-maintain/src/migrate/README.md
+++ b/crates/icegate-maintain/src/migrate/README.md
@@ -1,0 +1,80 @@
+# Table migration and snapshot retention
+
+`migrate create` creates the six IceGate tables from the schema module and stamps
+their properties; `migrate upgrade` reports schema drift and never rewrites a
+table in place. Both exit when done. What each command does with an existing
+table is documented on [`operations.rs`](operations.rs); what a policy field
+means, on the field in [`config.rs`](config.rs).
+
+This file covers what no single field can state: where snapshot expiration
+actually runs, and what an operator inherits by turning it on.
+
+## Why history is bounded
+
+IceGate does not use time travel, but every live snapshot in `metadata.json`
+keeps its manifests and data files referenced. GC's reachable set is built from
+those snapshots, so an unbounded history leaves the sweep nothing to reclaim and
+makes compaction free space on paper only.
+
+## Where expiration runs
+
+Not here, and not as a job anywhere in this crate. `migrate create` writes a
+retention policy into the properties of each table it creates; from then on every
+commit against that table — an ingest shift, a compaction rewrite, a pricing
+append — resolves the policy from those properties and carries a
+`RemoveSnapshots` update along with whatever it was already writing. The
+mechanism, and which snapshots it will never expire, belong to `iceberg-rust`
+(`transaction/snapshot_expiration.rs` in the `icegatetech` fork).
+
+Which properties carry the policy is
+[`SnapshotExpirationConfig::build_table_properties`](config.rs) — the spec keys
+are named there, against the constants of the spec crate. One of them is not a
+config field: the summary key whose carrier expiration must keep reachable is
+derived per table, because it is a promise about that table's own summaries.
+IceGate uses it for the WAL offset, so it is stamped onto the five tables the
+Shifter writes and left off `prices`
+([`operations.rs`](operations.rs)).
+
+## What the operator inherits
+
+- **The policy is written once, at creation.** `migrate create` skips a table
+  that already exists, properties included, and `migrate upgrade` does not touch
+  properties either. Changing the config re-stamps nothing; there is no backfill
+  command. A table created before this policy existed keeps its history forever.
+- **A live table is turned off on the table.** Setting
+  `history.expire.enabled=false` on the table itself is what stops expiration.
+  The `snapshot_expiration` block describes tables not yet created, which is why
+  nothing else in this crate reads it as a statement about the deployment.
+- **Expiration rides on commits and only on commits.** A table nothing writes to
+  never converges to its window: GC opens no transaction, and neither does an
+  empty one. TODO in the fork: an operator-driven one-off catch-up.
+- **A long history converges gradually.** One commit expires a bounded number of
+  snapshots, so a first run against a neglected table does not produce a
+  multi-megabyte commit body — the window is reached over several commits, at the
+  rate commits arrive.
+- **A bad property value fails the write, not a job.** An unparsable or
+  out-of-range `history.expire.*` value fails the commit that resolved it with
+  `DataInvalid`. Since every writer resolves it, that stops ingest, not just
+  maintenance. `MaintainConfig::validate` catches such a window while it is still
+  a config file; edits made directly to a live table's properties have no such
+  gate.
+- **Side branches keep their head, not their history.** Every reference target
+  survives, but the retained window is walked from the current snapshot alone, so
+  a branch's own ancestors expire out from under it. Per-branch retention
+  overrides (`SnapshotRetention`) are not resolved yet — TODO in the fork.
+
+## Rollback stops at the window
+
+A superseded `metadata.json` older than the retention window is not a restore
+point. The manifests and data files of the snapshots it names became orphans the
+moment those snapshots expired, and the sweep takes them once
+`gc.orphans.min_age_secs` has passed. Rolling a table back to such a version
+yields metadata pointing at deleted files — silently, since nothing rejects the
+rollback itself.
+
+This is why `metadata_previous_versions_max` is validated against
+`min_snapshots_to_keep` rather than set independently: a metadata log shorter
+than the snapshot window drops versions covering snapshots the table is still
+required to keep, and `icegate-catalog-s3` resolves a lost commit ack by finding
+its own metadata file in the head's metadata log — a log truncated past that
+point turns a landed commit into an unrecognised one.

--- a/crates/icegate-maintain/src/migrate/config.rs
+++ b/crates/icegate-maintain/src/migrate/config.rs
@@ -1,0 +1,289 @@
+//! Snapshot-retention policy that `migrate` writes onto the tables it creates.
+//!
+//! Expiration itself is not run here, nor anywhere in this crate: every commit
+//! against a table — an ingest shift, a compaction rewrite, a pricing append —
+//! resolves the policy from that table's own properties and carries the
+//! `RemoveSnapshots` update along with whatever it was already writing. This
+//! config is only the source of the values `migrate create` stamps into the
+//! table, which is what makes them auditable in `metadata.json` instead of an
+//! implicit default living in code.
+
+use std::collections::HashMap;
+
+use iceberg::spec::TableProperties;
+use serde::{Deserialize, Serialize};
+
+use crate::error::MaintainError;
+
+/// Number of newest ancestors of the current snapshot that always survive.
+///
+/// IceGate does not use time travel, so history exists only to keep the WAL
+/// offset and the in-flight readers of a snapshot reachable; this much slack is
+/// well past both and still small enough that expiration is what bounds the
+/// metadata, rather than the Iceberg spec default of a single ancestor.
+const DEFAULT_MIN_SNAPSHOTS_TO_KEEP: usize = 100;
+
+/// Age past which a snapshot is expired.
+///
+/// The floor is the query engine's provider cache (`query.engine.max_age_secs`):
+/// a snapshot must outlive any cached reference to it, or a query can plan
+/// against manifests the sweep has already collected.
+const DEFAULT_MAX_SNAPSHOT_AGE_MS: i64 = 30 * 60 * 1000;
+
+/// Number of superseded `metadata.json` versions a table keeps.
+///
+/// Beyond the retention window a stored `metadata.json` is not a restore point:
+/// its snapshots' manifests and data files became orphans the moment those
+/// snapshots expired and are swept once GC's grace period passes, so keeping
+/// versions past the window only preserves files that no longer describe
+/// recoverable data. Twice the snapshot window rather than exactly it: the S3
+/// catalog resolves a lost commit ack by looking its own metadata file up in
+/// the head's metadata-log (`icegate-catalog-s3` `root.rs`), and that verdict
+/// is sound only while the log has not been truncated past it.
+const DEFAULT_METADATA_PREVIOUS_VERSIONS_MAX: usize = 2 * DEFAULT_MIN_SNAPSHOTS_TO_KEEP;
+
+/// Snapshot-retention policy stamped onto every table `migrate create` creates.
+///
+/// Field-for-field the `history.expire.*` table properties of the Iceberg spec,
+/// plus the metadata-log bound that has to move with them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SnapshotExpirationConfig {
+    /// Whether created tables expire snapshots at all. Writing `false` here does
+    /// not stop expiration on tables that already exist — the property on the
+    /// table is what every writer resolves, so an existing table is turned off
+    /// by setting `history.expire.enabled=false` on the table itself.
+    pub enabled: bool,
+    /// Newest ancestors of the current snapshot that always survive.
+    pub min_snapshots_to_keep: usize,
+    /// Age in milliseconds past which a snapshot is eligible for expiration.
+    pub max_snapshot_age_ms: i64,
+    /// Superseded `metadata.json` versions a table keeps.
+    pub metadata_previous_versions_max: usize,
+}
+
+impl Default for SnapshotExpirationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            min_snapshots_to_keep: DEFAULT_MIN_SNAPSHOTS_TO_KEEP,
+            max_snapshot_age_ms: DEFAULT_MAX_SNAPSHOT_AGE_MS,
+            metadata_previous_versions_max: DEFAULT_METADATA_PREVIOUS_VERSIONS_MAX,
+        }
+    }
+}
+
+impl SnapshotExpirationConfig {
+    /// The `history.expire.*` properties this policy contributes to a table.
+    ///
+    /// `preserved_summary_property` names a snapshot-summary key whose most
+    /// recent carrier — and the ancestor chain leading to it — expiration must
+    /// keep reachable. Tables whose snapshots carry no such key pass `None`:
+    /// the property is a promise about that table's summaries, and naming a key
+    /// nothing writes only tells every writer to look for a carrier that will
+    /// never be there.
+    pub fn build_table_properties(&self, preserved_summary_property: Option<&str>) -> HashMap<String, String> {
+        // `enabled` is written either way: absent reads as "off" to a writer,
+        // so an explicit `false` is what distinguishes a table deliberately
+        // opted out from one created before this policy existed.
+        let mut properties = HashMap::from([
+            (
+                TableProperties::PROPERTY_HISTORY_EXPIRE_ENABLED.to_string(),
+                self.enabled.to_string(),
+            ),
+            (
+                TableProperties::PROPERTY_HISTORY_EXPIRE_MIN_SNAPSHOTS_TO_KEEP.to_string(),
+                self.min_snapshots_to_keep.to_string(),
+            ),
+            (
+                TableProperties::PROPERTY_HISTORY_EXPIRE_MAX_SNAPSHOT_AGE_MS.to_string(),
+                self.max_snapshot_age_ms.to_string(),
+            ),
+            (
+                TableProperties::PROPERTY_METADATA_PREVIOUS_VERSIONS_MAX.to_string(),
+                self.metadata_previous_versions_max.to_string(),
+            ),
+        ]);
+
+        if let Some(key) = preserved_summary_property {
+            properties.insert(
+                TableProperties::PROPERTY_HISTORY_EXPIRE_PRESERVE_SUMMARY_PROPERTY.to_string(),
+                key.to_string(),
+            );
+        }
+
+        properties
+    }
+
+    /// Validate the retention window.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MaintainError::Config`] when a bound is zero or negative, or
+    /// when the metadata-log bound is shorter than the snapshot window — a
+    /// table would then drop `metadata.json` versions covering snapshots it is
+    /// still required to keep, and the S3 catalog loses the metadata-log
+    /// evidence it resolves a lost commit ack with.
+    pub fn validate(&self) -> Result<(), MaintainError> {
+        if self.min_snapshots_to_keep == 0 {
+            return Err(MaintainError::Config(
+                "snapshot_expiration.min_snapshots_to_keep must be greater than zero".to_string(),
+            ));
+        }
+        if self.max_snapshot_age_ms <= 0 {
+            return Err(MaintainError::Config(
+                "snapshot_expiration.max_snapshot_age_ms must be greater than zero".to_string(),
+            ));
+        }
+        if self.metadata_previous_versions_max < self.min_snapshots_to_keep {
+            return Err(MaintainError::Config(format!(
+                "snapshot_expiration.metadata_previous_versions_max ({}) must be at least \
+                 min_snapshots_to_keep ({}): the table would drop metadata.json versions \
+                 covering snapshots it is still required to keep, and the S3 catalog resolves \
+                 a lost commit ack by finding its own metadata file in the head's metadata-log \
+                 — a log truncated past that point turns a landed commit into an unrecognised one",
+                self.metadata_previous_versions_max, self.min_snapshots_to_keep
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iceberg::spec::TableProperties;
+    use icegate_common::WAL_OFFSET_PROPERTY;
+
+    use super::SnapshotExpirationConfig;
+
+    #[test]
+    fn defaults_keep_a_hundred_snapshots_for_thirty_minutes() {
+        let config = SnapshotExpirationConfig::default();
+
+        assert!(config.enabled);
+        assert_eq!(config.min_snapshots_to_keep, 100);
+        assert_eq!(config.max_snapshot_age_ms, 1_800_000);
+        assert_eq!(config.metadata_previous_versions_max, 200);
+        config.validate().expect("the shipped defaults must validate");
+    }
+
+    /// `DEFAULT_MAX_AGE_SECS` of `icegate-query` `engine/config.rs`: the width of
+    /// the query engine's provider cache. `icegate-maintain` does not depend on
+    /// that crate, so this is a hand-synced copy — the one place the floor is
+    /// named here, rather than a literal inside the assertion.
+    const QUERY_PROVIDER_CACHE_SECS: i64 = 30;
+
+    /// The window has to outlive the query engine's provider cache, or a cached
+    /// provider can plan against a snapshot whose files GC has already swept.
+    /// The chart checks the two *configured* values against each other; this
+    /// checks the two defaults, which is what a Compose or hand-written
+    /// deployment runs on.
+    #[test]
+    fn default_window_outlives_the_query_provider_cache() {
+        assert!(
+            SnapshotExpirationConfig::default().max_snapshot_age_ms > QUERY_PROVIDER_CACHE_SECS * 1000,
+            "the default retention window must clear the query provider cache"
+        );
+    }
+
+    #[test]
+    fn properties_carry_the_window_and_the_preserved_summary_key() {
+        let properties = SnapshotExpirationConfig::default().build_table_properties(Some(WAL_OFFSET_PROPERTY));
+
+        assert_eq!(
+            properties.get(TableProperties::PROPERTY_HISTORY_EXPIRE_ENABLED),
+            Some(&"true".to_string())
+        );
+        assert_eq!(
+            properties.get(TableProperties::PROPERTY_HISTORY_EXPIRE_MIN_SNAPSHOTS_TO_KEEP),
+            Some(&"100".to_string())
+        );
+        assert_eq!(
+            properties.get(TableProperties::PROPERTY_HISTORY_EXPIRE_MAX_SNAPSHOT_AGE_MS),
+            Some(&"1800000".to_string())
+        );
+        assert_eq!(
+            properties.get(TableProperties::PROPERTY_METADATA_PREVIOUS_VERSIONS_MAX),
+            Some(&"200".to_string())
+        );
+        assert_eq!(
+            properties.get(TableProperties::PROPERTY_HISTORY_EXPIRE_PRESERVE_SUMMARY_PROPERTY),
+            Some(&"icegate.queue.offset".to_string())
+        );
+    }
+
+    /// A table nothing stamps the WAL offset onto must not advertise a carrier:
+    /// writers would look for one on every expiring commit and log that the
+    /// history is unprotected, which for that table is simply the truth.
+    #[test]
+    fn no_preserved_key_is_written_when_the_table_carries_none() {
+        let properties = SnapshotExpirationConfig::default().build_table_properties(None);
+
+        assert!(
+            !properties.contains_key(TableProperties::PROPERTY_HISTORY_EXPIRE_PRESERVE_SUMMARY_PROPERTY),
+            "a table with no offset-carrying snapshots must not name a preserved summary key"
+        );
+    }
+
+    /// Disabled is written as an explicit `false` rather than by omitting the
+    /// key, so the table records the decision instead of looking untouched.
+    #[test]
+    fn disabled_policy_writes_an_explicit_false() {
+        let config = SnapshotExpirationConfig {
+            enabled: false,
+            ..SnapshotExpirationConfig::default()
+        };
+
+        assert_eq!(
+            config.build_table_properties(None).get("history.expire.enabled"),
+            Some(&"false".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_rejects_a_zero_snapshot_window() {
+        let config = SnapshotExpirationConfig {
+            min_snapshots_to_keep: 0,
+            ..SnapshotExpirationConfig::default()
+        };
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_a_non_positive_age() {
+        for max_snapshot_age_ms in [0, -1] {
+            let config = SnapshotExpirationConfig {
+                max_snapshot_age_ms,
+                ..SnapshotExpirationConfig::default()
+            };
+
+            assert!(
+                config.validate().is_err(),
+                "max_snapshot_age_ms {max_snapshot_age_ms} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_a_metadata_log_shorter_than_the_snapshot_window() {
+        let config = SnapshotExpirationConfig {
+            min_snapshots_to_keep: 10,
+            metadata_previous_versions_max: 9,
+            ..SnapshotExpirationConfig::default()
+        };
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_a_metadata_log_exactly_as_long_as_the_window() {
+        let config = SnapshotExpirationConfig {
+            min_snapshots_to_keep: 10,
+            metadata_previous_versions_max: 10,
+            ..SnapshotExpirationConfig::default()
+        };
+
+        assert!(config.validate().is_ok());
+    }
+}

--- a/crates/icegate-maintain/src/migrate/mod.rs
+++ b/crates/icegate-maintain/src/migrate/mod.rs
@@ -9,4 +9,5 @@
 //! - Add validation and dry-run support
 //! - Integrate with existing schemas from schema.rs
 
+pub mod config;
 pub mod operations;

--- a/crates/icegate-maintain/src/migrate/operations.rs
+++ b/crates/icegate-maintain/src/migrate/operations.rs
@@ -2,9 +2,11 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use iceberg::spec::TableProperties;
 use iceberg::{Catalog, NamespaceIdent, TableCreation, TableIdent};
 use icegate_common::{
     EVENTS_TABLE, ICEGATE_NAMESPACE, LOGS_TABLE, METRICS_TABLE, OPERATIONS_TABLE, PRICES_TABLE, SPANS_TABLE,
+    WAL_OFFSET_PROPERTY,
     schema::{
         events_partition_spec, events_schema, events_sort_order, logs_partition_spec, logs_schema, logs_sort_order,
         metrics_partition_spec, metrics_schema, metrics_sort_order, operations_partition_spec, operations_schema,
@@ -14,6 +16,7 @@ use icegate_common::{
 };
 
 use crate::error::Result;
+use crate::migrate::config::SnapshotExpirationConfig;
 
 /// Migration operation types
 #[derive(Debug, Clone)]
@@ -36,6 +39,11 @@ struct TableDefinition {
     schema: iceberg::spec::Schema,
     partition_spec: iceberg::spec::PartitionSpec,
     sort_order: iceberg::spec::SortOrder,
+    /// Whether this table's snapshots record the WAL queue offset in their
+    /// summary. True for every table the Shifter writes, whose readers resolve
+    /// that offset by walking the ancestor chain — expiration must be told to
+    /// keep the chain down to its most recent carrier intact.
+    carries_wal_offset: bool,
 }
 
 /// Build table definitions from schema module
@@ -51,6 +59,7 @@ fn build_table_definitions() -> Result<Vec<TableDefinition>> {
         schema: logs,
         partition_spec: logs_partition,
         sort_order: logs_sort,
+        carries_wal_offset: true,
     });
 
     // Spans table
@@ -62,6 +71,7 @@ fn build_table_definitions() -> Result<Vec<TableDefinition>> {
         schema: spans,
         partition_spec: spans_partition,
         sort_order: spans_sort,
+        carries_wal_offset: true,
     });
 
     // Events table
@@ -73,6 +83,7 @@ fn build_table_definitions() -> Result<Vec<TableDefinition>> {
         schema: events,
         partition_spec: events_partition,
         sort_order: events_sort,
+        carries_wal_offset: true,
     });
 
     // Metrics table
@@ -84,6 +95,7 @@ fn build_table_definitions() -> Result<Vec<TableDefinition>> {
         schema: metrics,
         partition_spec: metrics_partition,
         sort_order: metrics_sort,
+        carries_wal_offset: true,
     });
 
     // Operations table (LLM/GenAI projection over spans — the 5th physical table).
@@ -95,6 +107,7 @@ fn build_table_definitions() -> Result<Vec<TableDefinition>> {
         schema: operations,
         partition_spec: operations_partition,
         sort_order: operations_sort,
+        carries_wal_offset: true,
     });
 
     // Prices table (global LLM rate card — the 6th physical table, and the only
@@ -107,6 +120,9 @@ fn build_table_definitions() -> Result<Vec<TableDefinition>> {
         schema: prices,
         partition_spec: prices_partition,
         sort_order: prices_sort,
+        // The pricing crawler writes this table, not the Shifter: its snapshots
+        // carry no WAL offset, so expiration has no carrier to preserve here.
+        carries_wal_offset: false,
     });
 
     Ok(definitions)
@@ -123,7 +139,10 @@ fn build_table_definitions() -> Result<Vec<TableDefinition>> {
 /// - prices: global LLM rate card (no `tenant_id`, unpartitioned)
 ///
 /// Each table is created with appropriate partition specs and sort orders
-/// for optimal query performance.
+/// for optimal query performance, and with the `expiration` policy written into
+/// its properties — that stamp is what makes any later writer expire this
+/// table's snapshots, so a table created without it keeps its history forever.
+/// Existing tables are left untouched, properties included.
 ///
 /// # Return Value
 ///
@@ -133,11 +152,22 @@ fn build_table_definitions() -> Result<Vec<TableDefinition>> {
 /// # Errors
 ///
 /// Returns an error if:
+/// - `expiration` is out of the bounds of [`SnapshotExpirationConfig::validate`]
 /// - Schema construction fails
 /// - Namespace creation fails
 /// - Table creation fails (except for "already exists" errors)
 #[allow(clippy::cognitive_complexity)]
-pub async fn create_tables(catalog: &Arc<dyn Catalog>, dry_run: bool) -> Result<Vec<MigrationOperation>> {
+pub async fn create_tables(
+    catalog: &Arc<dyn Catalog>,
+    expiration: &SnapshotExpirationConfig,
+    dry_run: bool,
+) -> Result<Vec<MigrationOperation>> {
+    // A policy is stamped once and never re-stamped, so an out-of-range window
+    // reaching a table's properties fails every later commit against it — ingest
+    // included. The CLI validates the whole config, but this is a public entry
+    // point and the stamp is what it exists to write.
+    expiration.validate()?;
+
     let catalog_ref = catalog.as_ref();
     let namespace = NamespaceIdent::new(ICEGATE_NAMESPACE.to_string());
 
@@ -164,7 +194,7 @@ pub async fn create_tables(catalog: &Arc<dyn Catalog>, dry_run: bool) -> Result<
             tracing::info!("[dry-run] Would create table: {}", def.name);
         } else {
             tracing::info!("Creating table: {}", def.name);
-            create_table(catalog_ref, &namespace, &def).await?;
+            create_table(catalog_ref, &namespace, &def, expiration).await?;
             tracing::info!("Created table: {}", def.name);
         }
 
@@ -193,16 +223,27 @@ async fn ensure_namespace_exists(catalog: &dyn Catalog, namespace: &NamespaceIde
 }
 
 /// Create a single table in the catalog
-async fn create_table(catalog: &dyn Catalog, namespace: &NamespaceIdent, def: &TableDefinition) -> Result<()> {
+async fn create_table(
+    catalog: &dyn Catalog,
+    namespace: &NamespaceIdent,
+    def: &TableDefinition,
+    expiration: &SnapshotExpirationConfig,
+) -> Result<()> {
+    let mut properties = expiration.build_table_properties(def.carries_wal_offset.then_some(WAL_OFFSET_PROPERTY));
+    properties.extend([
+        (
+            TableProperties::PROPERTY_DEFAULT_FILE_FORMAT.to_string(),
+            "parquet".to_string(),
+        ),
+        ("write.parquet.compression-codec".to_string(), "zstd".to_string()),
+    ]);
+
     let table_creation = TableCreation::builder()
         .name(def.name.to_string())
         .schema(def.schema.clone())
         .partition_spec(def.partition_spec.clone())
         .sort_order(def.sort_order.clone())
-        .properties(HashMap::from([
-            ("write.format.default".to_string(), "parquet".to_string()),
-            ("write.parquet.compression-codec".to_string(), "zstd".to_string()),
-        ]))
+        .properties(properties)
         .build();
 
     catalog.create_table(namespace, table_creation).await?;
@@ -496,6 +537,25 @@ mod tests {
             prices.partition_spec.fields().is_empty(),
             "prices is the one unpartitioned table"
         );
+    }
+
+    /// Every table the Shifter writes must advertise a WAL-offset carrier to
+    /// expiration; `prices`, written by the pricing crawler, must not — nothing
+    /// stamps an offset onto its snapshots.
+    #[test]
+    fn only_shifter_written_tables_declare_a_wal_offset_carrier() {
+        let definitions = build_table_definitions().expect("build table definitions");
+
+        for def in &definitions {
+            let expected = def.name != PRICES_TABLE;
+            assert_eq!(
+                def.carries_wal_offset,
+                expected,
+                "{} must{} declare a WAL-offset carrier",
+                def.name,
+                if expected { "" } else { " not" }
+            );
+        }
     }
 
     #[test]

--- a/crates/icegate-maintain/tests/common/mod.rs
+++ b/crates/icegate-maintain/tests/common/mod.rs
@@ -2,21 +2,48 @@
 //!
 //! Centralizes the object-store bootstrap contract — container start, bucket
 //! creation, and concrete [`S3Catalog`] construction — shared verbatim across
-//! the maintain integration tests.
+//! the maintain integration tests, plus the `logs` writer path and the raw
+//! object-store listing the sweep tests assert against.
 
 // Each integration-test binary pulls this module in via `mod common;` and may
 // exercise only a subset of these helpers, so unused-item lints are expected.
 #![allow(dead_code, clippy::expect_used, clippy::unwrap_used)]
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use arrow::array::{Array, FixedSizeBinaryArray, MapArray, StringArray, StructArray, TimestampMicrosecondArray};
+use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::{DataType, Schema as ArrowSchema};
+use arrow::record_batch::RecordBatch;
+use futures::StreamExt;
 use iceberg::io::FileIOBuilder;
+use iceberg::spec::{DataFile, DataFileFormat};
+use iceberg::table::Table;
+use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
+use iceberg::writer::file_writer::ParquetWriterBuilder;
+use iceberg::writer::file_writer::location_generator::{DefaultFileNameGenerator, DefaultLocationGenerator};
+use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
+use iceberg::writer::partitioning::PartitioningWriter;
+use iceberg::writer::partitioning::fanout_writer::FanoutWriter;
 use icegate_catalog_s3::{CatalogCodecKind, S3Catalog, S3CatalogConfig};
 use icegate_common::catalog::IoHandle;
-use icegate_common::testing::{S3TestContainer, create_s3_bucket};
+use icegate_common::schema::logs_schema;
+use icegate_common::storage::{OperatorRegistry, S3Config, StorageBackend, StorageConfig};
+use icegate_common::testing::{S3TestContainer, create_s3_bucket, create_s3_object_store};
+use object_store::ObjectStore;
+use parquet::file::properties::WriterProperties;
+use uuid::Uuid;
 
 /// Object-store bucket every maintain integration test provisions and targets.
 pub const BUCKET_NAME: &str = "warehouse";
+
+/// Tenant every seeded `logs` row belongs to.
+pub const TENANT: &str = "tenant-a";
+
+/// 2026-06-11T00:00:00Z in microseconds. Rows seeded with this timestamp all
+/// land in the same `(tenant_id, day)` partition, so one batch yields one file.
+pub const DAY_MICROS: i64 = 1_749_600_000_000_000;
 
 /// Connection parameters for a running object store.
 #[derive(Clone)]
@@ -66,4 +93,129 @@ pub async fn build_s3_catalog(conn: &StorageConn) -> S3Catalog {
     )
     .await
     .expect("build S3 catalog")
+}
+
+/// The `StorageConfig` a sweep uses to build a raw object store.
+///
+/// The container credentials are threaded straight into the config, so a sweep
+/// authenticates against this test's object store without relying on ambient
+/// `AWS_*` environment variables.
+pub fn storage_config(conn: &StorageConn) -> StorageConfig {
+    StorageConfig {
+        backend: StorageBackend::S3(S3Config {
+            bucket: BUCKET_NAME.to_string(),
+            region: "us-east-1".to_string(),
+            endpoint: Some(conn.endpoint.clone()),
+            access_key_id: Some(conn.access_key.clone()),
+            secret_access_key: Some(conn.secret_key.clone()),
+        }),
+    }
+}
+
+/// The registry a sweep resolves its object store through, wired the way the
+/// maintain binary wires it: no read cache, the container's backend.
+pub async fn build_operator_registry(conn: &StorageConn) -> Arc<OperatorRegistry> {
+    IoHandle::from_config(None, Some(&storage_config(conn).backend))
+        .await
+        .expect("io handle")
+        .object_store_operator_registry()
+}
+
+/// List every object key in the bucket (sorted) via a direct object store, so
+/// assertions about what physically survives a sweep never go through the code
+/// that decides what to delete.
+pub async fn list_all_object_keys(conn: &StorageConn) -> Vec<String> {
+    let store: Arc<dyn ObjectStore> = create_s3_object_store(&conn.endpoint, BUCKET_NAME).expect("test object store");
+    let mut stream = store.list(None);
+    let mut keys = Vec::new();
+    while let Some(meta) = stream.next().await {
+        keys.push(meta.expect("list object").location.as_ref().to_string());
+    }
+    keys.sort();
+    keys
+}
+
+/// Build one `logs` Arrow batch from `(service_name, timestamp_micros)` rows,
+/// laid out in the caller's order. The `body` column is `msg-<unique>` so every
+/// row is globally distinguishable.
+pub fn logs_batch(rows: &[(&str, i64)], unique_offset: usize) -> RecordBatch {
+    let iceberg_schema = logs_schema().unwrap();
+    let arrow_schema = Arc::new(iceberg::arrow::schema_to_arrow_schema(&iceberg_schema).unwrap());
+    let n = rows.len();
+
+    let tenant = StringArray::from(vec![TENANT; n]);
+    let service_name = StringArray::from(rows.iter().map(|(s, _)| Some(*s)).collect::<Vec<_>>());
+    let ts: Vec<i64> = rows.iter().map(|(_, t)| *t).collect();
+    let trace_vals: Vec<[u8; 16]> = (0..n).map(|i| [u8::try_from((unique_offset + i) % 256).unwrap(); 16]).collect();
+    let trace_id = FixedSizeBinaryArray::try_from_iter(trace_vals.iter().map(|v| v.to_vec())).unwrap();
+    let span_vals: Vec<[u8; 8]> = (0..n).map(|i| [u8::try_from((unique_offset + i) % 256).unwrap(); 8]).collect();
+    let span_id = FixedSizeBinaryArray::try_from_iter(span_vals.iter().map(|v| v.to_vec())).unwrap();
+    let attributes = empty_string_map(&arrow_schema, n);
+
+    RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(tenant),
+            Arc::new(service_name),
+            Arc::new(TimestampMicrosecondArray::from(ts.clone())),
+            Arc::new(TimestampMicrosecondArray::from(ts.clone())),
+            Arc::new(TimestampMicrosecondArray::from(ts)),
+            Arc::new(trace_id),
+            Arc::new(span_id),
+            Arc::new(StringArray::from(vec![Some("INFO"); n])),
+            Arc::new(StringArray::from(
+                (0..n).map(|i| Some(format!("msg-{}", unique_offset + i))).collect::<Vec<_>>(),
+            )),
+            attributes,
+        ],
+    )
+    .expect("record batch")
+}
+
+/// Build an empty `MAP<Utf8,Utf8>` column of length `rows` typed exactly like
+/// the `attributes` field of the iceberg-derived arrow schema.
+fn empty_string_map(arrow_schema: &ArrowSchema, rows: usize) -> Arc<dyn Array> {
+    let attr_field = arrow_schema.field_with_name("attributes").unwrap();
+    let DataType::Map(entry_field, ordered) = attr_field.data_type() else {
+        panic!("attributes must be a Map");
+    };
+    let DataType::Struct(kv_fields) = entry_field.data_type() else {
+        panic!("map entry must be a Struct");
+    };
+    let empty_key: Arc<dyn Array> = Arc::new(StringArray::from(Vec::<&str>::new()));
+    let empty_value: Arc<dyn Array> = Arc::new(StringArray::from(Vec::<&str>::new()));
+    let entries = StructArray::new(kv_fields.clone(), vec![empty_key, empty_value], None);
+    let offsets = OffsetBuffer::new(vec![0_i32; rows + 1].into());
+    Arc::new(MapArray::new(entry_field.clone(), offsets, entries, None, *ordered))
+}
+
+/// Write a batch into the table as parquet (one file per partition); a single
+/// `(tenant, day)` batch yields exactly one [`DataFile`]. The file is written to
+/// object storage but committed to no snapshot — the caller decides that.
+pub async fn write_one_file(table: &Table, batch: RecordBatch) -> DataFile {
+    let metadata = table.metadata().clone();
+    let file_io = table.file_io().clone();
+    let location_generator = DefaultLocationGenerator::new(metadata.clone()).unwrap();
+    let file_name_generator = DefaultFileNameGenerator::new(Uuid::now_v7().to_string(), None, DataFileFormat::Parquet);
+    let parquet_builder =
+        ParquetWriterBuilder::new(WriterProperties::builder().build(), metadata.current_schema().clone());
+    let rolling_builder = RollingFileWriterBuilder::new(
+        parquet_builder,
+        1024 * 1024 * 1024,
+        file_io,
+        location_generator,
+        file_name_generator,
+    );
+    let mut fanout = FanoutWriter::new(DataFileWriterBuilder::new(rolling_builder));
+    let splitter = iceberg::arrow::RecordBatchPartitionSplitter::try_new_with_computed_values(
+        metadata.current_schema().clone(),
+        metadata.default_partition_spec().clone(),
+    )
+    .unwrap();
+    for (partition_key, partition_batch) in splitter.split(&batch).unwrap() {
+        fanout.write(partition_key, partition_batch).await.unwrap();
+    }
+    let mut files = fanout.close().await.unwrap();
+    assert_eq!(files.len(), 1, "single-partition batch must yield one data file");
+    files.pop().unwrap()
 }

--- a/crates/icegate-maintain/tests/gc_sweep_it.rs
+++ b/crates/icegate-maintain/tests/gc_sweep_it.rs
@@ -16,47 +16,33 @@ mod common;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow::array::{Array, FixedSizeBinaryArray, MapArray, StringArray, StructArray, TimestampMicrosecondArray};
-use arrow::buffer::OffsetBuffer;
-use arrow::datatypes::{DataType, Schema as ArrowSchema};
+use arrow::array::{StringArray, TimestampMicrosecondArray};
 use arrow::record_batch::RecordBatch;
 use chrono::Utc;
-use common::{BUCKET_NAME, StorageConn, build_s3_catalog, setup_object_store};
-use futures::StreamExt;
+use common::{
+    BUCKET_NAME, DAY_MICROS, StorageConn, build_operator_registry, build_s3_catalog, list_all_object_keys, logs_batch,
+    setup_object_store, write_one_file,
+};
 use futures::TryStreamExt;
 use iceberg::arrow::ArrowFileReader;
-use iceberg::spec::{DataFile, DataFileFormat};
+use iceberg::spec::DataFile;
 use iceberg::table::Table;
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
-use iceberg::writer::base_writer::data_file_writer::DataFileWriterBuilder;
-use iceberg::writer::file_writer::ParquetWriterBuilder;
-use iceberg::writer::file_writer::location_generator::{DefaultFileNameGenerator, DefaultLocationGenerator};
-use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
-use iceberg::writer::partitioning::PartitioningWriter;
-use iceberg::writer::partitioning::fanout_writer::FanoutWriter;
 use iceberg::{Catalog, NamespaceIdent, TableCreation, TableIdent};
 use icegate_catalog_s3::S3Catalog;
-use icegate_common::IoHandle;
 use icegate_common::manifest_scan::list_data_files_with_stats;
 use icegate_common::merge::sort_key::SortColumnsDescriptor;
 use icegate_common::schema::{logs_partition_spec, logs_schema, logs_sort_order};
-use icegate_common::storage::{OperatorRegistry, S3Config, StorageBackend, StorageConfig};
 use icegate_common::testing::create_s3_object_store;
 use icegate_maintain::gc::config::GcOrphansConfig;
 use icegate_maintain::gc::metrics::GcMetrics;
 use icegate_maintain::gc::sweep::run_sweep;
 use object_store::ObjectStore;
 use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
-use parquet::file::properties::WriterProperties;
 use tokio_util::sync::CancellationToken;
-use uuid::Uuid;
 
 const NAMESPACE: &str = "icegate";
 const TABLE: &str = "logs";
-const TENANT: &str = "tenant-a";
-/// 2026-06-11T00:00:00Z in microseconds. Every seeded file shares this day so
-/// they all land in the same `(tenant_id, day)` partition.
-const DAY_MICROS: i64 = 1_749_600_000_000_000;
 
 /// Create the namespace and `logs` table, returning the table identifier.
 async fn create_logs_table(catalog: &S3Catalog) -> TableIdent {
@@ -79,90 +65,6 @@ async fn create_logs_table(catalog: &S3Catalog) -> TableIdent {
         .await
         .expect("create logs table");
     TableIdent::new(NamespaceIdent::new(NAMESPACE.to_string()), TABLE.to_string())
-}
-
-/// Build one `logs` Arrow batch from `(service_name, timestamp_micros)` rows,
-/// laid out in the caller's order. The `body` column is `msg-<unique>` so every
-/// row is globally distinguishable.
-fn logs_batch(rows: &[(&str, i64)], unique_offset: usize) -> RecordBatch {
-    let iceberg_schema = logs_schema().unwrap();
-    let arrow_schema = Arc::new(iceberg::arrow::schema_to_arrow_schema(&iceberg_schema).unwrap());
-    let n = rows.len();
-
-    let tenant = StringArray::from(vec![TENANT; n]);
-    let service_name = StringArray::from(rows.iter().map(|(s, _)| Some(*s)).collect::<Vec<_>>());
-    let ts: Vec<i64> = rows.iter().map(|(_, t)| *t).collect();
-    let trace_vals: Vec<[u8; 16]> = (0..n).map(|i| [u8::try_from((unique_offset + i) % 256).unwrap(); 16]).collect();
-    let trace_id = FixedSizeBinaryArray::try_from_iter(trace_vals.iter().map(|v| v.to_vec())).unwrap();
-    let span_vals: Vec<[u8; 8]> = (0..n).map(|i| [u8::try_from((unique_offset + i) % 256).unwrap(); 8]).collect();
-    let span_id = FixedSizeBinaryArray::try_from_iter(span_vals.iter().map(|v| v.to_vec())).unwrap();
-    let attributes = empty_string_map(&arrow_schema, n);
-
-    RecordBatch::try_new(
-        arrow_schema,
-        vec![
-            Arc::new(tenant),
-            Arc::new(service_name),
-            Arc::new(TimestampMicrosecondArray::from(ts.clone())),
-            Arc::new(TimestampMicrosecondArray::from(ts.clone())),
-            Arc::new(TimestampMicrosecondArray::from(ts)),
-            Arc::new(trace_id),
-            Arc::new(span_id),
-            Arc::new(StringArray::from(vec![Some("INFO"); n])),
-            Arc::new(StringArray::from(
-                (0..n).map(|i| Some(format!("msg-{}", unique_offset + i))).collect::<Vec<_>>(),
-            )),
-            attributes,
-        ],
-    )
-    .expect("record batch")
-}
-
-/// Build an empty `MAP<Utf8,Utf8>` column of length `rows` typed exactly like
-/// the `attributes` field of the iceberg-derived arrow schema.
-fn empty_string_map(arrow_schema: &ArrowSchema, rows: usize) -> Arc<dyn Array> {
-    let attr_field = arrow_schema.field_with_name("attributes").unwrap();
-    let DataType::Map(entry_field, ordered) = attr_field.data_type() else {
-        panic!("attributes must be a Map");
-    };
-    let DataType::Struct(kv_fields) = entry_field.data_type() else {
-        panic!("map entry must be a Struct");
-    };
-    let empty_key: Arc<dyn Array> = Arc::new(StringArray::from(Vec::<&str>::new()));
-    let empty_value: Arc<dyn Array> = Arc::new(StringArray::from(Vec::<&str>::new()));
-    let entries = StructArray::new(kv_fields.clone(), vec![empty_key, empty_value], None);
-    let offsets = OffsetBuffer::new(vec![0_i32; rows + 1].into());
-    Arc::new(MapArray::new(entry_field.clone(), offsets, entries, None, *ordered))
-}
-
-/// Write a batch into the table as parquet (one file per partition); a single
-/// `(tenant, day)` batch yields exactly one [`DataFile`].
-async fn write_one_file(table: &Table, batch: RecordBatch) -> DataFile {
-    let metadata = table.metadata().clone();
-    let file_io = table.file_io().clone();
-    let location_generator = DefaultLocationGenerator::new(metadata.clone()).unwrap();
-    let file_name_generator = DefaultFileNameGenerator::new(Uuid::now_v7().to_string(), None, DataFileFormat::Parquet);
-    let parquet_builder =
-        ParquetWriterBuilder::new(WriterProperties::builder().build(), metadata.current_schema().clone());
-    let rolling_builder = RollingFileWriterBuilder::new(
-        parquet_builder,
-        1024 * 1024 * 1024,
-        file_io,
-        location_generator,
-        file_name_generator,
-    );
-    let mut fanout = FanoutWriter::new(DataFileWriterBuilder::new(rolling_builder));
-    let splitter = iceberg::arrow::RecordBatchPartitionSplitter::try_new_with_computed_values(
-        metadata.current_schema().clone(),
-        metadata.default_partition_spec().clone(),
-    )
-    .unwrap();
-    for (partition_key, partition_batch) in splitter.split(&batch).unwrap() {
-        fanout.write(partition_key, partition_batch).await.unwrap();
-    }
-    let mut files = fanout.close().await.unwrap();
-    assert_eq!(files.len(), 1, "single-partition batch must yield one data file");
-    files.pop().unwrap()
 }
 
 /// Commit a single data file in its own `fast_append` (its own snapshot).
@@ -233,33 +135,6 @@ fn append_rows(batch: &RecordBatch, rows: &mut Vec<LogRow>) {
 
 // ── GC-specific helpers ────────────────────────────────────────────────────────
 
-/// Build the `StorageConfig` that `run_sweep` uses to construct a raw object
-/// store.
-///
-/// The container credentials are threaded straight into the config, so the sweep
-/// authenticates against this test's object store without relying on ambient `AWS_*`
-/// environment variables.
-fn gc_storage_config(conn: &StorageConn) -> StorageConfig {
-    StorageConfig {
-        backend: StorageBackend::S3(S3Config {
-            bucket: BUCKET_NAME.to_string(),
-            region: "us-east-1".to_string(),
-            endpoint: Some(conn.endpoint.clone()),
-            access_key_id: Some(conn.access_key.clone()),
-            secret_access_key: Some(conn.secret_key.clone()),
-        }),
-    }
-}
-
-/// The registry the sweep resolves its object store through, wired the way the
-/// maintain binary wires it: no read cache, the container's backend.
-async fn gc_operator_registry(conn: &StorageConn) -> Arc<OperatorRegistry> {
-    IoHandle::from_config(None, Some(&gc_storage_config(conn).backend))
-        .await
-        .expect("io handle")
-        .object_store_operator_registry()
-}
-
 /// A `GcOrphansConfig` with a zero grace period (everything unreferenced is
 /// eligible) unless overridden by the caller.
 const fn orphans_config(min_age_secs: u64, dry_run: bool, include_metadata: bool) -> GcOrphansConfig {
@@ -271,20 +146,6 @@ const fn orphans_config(min_age_secs: u64, dry_run: bool, include_metadata: bool
         delete_concurrency: 8,
         sweep_timeout_secs: 600,
     }
-}
-
-/// List every object key in the bucket (sorted) via a direct S3 object store.
-async fn list_all_object_keys(conn: &StorageConn) -> Vec<String> {
-    let store: Arc<dyn ObjectStore> =
-        create_s3_object_store(&conn.endpoint, BUCKET_NAME).expect("build test object store");
-    let mut stream = store.list(None);
-    let mut keys = Vec::new();
-    while let Some(meta) = stream.next().await {
-        let meta = meta.expect("list object");
-        keys.push(meta.location.as_ref().to_string());
-    }
-    keys.sort();
-    keys
 }
 
 /// Count object keys that include `/<segment>/` anywhere in the path.
@@ -353,7 +214,7 @@ async fn gc_reclaims_unreferenced_files_and_keeps_live_ones() {
     assert_eq!(data_before, 2, "expected 1 live + 1 leaked data file before sweep");
 
     let dyn_catalog: Arc<dyn Catalog> = catalog.clone();
-    let operator_registry = gc_operator_registry(&conn).await;
+    let operator_registry = build_operator_registry(&conn).await;
     let summary = run_sweep(
         &dyn_catalog,
         &operator_registry,
@@ -399,7 +260,7 @@ async fn gc_preserves_everything_inside_the_grace_period() {
 
     let before = list_all_object_keys(&conn).await;
     let dyn_catalog: Arc<dyn Catalog> = catalog.clone();
-    let operator_registry = gc_operator_registry(&conn).await;
+    let operator_registry = build_operator_registry(&conn).await;
     // 1 hour grace: everything was written seconds ago, so nothing is eligible.
     let summary = run_sweep(
         &dyn_catalog,
@@ -437,7 +298,7 @@ async fn gc_dry_run_finds_orphans_but_deletes_nothing() {
 
     let before = list_all_object_keys(&conn).await;
     let dyn_catalog: Arc<dyn Catalog> = catalog.clone();
-    let operator_registry = gc_operator_registry(&conn).await;
+    let operator_registry = build_operator_registry(&conn).await;
     let summary = run_sweep(
         &dyn_catalog,
         &operator_registry,
@@ -477,7 +338,7 @@ async fn gc_leaves_metadata_when_metadata_sweeping_is_disabled() {
     let metadata_before = count_under_segment(&list_all_object_keys(&conn).await, "metadata");
     let data_before = count_under_segment(&list_all_object_keys(&conn).await, "data");
     let dyn_catalog: Arc<dyn Catalog> = catalog.clone();
-    let operator_registry = gc_operator_registry(&conn).await;
+    let operator_registry = build_operator_registry(&conn).await;
     let summary = run_sweep(
         &dyn_catalog,
         &operator_registry,
@@ -541,7 +402,7 @@ async fn gc_fails_closed_and_deletes_nothing_when_a_manifest_is_unreadable() {
 
     let before = list_all_object_keys(&conn).await;
     let dyn_catalog: Arc<dyn Catalog> = catalog.clone();
-    let operator_registry = gc_operator_registry(&conn).await;
+    let operator_registry = build_operator_registry(&conn).await;
     let result = run_sweep(
         &dyn_catalog,
         &operator_registry,
@@ -609,7 +470,7 @@ async fn gc_runner_reclaims_in_the_background() {
     };
 
     let dyn_catalog: Arc<dyn Catalog> = catalog.clone();
-    let runner = GcRunner::new_with_max_iterations(dyn_catalog, gc_operator_registry(&conn).await, &gc, Some(1))
+    let runner = GcRunner::new_with_max_iterations(dyn_catalog, build_operator_registry(&conn).await, &gc, Some(1))
         .await
         .expect("build runner");
     let data_before = count_under_segment(&list_all_object_keys(&conn).await, "data");

--- a/crates/icegate-maintain/tests/migrate_integration_test.rs
+++ b/crates/icegate-maintain/tests/migrate_integration_test.rs
@@ -14,10 +14,12 @@
 use std::collections::HashMap;
 
 use icegate_common::{
-    CancellationToken,
+    CancellationToken, LOGS_TABLE, PRICES_TABLE,
     catalog::{CatalogBackend, CatalogBuilder, CatalogConfig, IoHandle},
+    icegate_table_ident,
     testing::{S3TestContainer, create_s3_bucket},
 };
+use icegate_maintain::migrate::config::SnapshotExpirationConfig;
 use icegate_maintain::migrate::operations::{MigrationOperation, create_tables, upgrade_schemas};
 
 /// Object-storage bucket used as the Iceberg warehouse root for the catalog under test.
@@ -64,7 +66,7 @@ async fn test_migrate_create_tables() {
 
     println!("Catalog created, calling create_tables...");
 
-    let ops = match create_tables(&catalog, false).await {
+    let ops = match create_tables(&catalog, &SnapshotExpirationConfig::default(), false).await {
         Ok(ops) => ops,
         Err(e) => {
             println!("Error creating tables: {:?}", e);
@@ -105,14 +107,16 @@ async fn test_migrate_create_tables_dry_run() {
         .expect("Failed to create catalog");
 
     // First call with dry_run=true
-    let ops = create_tables(&catalog, true).await.expect("Failed to dry-run create tables");
+    let ops = create_tables(&catalog, &SnapshotExpirationConfig::default(), true)
+        .await
+        .expect("Failed to dry-run create tables");
 
     // Should report 6 operations
     assert_eq!(ops.len(), 6, "Expected 6 table creation operations in dry-run");
 
     // Verify NO tables were actually created by calling create_tables again
     // This time with dry_run=false, it should still create 6 tables
-    let ops_actual = create_tables(&catalog, false)
+    let ops_actual = create_tables(&catalog, &SnapshotExpirationConfig::default(), false)
         .await
         .expect("Failed to create tables after dry-run");
 
@@ -133,13 +137,13 @@ async fn test_migrate_create_tables_idempotent() {
         .expect("Failed to create catalog");
 
     // First call - creates tables
-    let ops_first = create_tables(&catalog, false)
+    let ops_first = create_tables(&catalog, &SnapshotExpirationConfig::default(), false)
         .await
         .expect("Failed to create tables first time");
     assert_eq!(ops_first.len(), 6, "First call should create 6 tables");
 
     // Second call - should be idempotent
-    let ops_second = create_tables(&catalog, false)
+    let ops_second = create_tables(&catalog, &SnapshotExpirationConfig::default(), false)
         .await
         .expect("Failed to create tables second time");
     assert_eq!(
@@ -159,7 +163,9 @@ async fn test_migrate_upgrade_schemas() {
         .expect("Failed to create catalog");
 
     // First create the tables
-    let create_ops = create_tables(&catalog, false).await.expect("Failed to create tables");
+    let create_ops = create_tables(&catalog, &SnapshotExpirationConfig::default(), false)
+        .await
+        .expect("Failed to create tables");
     assert_eq!(create_ops.len(), 6);
 
     // Now call upgrade_schemas - should return 0 operations since schemas are
@@ -170,5 +176,159 @@ async fn test_migrate_upgrade_schemas() {
         upgrade_ops.len(),
         0,
         "Expected 0 upgrade operations (schemas are up to date)"
+    );
+}
+
+/// The retention policy has to survive the round trip through the catalog: it is
+/// the table's own properties, not any config file, that every later writer
+/// resolves its expiration window from. A window that never reaches
+/// `metadata.json` is a feature that silently does nothing.
+#[tokio::test]
+async fn created_tables_carry_the_configured_retention_policy() {
+    let (_store, config) = setup_containers().await;
+
+    let catalog = CatalogBuilder::from_config(&config, &IoHandle::noop(), CancellationToken::new())
+        .await
+        .expect("Failed to create catalog");
+
+    let expiration = SnapshotExpirationConfig {
+        enabled: true,
+        min_snapshots_to_keep: 7,
+        max_snapshot_age_ms: 90_000,
+        metadata_previous_versions_max: 14,
+    };
+    create_tables(&catalog, &expiration, false)
+        .await
+        .expect("Failed to create tables");
+
+    let logs = catalog
+        .load_table(&icegate_table_ident(LOGS_TABLE))
+        .await
+        .expect("load logs table");
+    let properties = logs.metadata().properties();
+
+    assert_eq!(properties.get("history.expire.enabled"), Some(&"true".to_string()));
+    assert_eq!(
+        properties.get("history.expire.min-snapshots-to-keep"),
+        Some(&"7".to_string())
+    );
+    assert_eq!(
+        properties.get("history.expire.max-snapshot-age-ms"),
+        Some(&"90000".to_string())
+    );
+    assert_eq!(
+        properties.get("write.metadata.previous-versions-max"),
+        Some(&"14".to_string())
+    );
+    // The WAL offset lives in the snapshot summary under this key; expiration
+    // must keep its most recent carrier — and the chain to it — reachable, or
+    // the Shifter resumes from 0 and re-commits the whole queue.
+    assert_eq!(
+        properties.get("history.expire.preserve-summary-property"),
+        Some(&"icegate.queue.offset".to_string())
+    );
+    // Pre-existing table properties must not be lost to the new ones.
+    assert_eq!(properties.get("write.format.default"), Some(&"parquet".to_string()));
+
+    let prices = catalog
+        .load_table(&icegate_table_ident(PRICES_TABLE))
+        .await
+        .expect("load prices table");
+    assert!(
+        !prices
+            .metadata()
+            .properties()
+            .contains_key("history.expire.preserve-summary-property"),
+        "prices is written by the pricing crawler, so no snapshot of it carries a WAL offset"
+    );
+}
+
+/// Turning expiration off in the config must reach the table as an explicit
+/// `false`, not as an absent key: a writer reads the property, and only an
+/// explicit value distinguishes a table opted out from one created before the
+/// policy existed.
+#[tokio::test]
+async fn disabled_expiration_reaches_the_table_as_an_explicit_false() {
+    let (_store, config) = setup_containers().await;
+
+    let catalog = CatalogBuilder::from_config(&config, &IoHandle::noop(), CancellationToken::new())
+        .await
+        .expect("Failed to create catalog");
+
+    let expiration = SnapshotExpirationConfig {
+        enabled: false,
+        ..SnapshotExpirationConfig::default()
+    };
+    create_tables(&catalog, &expiration, false)
+        .await
+        .expect("Failed to create tables");
+
+    let logs = catalog
+        .load_table(&icegate_table_ident(LOGS_TABLE))
+        .await
+        .expect("load logs table");
+
+    assert_eq!(
+        logs.metadata().properties().get("history.expire.enabled"),
+        Some(&"false".to_string())
+    );
+}
+
+/// The policy is written once, at creation: `migrate create` skips a table that
+/// already exists, properties included. An operator who widens the window in the
+/// config and re-runs the command gets nothing — there is no backfill — and the
+/// tables keep the policy they were created with. That is what the deployment
+/// contract of `migrate/README.md` promises, so it is asserted rather than left
+/// to the skip path's `continue`.
+#[tokio::test]
+async fn a_second_create_leaves_an_existing_table_on_its_original_policy() {
+    let (_store, config) = setup_containers().await;
+
+    let catalog = CatalogBuilder::from_config(&config, &IoHandle::noop(), CancellationToken::new())
+        .await
+        .expect("Failed to create catalog");
+
+    let original = SnapshotExpirationConfig {
+        enabled: true,
+        min_snapshots_to_keep: 7,
+        max_snapshot_age_ms: 90_000,
+        metadata_previous_versions_max: 14,
+    };
+    create_tables(&catalog, &original, false)
+        .await
+        .expect("Failed to create tables");
+
+    // Every field differs, so any re-stamp shows up whichever one it touches.
+    let widened = SnapshotExpirationConfig {
+        enabled: false,
+        min_snapshots_to_keep: 21,
+        max_snapshot_age_ms: 600_000,
+        metadata_previous_versions_max: 42,
+    };
+    let ops = create_tables(&catalog, &widened, false).await.expect("Failed to re-run create");
+    assert!(ops.is_empty(), "every table already exists, so nothing is created");
+
+    let logs = catalog
+        .load_table(&icegate_table_ident(LOGS_TABLE))
+        .await
+        .expect("load logs table");
+    let properties = logs.metadata().properties();
+
+    assert_eq!(properties.get("history.expire.enabled"), Some(&"true".to_string()));
+    assert_eq!(
+        properties.get("history.expire.min-snapshots-to-keep"),
+        Some(&"7".to_string())
+    );
+    assert_eq!(
+        properties.get("history.expire.max-snapshot-age-ms"),
+        Some(&"90000".to_string())
+    );
+    assert_eq!(
+        properties.get("write.metadata.previous-versions-max"),
+        Some(&"14".to_string())
+    );
+    assert_eq!(
+        properties.get("history.expire.preserve-summary-property"),
+        Some(&"icegate.queue.offset".to_string())
     );
 }

--- a/crates/icegate-maintain/tests/pricing_crawl_it.rs
+++ b/crates/icegate-maintain/tests/pricing_crawl_it.rs
@@ -22,6 +22,7 @@ use futures::TryStreamExt;
 use iceberg::Catalog;
 use icegate_common::{PRICES_TABLE, icegate_table_ident};
 use icegate_maintain::compact::config::{CompactionJobsManagerConfig, JobStateCodec, JobsStorageConfig};
+use icegate_maintain::migrate::config::SnapshotExpirationConfig;
 use icegate_maintain::migrate::operations::create_tables;
 use icegate_maintain::pricing::PricingRunner;
 use icegate_maintain::pricing::config::{PricingConfig, SourceConfig};
@@ -164,7 +165,9 @@ async fn first_crawl_appends_and_second_identical_crawl_commits_nothing() {
     let (_store, conn) = common::setup_object_store().await;
     let catalog = Arc::new(build_s3_catalog(&conn).await);
     let dyn_catalog: Arc<dyn Catalog> = catalog.clone();
-    create_tables(&dyn_catalog, false).await.expect("create tables");
+    create_tables(&dyn_catalog, &SnapshotExpirationConfig::default(), false)
+        .await
+        .expect("create tables");
 
     let now = Utc::now();
     let stub = StubSource {
@@ -203,7 +206,9 @@ async fn a_changed_rate_appends_exactly_one_revision() {
     let (_store, conn) = common::setup_object_store().await;
     let catalog = Arc::new(build_s3_catalog(&conn).await);
     let dyn_catalog: Arc<dyn Catalog> = catalog.clone();
-    create_tables(&dyn_catalog, false).await.expect("create tables");
+    create_tables(&dyn_catalog, &SnapshotExpirationConfig::default(), false)
+        .await
+        .expect("create tables");
 
     let config = PricingConfig::default();
     let first_valid_from = Utc::now();
@@ -264,7 +269,9 @@ async fn pricing_runner_builds_starts_and_drains() {
     let (_store, conn) = common::setup_object_store().await;
     let catalog = Arc::new(build_s3_catalog(&conn).await);
     let dyn_catalog: Arc<dyn Catalog> = catalog.clone();
-    create_tables(&dyn_catalog, false).await.expect("create tables");
+    create_tables(&dyn_catalog, &SnapshotExpirationConfig::default(), false)
+        .await
+        .expect("create tables");
 
     let config = PricingConfig {
         enabled: true,

--- a/crates/icegate-maintain/tests/snapshot_expiration_it.rs
+++ b/crates/icegate-maintain/tests/snapshot_expiration_it.rs
@@ -1,0 +1,461 @@
+//! Snapshot retention, end to end against a real catalog.
+//!
+//! What `migrate create` stamps onto a table is the whole of IceGate's side of
+//! expiration: the plan is computed and applied upstream, by every commit, off
+//! those properties. These tests therefore drive the real path — create the
+//! tables through [`create_tables`], commit through a `Transaction` the way the
+//! Shifter does — and assert what the stamp is responsible for: the history
+//! stays inside the configured window, the WAL offset stays resolvable across
+//! the snapshots expiration removes, and the storage those snapshots held is
+//! actually reclaimed by the GC sweep, which is the reason the policy exists.
+//!
+//! Requires Docker:
+//!
+//! ```text
+//! cargo test -p icegate-maintain --test snapshot_expiration_it
+//! ```
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+mod common;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use chrono::Utc;
+use common::{
+    BUCKET_NAME, DAY_MICROS, StorageConn, build_operator_registry, build_s3_catalog, list_all_object_keys, logs_batch,
+    setup_object_store, write_one_file,
+};
+use iceberg::Catalog;
+use iceberg::spec::DataFile;
+use iceberg::transaction::{ApplyTransactionAction, Transaction};
+use icegate_catalog_s3::S3Catalog;
+use icegate_common::{LOGS_TABLE, WAL_OFFSET_PROPERTY, icegate_table_ident, resolve_wal_offset};
+use icegate_maintain::gc::config::GcOrphansConfig;
+use icegate_maintain::gc::metrics::GcMetrics;
+use icegate_maintain::gc::sweep::run_sweep;
+use icegate_maintain::migrate::config::SnapshotExpirationConfig;
+use icegate_maintain::migrate::operations::create_tables;
+use tokio_util::sync::CancellationToken;
+
+/// Ancestors kept regardless of age. Two rather than one so a test can tell
+/// "the window held it" from "nothing was expired at all".
+const MIN_SNAPSHOTS_TO_KEEP: usize = 2;
+
+/// Age window of a single millisecond: a commit against the object store takes
+/// far longer than that, so by the time the next commit plans, every earlier
+/// snapshot is past the window and only the explicit protections remain.
+const MAX_SNAPSHOT_AGE_MS: i64 = 1;
+
+/// Summary key every commit below carries, so an append with no data files is
+/// still a well-formed snapshot (an append with neither files nor summary
+/// properties is rejected upstream). Its value is never read; what matters is
+/// that a snapshot can be built without the WAL offset in its summary.
+const COMMIT_MARKER_KEY: &str = "icegate.test.commit";
+
+/// A policy that expires aggressively, so the protections are what is under
+/// test rather than the width of the window.
+const fn narrow_window() -> SnapshotExpirationConfig {
+    SnapshotExpirationConfig {
+        enabled: true,
+        min_snapshots_to_keep: MIN_SNAPSHOTS_TO_KEEP,
+        max_snapshot_age_ms: MAX_SNAPSHOT_AGE_MS,
+        metadata_previous_versions_max: MIN_SNAPSHOTS_TO_KEEP,
+    }
+}
+
+/// Create the IceGate tables under `expiration`.
+async fn create_logs_table(catalog: &Arc<S3Catalog>, expiration: &SnapshotExpirationConfig) {
+    let dyn_catalog: Arc<dyn Catalog> = Arc::clone(catalog) as Arc<dyn Catalog>;
+    create_tables(&dyn_catalog, expiration, false).await.expect("create tables");
+}
+
+/// Commit an empty append, optionally stamping the WAL offset onto the snapshot
+/// summary the way the Shifter does. Data files are beside the point here — a
+/// snapshot counts towards the retention window whether or not it added rows,
+/// and the offset lives in the summary either way.
+async fn commit_snapshot(catalog: &S3Catalog, offset: Option<u64>) {
+    let table = catalog
+        .load_table(&icegate_table_ident(LOGS_TABLE))
+        .await
+        .expect("load logs table");
+
+    let mut properties = HashMap::from([(COMMIT_MARKER_KEY.to_string(), "1".to_string())]);
+    if let Some(offset) = offset {
+        properties.insert(WAL_OFFSET_PROPERTY.to_string(), offset.to_string());
+    }
+
+    let tx = Transaction::new(&table);
+    let action = tx.fast_append().set_snapshot_properties(properties);
+    let tx = action.apply(tx).expect("apply fast append");
+    tx.commit(catalog).await.expect("commit snapshot");
+}
+
+/// Appends committed before the rewrite; each lands in its own snapshot and
+/// contributes one data file the rewrite then replaces.
+const APPENDS_BEFORE_REWRITE: usize = 3;
+
+/// Appends committed after the rewrite, enough to push the rewrite snapshot and
+/// everything before it out of a [`MIN_SNAPSHOTS_TO_KEEP`]-wide window.
+const APPENDS_AFTER_REWRITE: usize = 2;
+
+/// WAL offset the last seeded append stamps: the appends carry `0..n`, so the
+/// newest is one below their total.
+const LAST_COMMITTED_OFFSET: u64 = (APPENDS_BEFORE_REWRITE + APPENDS_AFTER_REWRITE - 1) as u64;
+
+/// The files a seeded history left in object storage, captured as it was built
+/// rather than read back from the table, so the assertions never depend on the
+/// reachability walk the sweep itself uses.
+struct SeededHistory {
+    /// Data files the rewrite replaced. Referenced only by the snapshots that
+    /// preceded it — the storage a bounded history is supposed to free.
+    replaced_data_files: Vec<String>,
+    /// Data files the current snapshot still names: the rewrite's output and
+    /// every append after it.
+    live_data_files: Vec<String>,
+    /// Manifest-list path of each snapshot, in commit order. A manifest list
+    /// belongs to exactly one snapshot and is never inherited, so its presence
+    /// is a direct statement about that snapshot's own files.
+    manifest_lists: Vec<String>,
+}
+
+/// Commit one data file in its own `fast_append`, stamping the WAL offset onto
+/// the snapshot summary the way the Shifter does, and returning the committed
+/// file. The row tag doubles as the offset, so each is unique per commit.
+async fn append_one_file(catalog: &S3Catalog, unique_offset: usize) -> DataFile {
+    let table = catalog
+        .load_table(&icegate_table_ident(LOGS_TABLE))
+        .await
+        .expect("load logs table");
+    let data_file = write_one_file(&table, logs_batch(&[("svc", DAY_MICROS)], unique_offset)).await;
+
+    let tx = Transaction::new(&table);
+    let action = tx
+        .fast_append()
+        .add_data_files(vec![data_file.clone()])
+        .set_snapshot_properties(HashMap::from([(
+            WAL_OFFSET_PROPERTY.to_string(),
+            unique_offset.to_string(),
+        )]));
+    let tx = action.apply(tx).expect("apply fast append");
+    tx.commit(catalog).await.expect("commit append");
+    data_file
+}
+
+/// Replace `replaced` with a single file in one `replace` snapshot, the way
+/// data compaction commits its rewrites — WAL offset carried forward from the
+/// snapshot the rewrite supersedes. The output carries the same rows, so the
+/// rewrite loses no data on its way through the sweep.
+async fn rewrite_into_one_file(catalog: &S3Catalog, replaced: Vec<DataFile>) -> DataFile {
+    let table = catalog
+        .load_table(&icegate_table_ident(LOGS_TABLE))
+        .await
+        .expect("load logs table");
+    let rows = vec![("svc", DAY_MICROS); replaced.len()];
+    let compacted = write_one_file(&table, logs_batch(&rows, 0)).await;
+
+    let tx = Transaction::new(&table);
+    let tx = tx
+        .rewrite_files()
+        .add_data_files(vec![compacted.clone()])
+        .delete_files(replaced)
+        .inherit_summary_property(WAL_OFFSET_PROPERTY)
+        .apply(tx)
+        .expect("apply rewrite");
+    tx.commit(catalog).await.expect("commit rewrite");
+    compacted
+}
+
+/// The manifest-list path of the table's current snapshot.
+async fn read_head_manifest_list(catalog: &S3Catalog) -> String {
+    let table = catalog
+        .load_table(&icegate_table_ident(LOGS_TABLE))
+        .await
+        .expect("load logs table");
+    table
+        .metadata()
+        .current_snapshot()
+        .expect("a committed snapshot")
+        .manifest_list()
+        .to_string()
+}
+
+/// Seed the history compaction leaves behind: appends, a rewrite that replaces
+/// all of them with one file, then further appends. Without expiration every
+/// replaced file stays referenced by the snapshots that preceded the rewrite,
+/// which is precisely why compaction alone never frees storage.
+async fn seed_rewritten_history(catalog: &S3Catalog) -> SeededHistory {
+    let mut manifest_lists = Vec::with_capacity(APPENDS_BEFORE_REWRITE + 1 + APPENDS_AFTER_REWRITE);
+    let mut replaced = Vec::with_capacity(APPENDS_BEFORE_REWRITE);
+    for unique_offset in 0..APPENDS_BEFORE_REWRITE {
+        replaced.push(append_one_file(catalog, unique_offset).await);
+        manifest_lists.push(read_head_manifest_list(catalog).await);
+    }
+    let replaced_data_files = replaced.iter().map(|file| file.file_path().to_string()).collect();
+
+    let compacted = rewrite_into_one_file(catalog, replaced).await;
+    manifest_lists.push(read_head_manifest_list(catalog).await);
+
+    let mut live_data_files = vec![compacted.file_path().to_string()];
+    for index in 0..APPENDS_AFTER_REWRITE {
+        let appended = append_one_file(catalog, APPENDS_BEFORE_REWRITE + index).await;
+        live_data_files.push(appended.file_path().to_string());
+        manifest_lists.push(read_head_manifest_list(catalog).await);
+    }
+
+    SeededHistory {
+        replaced_data_files,
+        live_data_files,
+        manifest_lists,
+    }
+}
+
+/// Run one orphan sweep of `logs` with no grace period, so the assertion is
+/// about reachability alone rather than about how long ago a file was written.
+async fn sweep_logs_orphans(catalog: &Arc<S3Catalog>, conn: &StorageConn) {
+    let dyn_catalog: Arc<dyn Catalog> = Arc::clone(catalog) as Arc<dyn Catalog>;
+    let orphans = GcOrphansConfig {
+        enabled: true,
+        dry_run: false,
+        min_age_secs: 0,
+        include_metadata: true,
+        delete_concurrency: 8,
+        sweep_timeout_secs: 600,
+    };
+    let operator_registry = build_operator_registry(conn).await;
+    run_sweep(
+        &dyn_catalog,
+        &operator_registry,
+        LOGS_TABLE,
+        &orphans,
+        Utc::now(),
+        &GcMetrics::new(),
+        &CancellationToken::new(),
+    )
+    .await
+    .expect("sweep succeeds");
+}
+
+/// The bucket-relative key of an absolute table URI, which is how the object
+/// store lists it.
+fn to_object_key(uri: &str) -> String {
+    uri.strip_prefix(&format!("s3://{BUCKET_NAME}/"))
+        .expect("table files live under s3://<bucket>/ with this catalog")
+        .to_string()
+}
+
+/// Every object key currently in the bucket.
+async fn read_object_keys(conn: &StorageConn) -> HashSet<String> {
+    list_all_object_keys(conn).await.into_iter().collect()
+}
+
+/// Assert each URI in `uris` is (or is not) backed by an object right now.
+fn assert_objects_exist(keys: &HashSet<String>, uris: &[String], expected: bool, reason: &str) {
+    for uri in uris {
+        let key = to_object_key(uri);
+        assert_eq!(keys.contains(&key), expected, "{reason}: {key}");
+    }
+}
+
+/// The current state of `logs` as `(snapshot count, resolved WAL offset)`.
+async fn read_history(catalog: &S3Catalog) -> (usize, Option<u64>) {
+    let table = catalog
+        .load_table(&icegate_table_ident(LOGS_TABLE))
+        .await
+        .expect("load logs table");
+    let metadata = table.metadata();
+    let offset = resolve_wal_offset(metadata).expect("the WAL offset must stay resolvable");
+    (metadata.snapshots().len(), offset)
+}
+
+/// Every commit carries the offset, so the carrier is the current snapshot and
+/// nothing beyond the window needs protecting: the history collapses to the
+/// window itself, and the offset is still the one the last commit recorded.
+#[tokio::test]
+async fn expiration_holds_the_history_at_the_configured_window() {
+    let (_store, conn) = setup_object_store().await;
+    let catalog = Arc::new(build_s3_catalog(&conn).await);
+    create_logs_table(&catalog, &narrow_window()).await;
+
+    for offset in 1..=6_u64 {
+        commit_snapshot(&catalog, Some(offset)).await;
+    }
+
+    let (snapshot_count, offset) = read_history(&catalog).await;
+    assert_eq!(
+        snapshot_count, MIN_SNAPSHOTS_TO_KEEP,
+        "six commits, a two-snapshot window: only the current snapshot and its parent survive"
+    );
+    assert_eq!(offset, Some(6), "the newest commit's offset must survive");
+}
+
+/// The case the preserved-summary property exists for: compaction and any other
+/// writer commit snapshots that carry no offset, so the carrier sinks out of the
+/// retention window. Expiring it — or any link between it and the current
+/// snapshot — would send the Shifter back to offset 0 and re-commit the queue.
+#[tokio::test]
+async fn expiration_keeps_a_wal_offset_carrier_outside_the_window() {
+    let (_store, conn) = setup_object_store().await;
+    let catalog = Arc::new(build_s3_catalog(&conn).await);
+    create_logs_table(&catalog, &narrow_window()).await;
+
+    commit_snapshot(&catalog, Some(42)).await;
+    // Five offset-less commits push the carrier well past a two-snapshot window.
+    for _ in 0..5 {
+        commit_snapshot(&catalog, None).await;
+    }
+
+    let (snapshot_count, offset) = read_history(&catalog).await;
+    assert_eq!(
+        offset,
+        Some(42),
+        "the offset must still resolve by walking the ancestor chain to its carrier"
+    );
+    assert_eq!(
+        snapshot_count, 6,
+        "the carrier and every link from the current snapshot down to it must survive"
+    );
+}
+
+/// A table created with the policy switched off keeps every snapshot: the
+/// property is the only thing that makes a writer expire anything, and `false`
+/// must read as "off", not as "use the spec default".
+#[tokio::test]
+async fn a_table_created_with_expiration_disabled_keeps_every_snapshot() {
+    let (_store, conn) = setup_object_store().await;
+    let catalog = Arc::new(build_s3_catalog(&conn).await);
+    let disabled = SnapshotExpirationConfig {
+        enabled: false,
+        ..narrow_window()
+    };
+    create_logs_table(&catalog, &disabled).await;
+
+    for offset in 1..=4_u64 {
+        commit_snapshot(&catalog, Some(offset)).await;
+    }
+
+    let (snapshot_count, offset) = read_history(&catalog).await;
+    assert_eq!(snapshot_count, 4, "expiration is off: no snapshot may be removed");
+    assert_eq!(offset, Some(4));
+}
+
+/// The point of the policy: storage a compaction rewrote is actually reclaimed.
+/// Trimming the history only moves the files out of the referenced set — the GC
+/// sweep is what deletes them, and it reads that set from the current metadata
+/// (`gc/reachable.rs`). This drives the whole chain on one table: rewrite the
+/// data the way compaction does, let the window drop the snapshots that still
+/// named the originals, then sweep and check the objects themselves.
+#[tokio::test]
+async fn the_sweep_reclaims_the_data_and_manifests_of_expired_snapshots() {
+    let (_store, conn) = setup_object_store().await;
+    let catalog = Arc::new(build_s3_catalog(&conn).await);
+    create_logs_table(&catalog, &narrow_window()).await;
+
+    let history = seed_rewritten_history(&catalog).await;
+
+    let (snapshot_count, offset) = read_history(&catalog).await;
+    assert_eq!(
+        snapshot_count, MIN_SNAPSHOTS_TO_KEEP,
+        "the fixture must reach the condition under test: every snapshot but the newest two gone"
+    );
+    assert_eq!(
+        offset,
+        Some(LAST_COMMITTED_OFFSET),
+        "the newest commit's offset survives"
+    );
+    let before = read_object_keys(&conn).await;
+    assert_objects_exist(
+        &before,
+        &history.replaced_data_files,
+        true,
+        "a rewritten file is unreferenced but still on disk until the sweep runs",
+    );
+
+    sweep_logs_orphans(&catalog, &conn).await;
+
+    let after = read_object_keys(&conn).await;
+    assert_objects_exist(
+        &after,
+        &history.replaced_data_files,
+        false,
+        "the data files of the expired snapshots must be reclaimed",
+    );
+    let expired_count = history.manifest_lists.len() - MIN_SNAPSHOTS_TO_KEEP;
+    assert_objects_exist(
+        &after,
+        &history.manifest_lists[..expired_count],
+        false,
+        "the manifest list of an expired snapshot is referenced by nothing",
+    );
+    assert_objects_exist(
+        &after,
+        &history.manifest_lists[expired_count..],
+        true,
+        "the retained snapshots' manifest lists must survive",
+    );
+    assert_objects_exist(
+        &after,
+        &history.live_data_files,
+        true,
+        "a file the current snapshot names must survive",
+    );
+
+    // The metadata the table still points at, and the metadata-log the S3
+    // catalog resolves a lost commit ack against, are referenced by definition.
+    let table = catalog
+        .load_table(&icegate_table_ident(LOGS_TABLE))
+        .await
+        .expect("load logs table");
+    let metadata_files: Vec<String> =
+        std::iter::once(table.metadata_location().expect("a metadata pointer").to_string())
+            .chain(table.metadata().metadata_log().iter().map(|entry| entry.metadata_file.clone()))
+            .collect();
+    assert_objects_exist(
+        &after,
+        &metadata_files,
+        true,
+        "the current metadata and every retained metadata-log entry must survive",
+    );
+}
+
+/// The same history without the policy, which is what makes the test above a
+/// statement about expiration rather than about GC: with every snapshot kept,
+/// the pre-rewrite snapshots still name the replaced files, the sweep finds no
+/// orphan among them, and compaction has freed nothing.
+#[tokio::test]
+async fn the_sweep_keeps_rewritten_files_while_expiration_is_disabled() {
+    let (_store, conn) = setup_object_store().await;
+    let catalog = Arc::new(build_s3_catalog(&conn).await);
+    let disabled = SnapshotExpirationConfig {
+        enabled: false,
+        ..narrow_window()
+    };
+    create_logs_table(&catalog, &disabled).await;
+
+    let history = seed_rewritten_history(&catalog).await;
+
+    let (snapshot_count, offset) = read_history(&catalog).await;
+    assert_eq!(
+        snapshot_count,
+        APPENDS_BEFORE_REWRITE + 1 + APPENDS_AFTER_REWRITE,
+        "expiration is off: the rewrite and every append keep their snapshot"
+    );
+    assert_eq!(offset, Some(LAST_COMMITTED_OFFSET));
+
+    sweep_logs_orphans(&catalog, &conn).await;
+
+    let after = read_object_keys(&conn).await;
+    assert_objects_exist(
+        &after,
+        &history.replaced_data_files,
+        true,
+        "an unbounded history keeps every rewritten file referenced, so the sweep must not take it",
+    );
+    assert_objects_exist(
+        &after,
+        &history.manifest_lists,
+        true,
+        "every snapshot survives, so does its manifest list",
+    );
+}

--- a/crates/icegate-query/src/engine/core.rs
+++ b/crates/icegate-query/src/engine/core.rs
@@ -1,10 +1,20 @@
 //! Query execution engine with background-refreshed catalog provider.
 //!
-//! The `QueryEngine` keeps a cached catalog provider that is refreshed
-//! in the background every `refresh_interval` (default 15s). The cached
-//! provider remains valid for up to `max_age` (default 30s). Queries
-//! never block on catalog rebuilds unless the cache is completely cold
-//! (first query or after a prolonged refresh failure).
+//! TODO: a cached provider pins a table state, not the files behind it. Snapshot
+//! expiration turns the manifests and data files of every snapshot it drops into
+//! orphans, and the maintain sweep deletes them once its grace period passes, so
+//! a query planned against a provider older than that can reach for a file that
+//! is gone — a scan error, not wrong results. Today the deployment keeps the two
+//! apart by configuration alone: `query.engine.max_age_secs * 1000` must stay
+//! below `history.expire.max-snapshot-age-ms` — the window is in milliseconds —
+//! so an expiring snapshot outlives every cached reference to it, and
+//! `gc.orphans.min_age_secs` must stay above
+//! `max_age_secs` so a swept file was already unreferenced when the newest
+//! provider was built. The Helm chart enforces both (`_helpers.tpl`,
+//! `icegate.validateRetentionWindow`); nothing enforces them at runtime, and a
+//! query holding a provider across a slow rebuild has no defence at all. The fix
+//! is for the read path to detect a missing referenced file and retry on a fresh
+//! provider rather than surfacing the object-store 404.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
Without bounded history a table keeps every snapshot it ever had, so GC can reclaim nothing: manifests and data files stay referenced from metadata.json forever. This adds the retention policy that lets them go.

Expiration is not a maintenance job. The policy lives in the table's own properties (`history.expire.*`), and every writer — ingest shift, compaction rewrite, pricing append — resolves it on commit and carries a `RemoveSnapshots` update along with whatever it was already writing (support comes from the iceberg-rust bump to 0c07964). Keeping the values in table properties makes them auditable in metadata.json instead of an implicit default hidden in code.

What is in the change:

- `migrate/config.rs`: new `SnapshotExpirationConfig` — enabled, min_snapshots_to_keep, max_snapshot_age_ms, metadata_previous_versions_max — with validation and defaults (100 snapshots / 30 min / 200 metadata versions).
- `migrate/operations.rs`: `migrate create` stamps the policy onto every table it creates. Tables written by the Shifter declare their WAL-offset summary key as a carrier expiration must keep reachable; `prices` does not, since the pricing crawler writes no offset. Existing tables are left untouched.
- `MaintainConfig::validate` rejects an orphan sweep running with a zero grace period, and the Helm chart gains `icegate.validateRetentionWindow`, which fails the render unless `query.engine.maxAgeSecs < migrate.snapshotExpiration.maxSnapshotAgeMs` and `query.engine.maxAgeSecs < maintain.gc.orphans.minAgeSecs`. A cached query provider must not outlive the files it plans against.
- Deployment configs on both sides: chart values plus configmaps, and `config/docker/maintain.yaml`.
- Docs: `migrate/README.md` (retention contract), `maintain/README.md`, and a TODO in `query/engine/core.rs` — the ordering is enforced by configuration only; the read path should retry a missing file on a fresh provider.
- Tests: `snapshot_expiration_it.rs` integration suite, plus a `logs` writer and raw object-store listing helpers shared through `tests/common`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable snapshot expiration for newly created tables, including minimum snapshots, maximum age, and metadata retention.
  - Added retention settings to Helm deployments and maintenance configuration.
  - Preserved WAL-related metadata where applicable during table creation.

- **Bug Fixes**
  - Added validation for retention windows, cache age, refresh intervals, and orphan cleanup grace periods.
  - Disabled snapshot expiration now explicitly preserves snapshots.

- **Documentation**
  - Expanded configuration, migration, maintenance, and public documentation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->