### PR TITLE
(refactor) Replace `Box::leak` with RAII for temporary directories intests and async harnesses.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing to IceGate! This document provides g
 
 ### Prerequisites
 
-- **Rust** >= 1.92.0 (for Rust 2024 edition support)
+- **Rust** at or above the `rust-version` declared in the workspace [`Cargo.toml`](Cargo.toml)
 - **Cargo** (included with Rust)
 - **Git**
 - **Docker** and **Docker Compose** (for development environment)
@@ -28,7 +28,7 @@ Thank you for your interest in contributing to IceGate! This document provides g
 
 2. Verify your Rust installation:
    ```bash
-   rustc --version  # Should be 1.92.0 or later
+   rustc --version  # Must be at or above Cargo.toml's rust-version
    cargo --version
    ```
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [workspace.package]
 version = "0.2.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.95.0"
 authors = ["IceGate Tech"]
 license = "Apache-2.0"
 repository = "https://github.com/icegatetech/icegate"

--- a/clippy.toml
+++ b/clippy.toml
@@ -32,9 +32,13 @@ too-many-lines-threshold = 150
 # Single character binding names (allowed for short-lived variables)
 single-char-binding-names-threshold = 4
 
-# Enforce minimum Rust version. Tracks Cargo.toml's `rust-version`.
-# `Option::is_none_or` requires 1.82+; `BinaryHeap::peek_mut`-style mut
-# methods we already rely on require 1.92+.
+# Floor for Clippy's version-gated suggestions. Deliberately BELOW the workspace
+# `rust-version` in Cargo.toml, which is the real MSRV — Clippy prints a warning
+# about the gap on every run, and that is the intended reminder. Raising this to
+# match unmasks ~70 modernization suggestions (let-chains, `const fn`, larger
+# `Duration` units) that are a workspace-wide pass of their own, not a rider on
+# an unrelated change. Lagging is the safe direction: Clippy only ever suggests
+# less than the toolchain allows, never code the declared MSRV cannot build.
 msrv = "1.82.0"
 
 # Literal representation

--- a/config/sanitizers/README.md
+++ b/config/sanitizers/README.md
@@ -21,15 +21,16 @@ not part of `make ci` — CI runs them nightly and on any PR labelled `sanitize`
 ## Reading a green run honestly
 
 A green `make sanitize-leak` means **no new leaks**, not no leaks. `lsan.supp` suppresses a
-documented baseline: upstream retention we do not control, plus one first-party entry that
-covers test scaffolding. Each entry records what leaks, how much, and the condition that
-retires it. Read that file before concluding the codebase is leak-free.
+documented baseline of upstream retention we do not control. Each entry records what leaks,
+how much, and the condition that retires it. Read that file before concluding the codebase
+is leak-free — and note that no figure in it has yet been reproduced on CI's stack shape.
 
-No first-party *production* path is suppressed today, and that is a property worth keeping —
-adding one back means the nightly stops reporting a real defect. Two such entries were
-deleted in August 2026 once the code they named had been refactored away; `lsan.supp`'s
-header records both, because the failure mode they share is that a suppression outlives its
-subject in silence.
+No first-party path is suppressed today, production or test, and that is a property worth
+keeping — adding one back means the nightly stops reporting a real defect. Three such
+entries were deleted in August 2026: two once the code they named had been refactored away,
+and one once the harnesses stopped leaking their `TempDir`. The first two had gone stale
+without anyone noticing, which is the failure mode to watch — a suppression outlives its
+subject in silence. `git log config/sanitizers/lsan.supp` has the details.
 
 **The sanitizer suite covers less than `make ci` does.** It runs no `--features`, so
 `crates/icegate-catalog-s3`'s `catalog` binary — which declares
@@ -62,10 +63,10 @@ Two rules, stated in full at the top of `lsan.supp`: every entry names the libra
 the allocation is not ours, and no entry may match a frame inside `icegate_*`. A leak in
 first-party code is a bug to fix, not to suppress.
 
-`lsan.supp` carries documented exceptions to the second rule, each with measured figures
-and a retirement condition. Adding another needs the same accounting, or the target quietly
-becomes a rubber stamp. `asan.supp` gets no such exemption: an ASan report is a memory error
-rather than a retained allocation, so suppressing one hides a bug.
+`lsan.supp` carries no exception to the second rule today. Adding one needs measured figures
+from a full run on the current tree plus a retirement condition, or the target quietly
+becomes a rubber stamp. `asan.supp` gets no such exemption either: an ASan report is a memory
+error rather than a retained allocation, so suppressing one hides a bug.
 
 ## Maintaining the targets
 

--- a/config/sanitizers/asan.supp
+++ b/config/sanitizers/asan.supp
@@ -6,9 +6,7 @@
 # Same two rules as lsan.supp — every entry names the library and why the
 # allocation is not ours, and no entry may match a frame inside icegate_*.
 #
-# Note that lsan.supp now carries three documented exceptions to the second rule,
-# each covering a known first-party defect. Those were deliberate, individually
-# approved, and each carries measured figures and the fix that retires it. They
-# are not a precedent for this file: an ASan report is a memory error, not a
-# retained allocation, so there is no equivalent "known and bounded" category.
-# Suppressing one here would be hiding a bug outright.
+# An exception to the second rule in lsan.supp would not be a precedent for this
+# file: an ASan report is a memory error, not a retained allocation, so there is
+# no equivalent "known and bounded" category. Suppressing one here would be
+# hiding a bug outright.

--- a/config/sanitizers/lsan.supp
+++ b/config/sanitizers/lsan.supp
@@ -1,215 +1,64 @@
 # LeakSanitizer suppressions.
 #
-# Rules for this file:
+# Rules:
 #   1. Every entry names the library and why the allocation is not ours.
 #   2. No entry may match a frame inside icegate_* — suppressing our own code
-#      defeats the point of the target.
+#      defeats the point of the target. There is no exception today, and adding
+#      one needs measured figures from a full run on the current tree plus a
+#      retirement condition.
 #
-# Rule 2 currently has ONE documented exception, and it is TEST SCAFFOLDING.
-# There is no longer a first-party production-path suppression in this file, and
-# adding one back needs the dated accounting described at the bottom of this
-# header — not a pattern and a paragraph.
+# A green run means "no NEW leaks", not "no leaks". Every entry below records
+# what leaks, roughly how much, and the condition that retires it.
 #
-# TWO first-party production entries were deleted rather than corrected, both for
-# the same reason: each was written against a pre-#174 tree and cited code that no
-# longer existed by the time this file was committed at 066fa48.
-#
-#   * create_operator, which built a fresh opendal S3 backend per file operation
-#     (~9,578 of the original baseline's 9,930 allocations). #174 replaced it with
-#     `storage::registry::OperatorRegistry`, which builds one operator per
-#     identity and shares it. The entry was dead on arrival: at 066fa48,
-#     `git grep create_operator` matched only this file.
-#   * create_object_store / create_s3_store, cited at builder.rs:213 and :53 with
-#     5,080 bytes / 115 allocations in gc_sweep_it. Neither symbol exists in the
-#     tree, and builder.rs is 53 lines holding only create_local_store and
-#     create_memory_store — #174 moved S3 object stores onto the cached operator
-#     (registry.rs:223). Its `create_*_store` glob did still match the two
-#     local/memory functions, whose volume has never been measured; deleting it
-#     lets the first full nightly say whether they leak at all, instead of
-#     answering that question with a stale figure.
-#
-# The whole-suite total those figures fed is gone with them. No current total
-# replaces it, deliberately: the only scheduled run to date (2026-08-09, on
-# 066fa48) aborted inside `icegate-common --lib` before `--no-fail-fast` was added
-# to scripts/sanitize.sh, having run 2 of the workspace's test binaries. Every
-# icegate-query target was skipped, so EXCEPTION 1's two patterns and the
-# apache_avro entry were not exercised at all, and their figures below are still
-# the 2026-08-05 pre-#174 measurements. Re-measure across a full run before
-# writing a total back, and treat those three numbers as unverified until then.
-#
-# That run was red on 2,608 bytes / 46 allocations that nothing here matched.
-# The last two THIRD-PARTY entries in this file now cover exactly those 46 — no
-# more and no fewer, verified by `print_suppressions=1` reporting 36 + 10
-# hits — which is why the file grew rather than the code changing. Measured 2026-08-09 by
-# running the instrumented `icegate-common --lib` binary under three option sets
-# (aarch64: 2,608 bytes / 46 allocations; CI's x86_64: 2,448 / 46 — so the defect
-# is not architecture-specific):
-#
-#   * NO suppression here matches any of it. `print_suppressions=1` prints no
-#     "Suppressions used" table at all, and the totals with this file, with an
-#     empty file, and with CI's exact options agree to within one allocation.
-#   * There are ZERO Direct leaks even with suppressions disabled entirely. That
-#     rules out a suppressed root and means a reference cycle: every leaked block
-#     is reachable from another leaked block.
-#   * Every leaked object is third-party — 17 opentelemetry NoopSyncInstrument,
-#     17 opentelemetry_sdk ResolvedMeasures, plus opendal AccessorInfo /
-#     MetricsHttpFetcher / TokioExecutor and reqwest Client. Not one first-party
-#     allocation is in the set; first-party frames are call sites only, dominated
-#     by the OtelMetricsLayer registration at layers.rs:118 (once per registry)
-#     and the AccessorInfo built under registry.rs:265.
-#   * It is gated on a configured meter — no meter, no instruments, no leak — and
-#     bounded by registry count, not by traffic. It is NOT the per-operation
-#     shape that made the create_operator leak alarming.
-#
-# So it belongs with apache_avro as upstream retention rather than as a
-# first-party EXCEPTION, and that is where it is recorded — two entries, because
-# no single anchor covers both halves: the instrument/fetcher half always carries
-# an `opendal_layer_otelmetrics` frame and the AccessorInfo half never does. The
-# wide anchors (*opentelemetry_sdk*, *opendal*) were rejected for the reason the
-# deleted create_operator entry gave: they suppress those libraries across the
-# whole workspace. Breaking the cycle upstream retires both entries.
-#
-# What a green run means is unchanged: "no NEW leaks", not "no leaks".
-#
-# Every first-party entry must be deleted as its defect is fixed — both deletions
-# above are that rule being applied late, and the lesson is that an entry outlives
-# the code it names silently. Adding a SECOND exception needs measurement from a
-# full run on the current tree, naming the run, or this target quietly becomes a
-# rubber stamp. (One exception, two first-party patterns: EXCEPTION 1 needs two
-# anchors to cover its six call sites.)
+# THE FIGURES ARE UNVERIFIED. All were measured through the local aarch64
+# wrapper. CI is x86_64, where Rust omits frame pointers and LSan's fast
+# unwinder collapsed every stack to 3-8 frames — run 31771079196 matched only
+# *apache_avro* and failed all 13 leaking binaries. scripts/sanitize.sh now sets
+# fast_unwind_on_malloc=0; re-measure on the first run under it.
 
-# ===========================================================================
-# EXCEPTION 1 — TEST SCAFFOLDING, not shipped code. A deliberate `Box::leak`,
-# repeated as an idiom in six places, all in icegate-query:
-#
-#   crates/icegate-query/tests/loki/harness.rs:141    TestServer::start
-#   crates/icegate-query/tests/tempo/harness.rs:135   TestServer::start
-#   crates/icegate-query/benches/common/harness.rs:154
-#   crates/icegate-query/src/loki/routes.rs:111       (mod tests)
-#   crates/icegate-query/src/tempo/routes.rs:135      (mod tests)
-#   crates/icegate-query/src/prometheus/routes.rs:94  (mod tests)
-#
-# Each leaks a `tempfile::TempDir` holding the test warehouse, to keep the
-# directory alive while the server runs.
-#
-# Measured: 1,716 bytes / 88 allocations (loki_tests), 468 / 24 (tempo_tests),
-# 390 / 20 (query lib tests). Under the current patterns those land as
-# 88 + 24 = 112 on *harness::TestServer*start* and 20 on *routes::tests::build_state*.
-#
-# BLAST RADIUS. *harness::TestServer*start* is not namespaced to a crate, so it
-# also matches a third harness the list above does not name:
-# crates/icegate-query/tests/flight_sql/harness.rs:73 (TestServer::start, built
-# by --tests as flight_sql_tests). It contributes ~0 allocations today and is
-# still test scaffolding, so the "not shipped code" claim holds — but a future
-# leak in the Flight SQL harness would be swallowed here silently. Split into
-# *loki::harness::TestServer*start* / *tempo::harness::TestServer*start* if that
-# ever matters.
-#
-# Anchored on the first-party call sites, NOT on `tempfile::TempDir`. A type
-# anchor was tried first and rejected: although `tempfile` is a dev-dependency in
-# every first-party crate that names it, Cargo.lock lists it as a NORMAL
-# dependency of `datafusion` and `datafusion-execution` (Cargo does not resolve
-# external crates' dev-dependencies into the lock). `datafusion` is a normal
-# dependency of icegate-query, which ships the `query` binary, so a
-# `*tempfile*TempDir*` pattern would also cover DataFusion's DiskManager spill
-# path — masking a real production leak in exactly the kind of code a data engine
-# must not leak in.
-#
-# The bench harness needs no entry: `scripts/sanitize.sh` runs
-# `--lib --bins --tests`, which excludes benches.
-#
-# TODO(icegate): two real problems here, both worth fixing.
-#   1. The comment at loki/harness.rs:139 claims the tempdir "will be cleaned up
-#      when the process exits". It will not — `Box::leak` means `TempDir::drop`
-#      never runs, so the directory is never removed. This leaks disk, not just
-#      memory.
-#   2. docs/tests.md requires harnesses to own temporary directories through
-#      RAII-style guards that clean up on success, error, timeout, and panic.
-#      A leaked TempDir is precisely what that rule forbids.
-# The fix is to store the TempDir in the returned harness struct so RAII handles
-# it. Delete both entries then.
-leak:*harness::TestServer*start*
-leak:*routes::tests::build_state*
-
-# ===========================================================================
-# THIRD-PARTY — entries that satisfy rule 1 as originally written: each names the
-# library and why the allocation is not ours. The header's "delete each entry as
-# its defect is fixed" rule applies to the first-party EXCEPTION above, not to
-# these three; they retire when upstream stops retaining, which is why each
-# carries a retirement condition instead of a TODO.
-#
 # ---------------------------------------------------------------------------
 # apache-avro, reached through the iceberg fork's Avro value serialization
-# (iceberg::spec::values::serde::Record::serialize). The leaked blocks are
-# String clones the serializer retains for the life of the process; no
-# first-party frame appears in the stack.
+# (iceberg::spec::values::serde::Record::serialize). The leaked blocks are String
+# clones the serializer retains for the life of the process; no first-party frame
+# appears in the stack. Whole-suite: 108 allocations / 1,188 bytes.
 #
-# Measured whole-suite: 108 allocations / 1,188 bytes.
-#
-# Retires only if the iceberg fork stops serializing through apache-avro.
+# Retires if the iceberg fork stops serializing through apache-avro.
 leak:*apache_avro*
 
 # ---------------------------------------------------------------------------
-# opendal's OpenTelemetry metrics bridge, plus the OTel instruments it registers.
+# opendal's OpenTelemetry metrics bridge, plus the instruments it registers.
+# `OtelMetricsLayer::builder().register(meter)` — storage/layers.rs:118, once per
+# registry — registers opendal's instrument set and swaps the accessor's HTTP
+# client for a MetricsHttpFetcher. Nothing is released at exit, and with all
+# suppressions disabled LSan reports every block Indirect with zero Direct roots:
+# a reference cycle in the OTel/opendal object graph, not a Box of ours that went
+# missing. icegate-common --lib: 36 allocations / 1,576 bytes.
 #
-# `OtelMetricsLayer::builder().register(meter)` — called once per registry at
-# storage/layers.rs:118 — registers opendal's instrument set against the meter,
-# and applying the layer swaps the accessor's HTTP client for a
-# MetricsHttpFetcher. None of it is released at exit, and with ALL suppressions
-# disabled LSan still reports every block Indirect with ZERO Direct roots: the
-# retention is a reference cycle inside the OTel/opendal object graph, not a Box
-# of ours that went missing. No first-party allocation is in the set; the
-# first-party frames are call sites.
+# Safe to suppress where a first-party leak would not be: gated on a configured
+# meter (no meter, no instruments, so every IoHandle::noop() caller is
+# unaffected) and bounded by registry count, not by traffic.
 #
-# Measured 2026-08-09, `icegate-common --lib`: 36 of that binary's 46
-# allocations, 1,576 of its 2,608 bytes —
-#     17 x  40 B  opentelemetry_sdk ResolvedMeasures<f64|u64|i64>
-#     17 x  16 B  opentelemetry NoopSyncInstrument
-#      2 x 312 B  MetricsHttpFetcher<OtelMetricsInterceptor>
+# Anchored on the bridge crate, whose entire job is this one layer. Deliberately
+# NOT *opentelemetry_sdk* or *opendal* — either would suppress those libraries
+# across the whole workspace, including the query engine's metrics and every
+# opendal I/O path.
 #
-# Why this is safe to suppress where create_operator was not: it is gated on a
-# configured meter (no meter, no instruments, no leak — so every IoHandle::noop()
-# caller is unaffected) and bounded by REGISTRY count, not by request or
-# file-operation count. One registry per IoHandle, and IoHandle is built once per
-# service at startup (catalog/builder.rs:72/:76). create_operator scaled with
-# every Iceberg file operation; this does not scale at all.
-#
-# BLAST RADIUS. Anchored on the bridge crate, whose entire job is this one layer,
-# so what it can hide is a different leak in the same bridge. Deliberately NOT
-# *opentelemetry_sdk* or *opendal*: either would suppress those libraries across
-# the whole workspace, including the query engine's own metrics and every opendal
-# I/O path.
-#
-# Retires when opendal breaks the cycle, or when the layer stops replacing the
-# accessor's HTTP client. Re-measure rather than trusting the figures above.
+# Retires when opendal breaks the cycle.
 leak:*opendal_layer_otelmetrics*
 
 # ---------------------------------------------------------------------------
 # opendal's S3 backend construction — the other half of the same cycle.
-#
 # `S3Builder::build` allocates the backend's AccessorInfo, its reqwest client and
 # a TokioExecutor, reached through storage/registry.rs:265. A separate entry
-# because these stacks carry no `opendal_layer_otelmetrics` frame, so the entry
-# above cannot cover them.
+# because these stacks carry no opendal_layer_otelmetrics frame. One set per
+# operator built, and operators are cached by credentials plus bucket, so this is
+# bounded by distinct pairs per process, not by traffic. icegate-common --lib:
+# 10 allocations / 1,032 bytes.
 #
-# Measured 2026-08-09, `icegate-common --lib`: the remaining 10 of 46
-# allocations, 1,032 of 2,608 bytes —
-#      2 x 416 B  opendal_core AccessorInfo
-#      5 x  24 B  opendal-core / opendal-service-s3 backend internals
-#      2 x  16 B  as above
-#      1 x  48 B  as above
-#
-# One set per operator built, and operators are cached: the registry keys them by
-# credentials plus bucket and never evicts, warning once past
-# OPERATOR_WARN_THRESHOLD (storage/registry.rs). Bounded by distinct
-# credential/bucket pairs per process, not by traffic.
-#
-# BLAST RADIUS. Anchored on the builder's `build`, so it covers operator
-# CONSTRUCTION only — a leak in an S3 read, write, list, or stat carries no
-# S3Builder frame and still fails the run. The crate is named in the pattern
-# deliberately: a bare *S3Builder*build* would also match `object_store`'s
-# AmazonS3Builder, which icegate-catalog-s3 uses for an unrelated store
-# (storage/s3.rs:38) and icegate-common's own test helpers use as well.
+# Covers operator CONSTRUCTION only: a leak in an S3 read, write, list, or stat
+# carries no S3Builder frame and still fails the run. Crate-qualified on purpose
+# — a bare *S3Builder*build* would also match object_store's AmazonS3Builder,
+# which icegate-catalog-s3 and icegate-common's test helpers both use.
 #
 # Retires with the cycle upstream, or if opendal stops retaining AccessorInfo.
 leak:*opendal_service_s3::backend::S3Builder*build*

--- a/crates/icegate-catalog-s3/Cargo.toml
+++ b/crates/icegate-catalog-s3/Cargo.toml
@@ -5,6 +5,7 @@ readme = "../../README.md"
 keywords = ["iceberg", "s3", "catalog", "data-lake", "observability"]
 categories = ["database"]
 version = { workspace = true }
+rust-version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/icegate-common/Cargo.toml
+++ b/crates/icegate-common/Cargo.toml
@@ -5,6 +5,7 @@ readme = "../../README.md"
 keywords = ["iceberg", "datafusion", "data-lake", "observability"]
 categories = ["database"]
 version = { workspace = true }
+rust-version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
@@ -14,7 +15,10 @@ repository = { workspace = true }
 workspace = true
 
 [features]
-testing = ["testcontainers", "aws-config", "aws-sdk-s3"]
+testing = ["test-harness", "testcontainers", "aws-config", "aws-sdk-s3"]
+# Harness helpers for draining a spawned server task. tokio-only, so a test or
+# benchmark that needs them does not also build the testcontainers/S3 stack.
+test-harness = []
 # gRPC request-shedding interceptor. Only `icegate-query`/`icegate-ingest` (which
 # already depend on tonic) opt in; keeps `icegate-maintain`/jobmanager off tonic.
 shed-tonic = ["dep:tonic"]

--- a/crates/icegate-common/src/lib.rs
+++ b/crates/icegate-common/src/lib.rs
@@ -144,8 +144,8 @@ pub mod tracing;
 /// Compaction-safe resolution of the last committed WAL offset from snapshots.
 pub mod wal_offset;
 
-/// Testing utilities (available only with `testing` feature).
-#[cfg(feature = "testing")]
+/// Testing utilities (available with the `testing` or `test-harness` feature).
+#[cfg(any(feature = "testing", feature = "test-harness"))]
 pub mod testing;
 
 // Re-export commonly used types

--- a/crates/icegate-common/src/testing/mod.rs
+++ b/crates/icegate-common/src/testing/mod.rs
@@ -3,13 +3,23 @@
 //! This module provides reusable infrastructure for setting up test environments:
 //! - Object-storage containers for S3-compatible object storage
 //! - AWS S3 client configuration helpers
+//! - Draining the server task a test or benchmark harness spawned
 //!
-//! Available only when the `testing` feature is enabled.
+//! Split across two features so a consumer pays only for what it uses: the
+//! object-storage helpers need `testing`, the harness helpers only
+//! `test-harness`.
 
 /// Object-storage testcontainer setup.
+#[cfg(feature = "testing")]
 pub mod container;
 /// AWS S3 client helpers.
+#[cfg(feature = "testing")]
 pub mod s3;
+/// Draining a harness-spawned server task.
+#[cfg(feature = "test-harness")]
+pub mod server_task;
 
+#[cfg(feature = "testing")]
 pub use container::S3TestContainer;
+#[cfg(feature = "testing")]
 pub use s3::{create_s3_bucket, create_s3_object_store};

--- a/crates/icegate-common/src/testing/server_task.rs
+++ b/crates/icegate-common/src/testing/server_task.rs
@@ -1,0 +1,57 @@
+//! Lifecycle handling for a harness-spawned server task.
+//!
+//! Every server harness in the workspace runs its server on a temporary
+//! warehouse directory that is dropped as the harness frame unwinds, which is
+//! what makes draining the task non-optional: a task still running when that
+//! directory is removed serves from a deleted path, and under LeakSanitizer it
+//! also outlives the check. The harnesses are separate compilation units, so
+//! the drain sequence and its time limit live here rather than once per
+//! harness.
+
+use tokio::{task::JoinHandle, time::Duration};
+
+/// Grace period for a cancelled server task to wind down.
+///
+/// Bounded rather than unbounded because a task wedged in non-yielding code
+/// would never join at all, and a hung suite is a worse outcome than a failure.
+pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Why a drained server task stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DrainOutcome {
+    /// The task returned on its own within [`SHUTDOWN_TIMEOUT`].
+    Finished,
+    /// The task outlived [`SHUTDOWN_TIMEOUT`], was aborted, and was joined
+    /// again under the same bound. Cancellation is not guaranteed to have
+    /// completed even so, but the handle was never dropped, so the task was
+    /// never detached.
+    Aborted,
+}
+
+/// Drain a server task whose cancellation token has already fired.
+///
+/// Returns once the task is no longer running, or once it has been aborted and
+/// re-joined. The caller may then drop the warehouse directory.
+///
+/// # Panics
+///
+/// Resumes the task's own panic when it has one, so the failure that actually
+/// stopped the server surfaces instead of the caller's summary message — a
+/// startup failure reaches the harness only as a closed port channel, which
+/// says nothing about the cause. Panics with `server` named on a non-panic
+/// `JoinError`.
+pub async fn drain_server_task(handle: &mut JoinHandle<()>, server: &str) -> DrainOutcome {
+    match tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut *handle).await {
+        Ok(Ok(())) => DrainOutcome::Finished,
+        Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
+        Ok(Err(join_err)) => panic!("{server} server task failed to join: {join_err}"),
+        Err(_elapsed) => {
+            // `abort()` only schedules cancellation, so join again before
+            // handing control back to a caller that is about to delete the
+            // warehouse this task is still reading.
+            handle.abort();
+            let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, handle).await;
+            DrainOutcome::Aborted
+        }
+    }
+}

--- a/crates/icegate-ingest/Cargo.toml
+++ b/crates/icegate-ingest/Cargo.toml
@@ -5,6 +5,7 @@ readme = "../../README.md"
 keywords = ["iceberg", "otlp", "opentelemetry", "observability"]
 categories = ["database"]
 version = { workspace = true }
+rust-version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/icegate-ingest/src/shift/shift_runner.rs
+++ b/crates/icegate-ingest/src/shift/shift_runner.rs
@@ -798,7 +798,7 @@ mod tests {
             self.writes.lock().await.push(attempt_batches);
             if self
                 .fail_attempts_remaining
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                .try_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
                     (remaining > 0).then_some(remaining.saturating_sub(1))
                 })
                 .is_ok()

--- a/crates/icegate-maintain/Cargo.toml
+++ b/crates/icegate-maintain/Cargo.toml
@@ -5,6 +5,7 @@ readme = "../../README.md"
 keywords = ["iceberg", "maintenance", "migration", "observability"]
 categories = ["database"]
 version = { workspace = true }
+rust-version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/icegate-query/Cargo.toml
+++ b/crates/icegate-query/Cargo.toml
@@ -5,6 +5,7 @@ readme = "README.md"
 keywords = ["iceberg", "datafusion", "logql", "flight-sql"]
 categories = ["database"]
 version = { workspace = true }
+rust-version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
@@ -94,6 +95,7 @@ name = "loki_queries"
 harness = false
 
 [dev-dependencies]
+icegate-common = { workspace = true, features = ["test-harness"] }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
 criterion = { workspace = true }

--- a/crates/icegate-query/benches/common/harness.rs
+++ b/crates/icegate-query/benches/common/harness.rs
@@ -37,6 +37,10 @@ use tokio::sync::oneshot;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 
+/// Grace period for the server task to wind down once cancelled, used both for
+/// an orderly shutdown and for draining the task after a failed startup.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Build a `FixedSizeBinary(byte_width)` array by decoding `hex` once and
 /// repeating the resulting bytes `count` times. Used to seed identical
 /// `trace_id` / `span_id` values across many synthetic rows.
@@ -142,12 +146,16 @@ impl TestServer {
 
         let actual_port = match tokio::time::timeout(Duration::from_secs(10), port_rx).await {
             Ok(Ok(port)) => port,
-            Ok(Err(_)) => {
+            Ok(Err(_recv_err)) => {
                 cancel_token.cancel();
+                // Drain before unwinding: `warehouse_path` drops with this frame, so a
+                // detached server would go on running against a deleted directory.
+                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, server_handle).await;
                 panic!("Failed to receive port from server");
             }
-            Err(_) => {
+            Err(_elapsed) => {
                 cancel_token.cancel();
+                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, server_handle).await;
                 panic!("Timed out waiting for server to start");
             }
         };
@@ -171,13 +179,21 @@ impl TestServer {
     /// skew a benchmark (and leak the background task).
     pub async fn shutdown(mut self) {
         self.cancel_token.cancel();
-        match tokio::time::timeout(Duration::from_secs(5), &mut self.server_handle).await {
+        match tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await {
             Ok(Ok(())) => {}
             Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
             Ok(Err(join_err)) => panic!("Loki benchmark server task failed to join: {join_err}"),
             Err(_elapsed) => {
                 self.server_handle.abort();
-                panic!("Loki benchmark server did not shut down within 5s");
+                // `abort()` only schedules cancellation, so join the task before the
+                // panic unwinds and drops `temp_dir`. Bounded, because a task wedged
+                // in non-yielding code would never join at all, and a hung run is a
+                // worse outcome than this panic.
+                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await;
+                panic!(
+                    "Loki benchmark server did not shut down within {}s",
+                    SHUTDOWN_TIMEOUT.as_secs()
+                );
             }
         }
     }

--- a/crates/icegate-query/benches/common/harness.rs
+++ b/crates/icegate-query/benches/common/harness.rs
@@ -26,6 +26,7 @@ use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::file_writer::location_generator::{DefaultFileNameGenerator, DefaultLocationGenerator};
 use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
 use iceberg::writer::{IcebergWriter, IcebergWriterBuilder};
+use icegate_common::testing::server_task::{DrainOutcome, SHUTDOWN_TIMEOUT, drain_server_task};
 use icegate_common::{
     CatalogBackend, CatalogConfig, ICEGATE_NAMESPACE, IoHandle, LOGS_TABLE, catalog::CatalogBuilder, schema,
 };
@@ -37,9 +38,8 @@ use tokio::sync::oneshot;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-/// Grace period for the server task to wind down once cancelled, used both for
-/// an orderly shutdown and for draining the task after a failed startup.
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long to wait for the server to report the port it bound.
+const PORT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Build a `FixedSizeBinary(byte_width)` array by decoding `hex` once and
 /// repeating the resulting bytes `count` times. Used to seed identical
@@ -130,7 +130,7 @@ impl TestServer {
 
         let (port_tx, port_rx) = oneshot::channel::<u16>();
 
-        let server_handle = tokio::spawn(async move {
+        let mut server_handle = tokio::spawn(async move {
             let disabled_metrics = Arc::new(icegate_query::infra::metrics::QueryMetrics::new_disabled());
             icegate_query::loki::run_with_port_tx(
                 server_engine,
@@ -144,19 +144,17 @@ impl TestServer {
             .unwrap();
         });
 
-        let actual_port = match tokio::time::timeout(Duration::from_secs(10), port_rx).await {
+        let actual_port = match tokio::time::timeout(PORT_TIMEOUT, port_rx).await {
             Ok(Ok(port)) => port,
             Ok(Err(_recv_err)) => {
                 cancel_token.cancel();
-                // Drain before unwinding: `warehouse_path` drops with this frame, so a
-                // detached server would go on running against a deleted directory.
-                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, server_handle).await;
-                panic!("Failed to receive port from server");
+                drain_server_task(&mut server_handle, "Loki benchmark").await;
+                panic!("Loki benchmark server dropped the port channel before reporting a bound port");
             }
             Err(_elapsed) => {
                 cancel_token.cancel();
-                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, server_handle).await;
-                panic!("Timed out waiting for server to start");
+                drain_server_task(&mut server_handle, "Loki benchmark").await;
+                panic!("Timed out waiting for Loki benchmark server to bind");
             }
         };
 
@@ -179,22 +177,12 @@ impl TestServer {
     /// skew a benchmark (and leak the background task).
     pub async fn shutdown(mut self) {
         self.cancel_token.cancel();
-        match tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await {
-            Ok(Ok(())) => {}
-            Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
-            Ok(Err(join_err)) => panic!("Loki benchmark server task failed to join: {join_err}"),
-            Err(_elapsed) => {
-                self.server_handle.abort();
-                // `abort()` only schedules cancellation, so join the task before the
-                // panic unwinds and drops `temp_dir`. Bounded, because a task wedged
-                // in non-yielding code would never join at all, and a hung run is a
-                // worse outcome than this panic.
-                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await;
-                panic!(
-                    "Loki benchmark server did not shut down within {}s",
-                    SHUTDOWN_TIMEOUT.as_secs()
-                );
-            }
+        match drain_server_task(&mut self.server_handle, "Loki benchmark").await {
+            DrainOutcome::Finished => {}
+            DrainOutcome::Aborted => panic!(
+                "Loki benchmark server did not shut down within {}s",
+                SHUTDOWN_TIMEOUT.as_secs()
+            ),
         }
     }
 }

--- a/crates/icegate-query/benches/common/harness.rs
+++ b/crates/icegate-query/benches/common/harness.rs
@@ -55,6 +55,10 @@ pub struct TestServer {
     pub base_url: String,
     pub cancel_token: CancellationToken,
     server_handle: tokio::task::JoinHandle<()>,
+    /// Owns the temporary warehouse directory; held purely for its
+    /// `Drop`, which removes the directory when the server is dropped.
+    #[allow(dead_code)]
+    temp_dir: tempfile::TempDir,
 }
 
 impl TestServer {
@@ -148,26 +152,34 @@ impl TestServer {
             }
         };
 
-        // SAFETY: Intentionally leak the TempDir to keep it alive for the benchmark/server lifetime.
-        // The spawned server requires a persistent filesystem path that outlives this function.
-        // This is an acceptable leak in the benchmark harness context.
-        Box::leak(Box::new(warehouse_path));
-
         Ok((
             Self {
                 client: Client::new(),
                 base_url: format!("http://127.0.0.1:{actual_port}"),
                 cancel_token,
                 server_handle,
+                temp_dir: warehouse_path,
             },
             catalog,
         ))
     }
 
-    /// Shutdown the test server
-    pub async fn shutdown(self) {
+    /// Shut the server down, draining the spawn task.
+    ///
+    /// Surfaces a panic from the server task and fails on timeout rather
+    /// than swallowing both, so a crashing or hung server can't silently
+    /// skew a benchmark (and leak the background task).
+    pub async fn shutdown(mut self) {
         self.cancel_token.cancel();
-        let _ = tokio::time::timeout(Duration::from_secs(5), self.server_handle).await;
+        match tokio::time::timeout(Duration::from_secs(5), &mut self.server_handle).await {
+            Ok(Ok(())) => {}
+            Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
+            Ok(Err(join_err)) => panic!("Loki benchmark server task failed to join: {join_err}"),
+            Err(_elapsed) => {
+                self.server_handle.abort();
+                panic!("Loki benchmark server did not shut down within 5s");
+            }
+        }
     }
 }
 

--- a/crates/icegate-query/src/loki/routes.rs
+++ b/crates/icegate-query/src/loki/routes.rs
@@ -87,7 +87,10 @@ mod tests {
         guard
     }
 
-    async fn build_state() -> LokiState {
+    /// Builds the router state over a fresh temp-dir warehouse, returning the
+    /// directory guard alongside it. The caller MUST hold the guard for as long
+    /// as it uses the state: dropping it removes the directory the catalog reads.
+    async fn build_state() -> (LokiState, tempfile::TempDir) {
         let warehouse = tempfile::tempdir().expect("tempdir");
         let catalog_config = CatalogConfig {
             backend: CatalogBackend::Memory,
@@ -107,12 +110,13 @@ mod tests {
             wal_store,
             wal_reader,
         ));
-        // Keep the temp warehouse alive for the lifetime of the engine.
-        Box::leak(Box::new(warehouse));
-        LokiState {
-            engine,
-            metrics: Arc::new(QueryMetrics::new_disabled()),
-        }
+        (
+            LokiState {
+                engine,
+                metrics: Arc::new(QueryMetrics::new_disabled()),
+            },
+            warehouse,
+        )
     }
 
     fn get_request(uri: &str) -> Request<Body> {
@@ -121,21 +125,24 @@ mod tests {
 
     #[tokio::test]
     async fn inert_guard_allows_requests() {
-        let app = routes(build_state().await, MemoryPressure::inert());
+        let (state, _warehouse) = build_state().await;
+        let app = routes(state, MemoryPressure::inert());
         let response = app.oneshot(get_request("/ready")).await.expect("response");
         assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]
     async fn pressured_guard_sheds_work_path() {
-        let app = routes(build_state().await, pressured_guard());
+        let (state, _warehouse) = build_state().await;
+        let app = routes(state, pressured_guard());
         let response = app.oneshot(get_request("/loki/api/v1/query")).await.expect("response");
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]
     async fn pressured_guard_bypasses_ready() {
-        let app = routes(build_state().await, pressured_guard());
+        let (state, _warehouse) = build_state().await;
+        let app = routes(state, pressured_guard());
         let response = app.oneshot(get_request("/ready")).await.expect("response");
         assert_eq!(response.status(), StatusCode::OK);
     }

--- a/crates/icegate-query/src/prometheus/routes.rs
+++ b/crates/icegate-query/src/prometheus/routes.rs
@@ -71,7 +71,10 @@ mod tests {
         guard
     }
 
-    async fn build_state() -> PrometheusState {
+    /// Builds the router state over a fresh temp-dir warehouse, returning the
+    /// directory guard alongside it. The caller MUST hold the guard for as long
+    /// as it uses the state: dropping it removes the directory the catalog reads.
+    async fn build_state() -> (PrometheusState, tempfile::TempDir) {
         let warehouse = tempfile::tempdir().expect("tempdir");
         let catalog_config = CatalogConfig {
             backend: CatalogBackend::Memory,
@@ -91,8 +94,7 @@ mod tests {
             wal_store,
             wal_reader,
         ));
-        Box::leak(Box::new(warehouse));
-        PrometheusState { engine }
+        (PrometheusState { engine }, warehouse)
     }
 
     fn get_request(uri: &str) -> Request<Body> {
@@ -101,21 +103,24 @@ mod tests {
 
     #[tokio::test]
     async fn inert_guard_allows_requests() {
-        let app = routes(build_state().await, MemoryPressure::inert());
+        let (state, _warehouse) = build_state().await;
+        let app = routes(state, MemoryPressure::inert());
         let response = app.oneshot(get_request("/-/ready")).await.expect("response");
         assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]
     async fn pressured_guard_sheds_work_path() {
-        let app = routes(build_state().await, pressured_guard());
+        let (state, _warehouse) = build_state().await;
+        let app = routes(state, pressured_guard());
         let response = app.oneshot(get_request("/api/v1/query")).await.expect("response");
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]
     async fn pressured_guard_bypasses_ready() {
-        let app = routes(build_state().await, pressured_guard());
+        let (state, _warehouse) = build_state().await;
+        let app = routes(state, pressured_guard());
         let response = app.oneshot(get_request("/-/ready")).await.expect("response");
         assert_eq!(response.status(), StatusCode::OK);
     }

--- a/crates/icegate-query/src/tempo/mod.rs
+++ b/crates/icegate-query/src/tempo/mod.rs
@@ -15,4 +15,4 @@ pub mod trace_by_id;
 mod validation;
 
 pub use config::TempoConfig;
-pub use server::run;
+pub use server::{run, run_with_port_tx};

--- a/crates/icegate-query/src/tempo/routes.rs
+++ b/crates/icegate-query/src/tempo/routes.rs
@@ -112,7 +112,10 @@ mod tests {
         guard
     }
 
-    async fn build_state() -> TempoState {
+    /// Builds the router state over a fresh temp-dir warehouse, returning the
+    /// directory guard alongside it. The caller MUST hold the guard for as long
+    /// as it uses the state: dropping it removes the directory the catalog reads.
+    async fn build_state() -> (TempoState, tempfile::TempDir) {
         let warehouse = tempfile::tempdir().expect("tempdir");
         let catalog_config = CatalogConfig {
             backend: CatalogBackend::Memory,
@@ -132,8 +135,7 @@ mod tests {
             wal_store,
             wal_reader,
         ));
-        Box::leak(Box::new(warehouse));
-        TempoState { engine }
+        (TempoState { engine }, warehouse)
     }
 
     fn get_request(uri: &str) -> Request<Body> {
@@ -142,28 +144,32 @@ mod tests {
 
     #[tokio::test]
     async fn inert_guard_allows_requests() {
-        let app = routes(build_state().await, MemoryPressure::inert());
+        let (state, _warehouse) = build_state().await;
+        let app = routes(state, MemoryPressure::inert());
         let response = app.oneshot(get_request("/ready")).await.expect("response");
         assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]
     async fn pressured_guard_sheds_work_path() {
-        let app = routes(build_state().await, pressured_guard());
+        let (state, _warehouse) = build_state().await;
+        let app = routes(state, pressured_guard());
         let response = app.oneshot(get_request("/api/search")).await.expect("response");
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]
     async fn pressured_guard_bypasses_ready() {
-        let app = routes(build_state().await, pressured_guard());
+        let (state, _warehouse) = build_state().await;
+        let app = routes(state, pressured_guard());
         let response = app.oneshot(get_request("/ready")).await.expect("response");
         assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]
     async fn pressured_guard_bypasses_echo() {
-        let app = routes(build_state().await, pressured_guard());
+        let (state, _warehouse) = build_state().await;
+        let app = routes(state, pressured_guard());
         let response = app.oneshot(get_request("/api/echo")).await.expect("response");
         assert_eq!(response.status(), StatusCode::OK);
     }

--- a/crates/icegate-query/src/tempo/server.rs
+++ b/crates/icegate-query/src/tempo/server.rs
@@ -3,6 +3,7 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use icegate_common::MemoryPressure;
+use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
 use super::TempoConfig;
@@ -27,15 +28,39 @@ pub async fn run(
     cancel_token: CancellationToken,
     pressure: MemoryPressure,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    run_with_port_tx(engine, config, cancel_token, None, pressure).await
+}
+
+/// Run the Tempo HTTP server with optional port notification
+///
+/// When `port_tx` is provided, the actual bound port is sent after the listener binds.
+/// This is useful for ephemeral port assignment (port 0) in tests.
+///
+/// # Errors
+///
+/// Returns an error if the server cannot be started or encounters a fatal error
+pub async fn run_with_port_tx(
+    engine: Arc<QueryEngine>,
+    config: TempoConfig,
+    cancel_token: CancellationToken,
+    port_tx: Option<oneshot::Sender<u16>>,
+    pressure: MemoryPressure,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let addr: SocketAddr = format!("{}:{}", config.host, config.port).parse()?;
 
     let state = TempoState { engine };
 
     let app = super::routes::routes(state, pressure);
 
-    tracing::info!("Tempo API server listening on {}", addr);
-
     let listener = tokio::net::TcpListener::bind(addr).await?;
+    let local_addr = listener.local_addr()?;
+
+    tracing::info!("Tempo API server listening on {}", local_addr);
+
+    // Notify the caller of the actual bound port (useful for ephemeral ports)
+    if let Some(tx) = port_tx {
+        let _ = tx.send(local_addr.port());
+    }
 
     axum::serve(listener, app)
         .with_graceful_shutdown(async move {

--- a/crates/icegate-query/tests/flight_sql/harness.rs
+++ b/crates/icegate-query/tests/flight_sql/harness.rs
@@ -35,6 +35,7 @@ use iceberg::writer::file_writer::ParquetWriterBuilder;
 use iceberg::writer::file_writer::location_generator::{DefaultFileNameGenerator, DefaultLocationGenerator};
 use iceberg::writer::file_writer::rolling_writer::RollingFileWriterBuilder;
 use iceberg::writer::{IcebergWriter, IcebergWriterBuilder};
+use icegate_common::testing::server_task::{DrainOutcome, SHUTDOWN_TIMEOUT, drain_server_task};
 use icegate_common::{
     CatalogBackend, CatalogConfig, EVENTS_TABLE, ICEGATE_NAMESPACE, IoHandle, LOGS_TABLE, METRICS_TABLE, PRICES_TABLE,
     SPANS_TABLE, TENANT_ID_HEADER, catalog::CatalogBuilder, schema,
@@ -49,6 +50,9 @@ use tonic::transport::{Channel, Endpoint};
 
 /// Severity values cycled across written log rows.
 const SEVERITIES: [&str; 3] = ["INFO", "WARN", "ERROR"];
+
+/// How long to wait for the server to report the port it bound.
+const PORT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Connected Flight SQL test server.
 ///
@@ -105,7 +109,7 @@ impl TestServer {
         let server_engine = Arc::clone(&query_engine);
         let (port_tx, port_rx) = oneshot::channel::<u16>();
 
-        let server_handle = tokio::spawn(async move {
+        let mut server_handle = tokio::spawn(async move {
             icegate_query::flight_sql::run_with_port_tx(
                 server_engine,
                 flight_sql_config,
@@ -117,10 +121,23 @@ impl TestServer {
             .unwrap();
         });
 
-        let actual_port = tokio::time::timeout(Duration::from_secs(10), port_rx)
-            .await
-            .expect("Timed out waiting for Flight SQL server to start")
-            .expect("Failed to receive port from server");
+        // Drain the task on either failure before unwinding: `warehouse_path` drops
+        // with this frame, so a detached server would go on serving from a deleted
+        // directory. `drain_server_task` resumes the task's own panic when it has
+        // one, which is the only place the real startup error survives.
+        let actual_port = match tokio::time::timeout(PORT_TIMEOUT, port_rx).await {
+            Ok(Ok(port)) => port,
+            Ok(Err(_recv_err)) => {
+                cancel_token.cancel();
+                drain_server_task(&mut server_handle, "Flight SQL").await;
+                panic!("Flight SQL server dropped the port channel before reporting a bound port");
+            }
+            Err(_elapsed) => {
+                cancel_token.cancel();
+                drain_server_task(&mut server_handle, "Flight SQL").await;
+                panic!("Timed out waiting for Flight SQL server to bind");
+            }
+        };
 
         let endpoint = Endpoint::from_shared(format!("http://127.0.0.1:{actual_port}"))?;
         let channel = endpoint.connect().await?;
@@ -157,14 +174,12 @@ impl TestServer {
     /// pass the test (and leak the background task).
     pub async fn shutdown(mut self) {
         self.cancel_token.cancel();
-        match tokio::time::timeout(Duration::from_secs(5), &mut self.server_handle).await {
-            Ok(Ok(())) => {}
-            Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
-            Ok(Err(join_err)) => panic!("Flight SQL server task failed to join: {join_err}"),
-            Err(_elapsed) => {
-                self.server_handle.abort();
-                panic!("Flight SQL server did not shut down within 5s");
-            }
+        match drain_server_task(&mut self.server_handle, "Flight SQL").await {
+            DrainOutcome::Finished => {}
+            DrainOutcome::Aborted => panic!(
+                "Flight SQL server did not shut down within {}s",
+                SHUTDOWN_TIMEOUT.as_secs()
+            ),
         }
     }
 }

--- a/crates/icegate-query/tests/loki/harness.rs
+++ b/crates/icegate-query/tests/loki/harness.rs
@@ -52,6 +52,10 @@ pub struct TestServer {
     pub base_url: String,
     pub cancel_token: CancellationToken,
     server_handle: tokio::task::JoinHandle<()>,
+    /// Owns the temporary warehouse directory; held purely for its
+    /// `Drop`, which removes the directory when the server is dropped.
+    #[allow(dead_code)]
+    temp_dir: tempfile::TempDir,
 }
 
 impl TestServer {
@@ -136,25 +140,34 @@ impl TestServer {
             .expect("Timed out waiting for server to start")
             .expect("Failed to receive port from server");
 
-        // Leak the tempdir to keep it alive for the duration of the test
-        // (it will be cleaned up when the process exits)
-        Box::leak(Box::new(warehouse_path));
-
         Ok((
             Self {
                 client: Client::new(),
                 base_url: format!("http://127.0.0.1:{actual_port}"),
                 cancel_token,
                 server_handle,
+                temp_dir: warehouse_path,
             },
             catalog,
         ))
     }
 
-    /// Shutdown the test server
-    pub async fn shutdown(self) {
+    /// Shut the server down, draining the spawn task.
+    ///
+    /// Surfaces a panic from the server task and fails on timeout rather
+    /// than swallowing both, so a crashing or hung server can't silently
+    /// pass the test (and leak the background task).
+    pub async fn shutdown(mut self) {
         self.cancel_token.cancel();
-        let _ = tokio::time::timeout(Duration::from_secs(5), self.server_handle).await;
+        match tokio::time::timeout(Duration::from_secs(5), &mut self.server_handle).await {
+            Ok(Ok(())) => {}
+            Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
+            Ok(Err(join_err)) => panic!("Loki server task failed to join: {join_err}"),
+            Err(_elapsed) => {
+                self.server_handle.abort();
+                panic!("Loki server did not shut down within 5s");
+            }
+        }
     }
 }
 

--- a/crates/icegate-query/tests/loki/harness.rs
+++ b/crates/icegate-query/tests/loki/harness.rs
@@ -34,6 +34,7 @@ use iceberg::{
         },
     },
 };
+use icegate_common::testing::server_task::{DrainOutcome, SHUTDOWN_TIMEOUT, drain_server_task};
 use icegate_common::{
     CatalogBackend, CatalogConfig, ICEGATE_NAMESPACE, IoHandle, LOGS_TABLE, catalog::CatalogBuilder, schema,
 };
@@ -46,9 +47,8 @@ use tokio::sync::oneshot;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-/// Grace period for the server task to wind down once cancelled, used both for
-/// an orderly shutdown and for draining the task after a failed startup.
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long to wait for the server to report the port it bound.
+const PORT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Test server configuration and handles
 pub struct TestServer {
@@ -124,7 +124,7 @@ impl TestServer {
         // Create oneshot channel to receive the actual bound port
         let (port_tx, port_rx) = oneshot::channel::<u16>();
 
-        let server_handle = tokio::spawn(async move {
+        let mut server_handle = tokio::spawn(async move {
             let disabled_metrics = Arc::new(icegate_query::infra::metrics::QueryMetrics::new_disabled());
             icegate_query::loki::run_with_port_tx(
                 server_engine,
@@ -141,17 +141,17 @@ impl TestServer {
         // Wait for the server to bind and receive the actual port. Drain the task on
         // either failure: `warehouse_path` drops as this frame unwinds, so a detached
         // server would go on running against a deleted directory.
-        let actual_port = match tokio::time::timeout(Duration::from_secs(10), port_rx).await {
+        let actual_port = match tokio::time::timeout(PORT_TIMEOUT, port_rx).await {
             Ok(Ok(port)) => port,
             Ok(Err(_recv_err)) => {
                 cancel_token.cancel();
-                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, server_handle).await;
-                panic!("Failed to receive port from server");
+                drain_server_task(&mut server_handle, "Loki").await;
+                panic!("Loki server dropped the port channel before reporting a bound port");
             }
             Err(_elapsed) => {
                 cancel_token.cancel();
-                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, server_handle).await;
-                panic!("Timed out waiting for server to start");
+                drain_server_task(&mut server_handle, "Loki").await;
+                panic!("Timed out waiting for Loki server to bind");
             }
         };
 
@@ -174,19 +174,9 @@ impl TestServer {
     /// pass the test (and leak the background task).
     pub async fn shutdown(mut self) {
         self.cancel_token.cancel();
-        match tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await {
-            Ok(Ok(())) => {}
-            Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
-            Ok(Err(join_err)) => panic!("Loki server task failed to join: {join_err}"),
-            Err(_elapsed) => {
-                self.server_handle.abort();
-                // `abort()` only schedules cancellation, so join the task before the
-                // panic unwinds and drops `temp_dir`. Bounded, because a task wedged
-                // in non-yielding code would never join at all, and a hung suite is a
-                // worse outcome than this panic.
-                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await;
-                panic!("Loki server did not shut down within {}s", SHUTDOWN_TIMEOUT.as_secs());
-            }
+        match drain_server_task(&mut self.server_handle, "Loki").await {
+            DrainOutcome::Finished => {}
+            DrainOutcome::Aborted => panic!("Loki server did not shut down within {}s", SHUTDOWN_TIMEOUT.as_secs()),
         }
     }
 }

--- a/crates/icegate-query/tests/loki/harness.rs
+++ b/crates/icegate-query/tests/loki/harness.rs
@@ -46,6 +46,10 @@ use tokio::sync::oneshot;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 
+/// Grace period for the server task to wind down once cancelled, used both for
+/// an orderly shutdown and for draining the task after a failed startup.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Test server configuration and handles
 pub struct TestServer {
     pub client: Client,
@@ -134,11 +138,22 @@ impl TestServer {
             .unwrap();
         });
 
-        // Wait for the server to bind and receive the actual port
-        let actual_port = tokio::time::timeout(Duration::from_secs(10), port_rx)
-            .await
-            .expect("Timed out waiting for server to start")
-            .expect("Failed to receive port from server");
+        // Wait for the server to bind and receive the actual port. Drain the task on
+        // either failure: `warehouse_path` drops as this frame unwinds, so a detached
+        // server would go on running against a deleted directory.
+        let actual_port = match tokio::time::timeout(Duration::from_secs(10), port_rx).await {
+            Ok(Ok(port)) => port,
+            Ok(Err(_recv_err)) => {
+                cancel_token.cancel();
+                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, server_handle).await;
+                panic!("Failed to receive port from server");
+            }
+            Err(_elapsed) => {
+                cancel_token.cancel();
+                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, server_handle).await;
+                panic!("Timed out waiting for server to start");
+            }
+        };
 
         Ok((
             Self {
@@ -159,13 +174,18 @@ impl TestServer {
     /// pass the test (and leak the background task).
     pub async fn shutdown(mut self) {
         self.cancel_token.cancel();
-        match tokio::time::timeout(Duration::from_secs(5), &mut self.server_handle).await {
+        match tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await {
             Ok(Ok(())) => {}
             Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
             Ok(Err(join_err)) => panic!("Loki server task failed to join: {join_err}"),
             Err(_elapsed) => {
                 self.server_handle.abort();
-                panic!("Loki server did not shut down within 5s");
+                // `abort()` only schedules cancellation, so join the task before the
+                // panic unwinds and drops `temp_dir`. Bounded, because a task wedged
+                // in non-yielding code would never join at all, and a hung suite is a
+                // worse outcome than this panic.
+                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await;
+                panic!("Loki server did not shut down within {}s", SHUTDOWN_TIMEOUT.as_secs());
             }
         }
     }

--- a/crates/icegate-query/tests/tempo/harness.rs
+++ b/crates/icegate-query/tests/tempo/harness.rs
@@ -50,6 +50,10 @@ use tokio_util::sync::CancellationToken;
 const READY_ATTEMPTS: u32 = 50;
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Grace period for the server task to wind down once cancelled, used both for
+/// an orderly shutdown and for draining the task after a failed startup.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Test server running a Tempo HTTP API on an ephemeral port.
 pub struct TestServer {
     pub client: Client,
@@ -151,6 +155,11 @@ impl TestServer {
             tokio::time::sleep(READY_POLL_INTERVAL).await;
         }
         if !is_ready {
+            // Drain the server before returning: `warehouse_path` drops with this
+            // frame, so a detached task would go on serving from a directory that
+            // has been deleted under it.
+            cancel_token.cancel();
+            let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, server_handle).await;
             return Err(format!("Tempo server at {base_url} never became ready").into());
         }
 
@@ -173,13 +182,18 @@ impl TestServer {
     /// pass the test (and leak the background task).
     pub async fn shutdown(mut self) {
         self.cancel_token.cancel();
-        match tokio::time::timeout(Duration::from_secs(5), &mut self.server_handle).await {
+        match tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await {
             Ok(Ok(())) => {}
             Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
             Ok(Err(join_err)) => panic!("Tempo server task failed to join: {join_err}"),
             Err(_elapsed) => {
                 self.server_handle.abort();
-                panic!("Tempo server did not shut down within 5s");
+                // `abort()` only schedules cancellation, so join the task before the
+                // panic unwinds and drops `temp_dir`. Bounded, because a task wedged
+                // in non-yielding code would never join at all, and a hung suite is a
+                // worse outcome than this panic.
+                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await;
+                panic!("Tempo server did not shut down within {}s", SHUTDOWN_TIMEOUT.as_secs());
             }
         }
     }

--- a/crates/icegate-query/tests/tempo/harness.rs
+++ b/crates/icegate-query/tests/tempo/harness.rs
@@ -34,6 +34,7 @@ use iceberg::{
         },
     },
 };
+use icegate_common::testing::server_task::{DrainOutcome, SHUTDOWN_TIMEOUT, drain_server_task};
 use icegate_common::{
     CatalogBackend, CatalogConfig, ICEGATE_NAMESPACE, IoHandle, SPANS_TABLE, catalog::CatalogBuilder, schema,
 };
@@ -50,9 +51,8 @@ use tokio_util::sync::CancellationToken;
 const READY_ATTEMPTS: u32 = 50;
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-/// Grace period for the server task to wind down once cancelled, used both for
-/// an orderly shutdown and for draining the task after a failed startup.
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long to wait for the server to report the port it bound.
+const PORT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Test server running a Tempo HTTP API on an ephemeral port.
 pub struct TestServer {
@@ -123,7 +123,7 @@ impl TestServer {
 
         let (port_tx, port_rx) = oneshot::channel::<u16>();
 
-        let server_handle = tokio::spawn(async move {
+        let mut server_handle = tokio::spawn(async move {
             icegate_query::tempo::run_with_port_tx(
                 server_engine,
                 tempo_config,
@@ -135,10 +135,23 @@ impl TestServer {
             .unwrap();
         });
 
-        let actual_port = tokio::time::timeout(Duration::from_secs(10), port_rx)
-            .await
-            .expect("Timed out waiting for server to bind")
-            .expect("Failed to receive port from server");
+        // Drain the task on either failure before unwinding: `warehouse_path` drops
+        // with this frame, so a detached server would go on serving from a deleted
+        // directory. `drain_server_task` resumes the task's own panic when it has
+        // one, which is the only place the real startup error survives.
+        let actual_port = match tokio::time::timeout(PORT_TIMEOUT, port_rx).await {
+            Ok(Ok(port)) => port,
+            Ok(Err(_recv_err)) => {
+                cancel_token.cancel();
+                drain_server_task(&mut server_handle, "Tempo").await;
+                panic!("Tempo server dropped the port channel before reporting a bound port");
+            }
+            Err(_elapsed) => {
+                cancel_token.cancel();
+                drain_server_task(&mut server_handle, "Tempo").await;
+                panic!("Timed out waiting for Tempo server to bind");
+            }
+        };
 
         // A bound port is not a serving router, so confirm readiness before
         // handing the harness back. Failing here rather than pressing on turns a
@@ -155,11 +168,8 @@ impl TestServer {
             tokio::time::sleep(READY_POLL_INTERVAL).await;
         }
         if !is_ready {
-            // Drain the server before returning: `warehouse_path` drops with this
-            // frame, so a detached task would go on serving from a directory that
-            // has been deleted under it.
             cancel_token.cancel();
-            let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, server_handle).await;
+            drain_server_task(&mut server_handle, "Tempo").await;
             return Err(format!("Tempo server at {base_url} never became ready").into());
         }
 
@@ -182,19 +192,9 @@ impl TestServer {
     /// pass the test (and leak the background task).
     pub async fn shutdown(mut self) {
         self.cancel_token.cancel();
-        match tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await {
-            Ok(Ok(())) => {}
-            Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
-            Ok(Err(join_err)) => panic!("Tempo server task failed to join: {join_err}"),
-            Err(_elapsed) => {
-                self.server_handle.abort();
-                // `abort()` only schedules cancellation, so join the task before the
-                // panic unwinds and drops `temp_dir`. Bounded, because a task wedged
-                // in non-yielding code would never join at all, and a hung suite is a
-                // worse outcome than this panic.
-                let _ = tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut self.server_handle).await;
-                panic!("Tempo server did not shut down within {}s", SHUTDOWN_TIMEOUT.as_secs());
-            }
+        match drain_server_task(&mut self.server_handle, "Tempo").await {
+            DrainOutcome::Finished => {}
+            DrainOutcome::Aborted => panic!("Tempo server did not shut down within {}s", SHUTDOWN_TIMEOUT.as_secs()),
         }
     }
 }

--- a/crates/icegate-query/tests/tempo/harness.rs
+++ b/crates/icegate-query/tests/tempo/harness.rs
@@ -42,8 +42,13 @@ use icegate_query::{
     tempo::TempoConfig,
 };
 use reqwest::Client;
-use tokio::time::Duration;
+use tokio::{sync::oneshot, time::Duration};
 use tokio_util::sync::CancellationToken;
+
+/// Readiness poll budget for a freshly bound Tempo server. Generous because the
+/// sanitizer builds run this same harness at a fraction of normal speed.
+const READY_ATTEMPTS: u32 = 50;
+const READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Test server running a Tempo HTTP API on an ephemeral port.
 pub struct TestServer {
@@ -51,6 +56,10 @@ pub struct TestServer {
     pub base_url: String,
     pub cancel_token: CancellationToken,
     server_handle: tokio::task::JoinHandle<()>,
+    /// Owns the temporary warehouse directory; held purely for its
+    /// `Drop`, which removes the directory when the server is dropped.
+    #[allow(dead_code)]
+    temp_dir: tempfile::TempDir,
 }
 
 impl TestServer {
@@ -68,17 +77,14 @@ impl TestServer {
             cache: None,
         };
 
-        // Pick a random-but-free ephemeral port. We bind via TempoConfig
-        // on 0.0.0.0:0 effectively by using the OS assigned port. TempoConfig
-        // has no port_tx plumbing, so instead we probe a free port first.
-        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
-        let actual_port = probe.local_addr()?.port();
-        drop(probe);
-
+        // Port 0: the OS assigns a free port and the server reports it back over
+        // `port_tx`. Probing for a port here and handing the number to the server
+        // instead would reopen a race — the probe listener has to close before the
+        // server can bind, and anything on the host can take the port in between.
         let tempo_config = TempoConfig {
             enabled: true,
             host: "127.0.0.1".to_string(),
-            port: actual_port,
+            port: 0,
         };
 
         let catalog = CatalogBuilder::from_config(&catalog_config, &IoHandle::noop(), CancellationToken::new()).await?;
@@ -111,28 +117,42 @@ impl TestServer {
         let cancel_token_clone = cancel_token.clone();
         let server_engine = Arc::clone(&query_engine);
 
+        let (port_tx, port_rx) = oneshot::channel::<u16>();
+
         let server_handle = tokio::spawn(async move {
-            icegate_query::tempo::run(
+            icegate_query::tempo::run_with_port_tx(
                 server_engine,
                 tempo_config,
                 cancel_token_clone,
+                Some(port_tx),
                 icegate_common::MemoryPressure::inert(),
             )
             .await
             .unwrap();
         });
 
-        // Wait for the server to be reachable.
+        let actual_port = tokio::time::timeout(Duration::from_secs(10), port_rx)
+            .await
+            .expect("Timed out waiting for server to bind")
+            .expect("Failed to receive port from server");
+
+        // A bound port is not a serving router, so confirm readiness before
+        // handing the harness back. Failing here rather than pressing on turns a
+        // dead server into a clear message instead of an opaque connection error
+        // from whichever request the test happens to send first.
         let client = Client::new();
         let base_url = format!("http://127.0.0.1:{actual_port}");
-        for _ in 0..50 {
+        let mut is_ready = false;
+        for _ in 0..READY_ATTEMPTS {
             if client.get(format!("{base_url}/ready")).send().await.is_ok() {
+                is_ready = true;
                 break;
             }
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            tokio::time::sleep(READY_POLL_INTERVAL).await;
         }
-
-        Box::leak(Box::new(warehouse_path));
+        if !is_ready {
+            return Err(format!("Tempo server at {base_url} never became ready").into());
+        }
 
         Ok((
             Self {
@@ -140,15 +160,28 @@ impl TestServer {
                 base_url,
                 cancel_token,
                 server_handle,
+                temp_dir: warehouse_path,
             },
             catalog,
         ))
     }
 
-    /// Shut the server down and wait briefly for the task to exit.
-    pub async fn shutdown(self) {
+    /// Shut the server down, draining the spawn task.
+    ///
+    /// Surfaces a panic from the server task and fails on timeout rather
+    /// than swallowing both, so a crashing or hung server can't silently
+    /// pass the test (and leak the background task).
+    pub async fn shutdown(mut self) {
         self.cancel_token.cancel();
-        let _ = tokio::time::timeout(Duration::from_secs(5), self.server_handle).await;
+        match tokio::time::timeout(Duration::from_secs(5), &mut self.server_handle).await {
+            Ok(Ok(())) => {}
+            Ok(Err(join_err)) if join_err.is_panic() => std::panic::resume_unwind(join_err.into_panic()),
+            Ok(Err(join_err)) => panic!("Tempo server task failed to join: {join_err}"),
+            Err(_elapsed) => {
+                self.server_handle.abort();
+                panic!("Tempo server did not shut down within 5s");
+            }
+        }
     }
 }
 

--- a/crates/icegate-queue/Cargo.toml
+++ b/crates/icegate-queue/Cargo.toml
@@ -2,6 +2,7 @@
 name = "icegate-queue"
 description = "Generic WAL-based data queue with Parquet on object storage"
 version.workspace = true
+rust-version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -267,5 +267,5 @@ and how the suppression files are maintained: [config/sanitizers/README.md](../c
   `--features`, so anything behind a feature gate is skipped silently — that code still
   needs the tests required above.
 - A leak or memory error in first-party code is a defect to fix, not to suppress. A
-  suppression matching a frame inside `icegate_*` MUST carry measured figures and a
-  retirement condition, as the existing exceptions in `config/sanitizers/lsan.supp` do.
+  suppression matching a frame inside `icegate_*` MUST carry measured figures from a full
+  run on the current tree and a retirement condition.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -266,6 +266,8 @@ and how the suppression files are maintained: [config/sanitizers/README.md](../c
 - A sanitizer run MUST NOT be counted as coverage for feature-gated code. It builds with no
   `--features`, so anything behind a feature gate is skipped silently — that code still
   needs the tests required above.
-- A leak or memory error in first-party code is a defect to fix, not to suppress. A
-  suppression matching a frame inside `icegate_*` MUST carry measured figures from a full
-  run on the current tree and a retirement condition.
+- A leak or memory error in first-party code is a defect to fix, not to suppress. In
+  `lsan.supp`, a suppression matching a frame inside `icegate_*` MUST carry measured figures
+  from a full run on the current tree and a retirement condition. `asan.supp` has no such
+  allowance: an ASan report is a memory error rather than a retained allocation, so a
+  first-party entry there MUST NOT be added at all.

--- a/scripts/sanitize.sh
+++ b/scripts/sanitize.sh
@@ -165,7 +165,37 @@ case "$SANITIZER" in
         # No -Zbuild-std: standalone LSan intercepts malloc at runtime rather
         # than instrumenting code, so an uninstrumented std costs it nothing.
         # That keeps the leak pass the cheap one.
-        export LSAN_OPTIONS="suppressions=$REPO_ROOT/config/sanitizers/lsan.supp"
+        #
+        # fast_unwind_on_malloc=0 is what makes the suppression file work at all.
+        # LSan defaults it to 1, which records each allocation stack by walking
+        # the frame-pointer chain; nothing here forces frame pointers, so the
+        # walk skips every frame between the allocator and whichever ancestor
+        # happened to keep one. The 2026-08-14 nightly captured 3 to 8 return
+        # addresses per allocation against a malloc_context_size of 30 — not
+        # truncation, an aborted unwind — and every stack jumped straight from
+        # `alloc::alloc::alloc` into libtest's run_test_in_process. Third-party
+        # frames were absent workspace-wide, so four of lsan.supp's five patterns
+        # could not match: only *apache_avro* fired, because it is the one anchor
+        # that sits on the leaf frame. All 13 binaries failed on leaks the file
+        # already accounts for.
+        #
+        # This is why a local run disagrees: aarch64 keeps a frame-pointer chain
+        # by ABI, so the fast unwinder walks it correctly and the same
+        # suppressions match. Every figure in lsan.supp measured under the local
+        # wrapper was measured on that shape, not on CI's. Do not treat a green
+        # aarch64 run as evidence about x86_64.
+        #
+        # 0 selects the CFI unwinder instead, which reconstructs the full chain
+        # from the unwind tables rustc always emits. It is slower per allocation;
+        # the budget is the 300-minute job timeout, against 11.5 minutes for the
+        # whole leak job before this change.
+        #
+        # -Cforce-frame-pointers=yes would instead repair the fast unwinder, and
+        # is the lever to reach for if that budget is ever a problem. It is not
+        # used here because it is only a partial fix: without -Zbuild-std the
+        # precompiled std is not rebuilt, so any frame passing through std still
+        # breaks the chain.
+        export LSAN_OPTIONS="suppressions=$REPO_ROOT/config/sanitizers/lsan.supp:fast_unwind_on_malloc=0"
         ;;
     memory)
         # This target does not currently work, and is retained only so the


### PR DESCRIPTION
- Ensure proper cleanup with `TempDir::drop`, avoiding disk and memory leaks.
- Update `build_state` to return guards for temporary directories.
- Improve `shutdown` methods for async tasks with timeout handling and panic propagation.
- Simplify LSan suppressions post-harness fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved leak-sanitizer accuracy with more reliable stack unwinding and updated suppression rules.
  - Preserved expected retry behavior for simulated storage failures.

- **Testing & Reliability**
  - Test servers now clean up temporary data automatically.
  - Improved startup and shutdown error handling.
  - Enabled reliable testing with dynamically assigned ports and startup port reporting.

- **Documentation**
  - Clarified sanitizer suppression policies and retirement requirements.
  - Updated the minimum supported Rust version to 1.95.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->