### PR TITLE
(fix) Tempo v2 trace-by-ID returns the TraceByIDResponse envelope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Running rules:
   `cargo test <name>` for the code you touched.
 - Format only the affected crate: `cargo +nightly fmt -p <crate>` (plain `cargo fmt` ignores `rustfmt.toml`).
 
-### Docs
+## Docs
 
 - **A convention is only what is documented** in these three files. The mere presence of a pattern
   in the code is **NOT** a convention — someone may have committed junk. Do not justify a decision
@@ -35,6 +35,22 @@ Running rules:
 - `docs/` holds only cross-cutting policy ([tests.md](docs/tests.md)).
   Never add a `docs/<module>.md` — a deep-dive for a subsystem goes in a README beside its code.
 - Design notes, specs, and plans are working artifacts: keep them in `.tmp/`, not in `docs/`.
+
+### Third-party systems in code and docs
+
+- **A third-party name is an identifier, not a claim.** Free wherever it names or
+  carries an external system: code that talks to it, config that points at it, a
+  wire protocol we implement, data that came from it.
+- **A claim about someone else's behaviour must be pinned by our test.** "Client X
+  falls back to v1 on 404" is allowed only where a test of ours fails if it stops
+  being true — cite that test. Unpinned lore ("X usually does Y", "X is expected to")
+  is banned: nothing catches it going stale.
+- **Never compare.** No "faster than X", "unlike X", "X cannot do Y", no claim about
+  another product's quality, market position, or roadmap. Drop the comparison; the
+  name itself may stay where it identifies the system. Comparative material lives in
+  the marketing repo, not here.
+- The trademark position for the names used in this repo is stated once in
+  [README.md](README.md#trademarks) — do not restate it per file.
 
 ## Crates and where code goes
 

--- a/crates/icegate-query/src/tempo/formatters.rs
+++ b/crates/icegate-query/src/tempo/formatters.rs
@@ -1,12 +1,14 @@
 //! `RecordBatch` → Tempo response formatters.
 //!
-//! Three responsibilities:
+//! Responsibilities:
 //! - [`spans_to_otlp_json`] — convert a list of span batches into the
 //!   OTLP `resourceSpans[].scopeSpans[].spans[]` JSON shape (used for
 //!   `GET /api/traces/{traceID}` with `Accept: application/json`).
 //! - [`spans_to_otlp_proto`] — same rows, encoded as the OTLP `TracesData`
-//!   protobuf message. This is what Grafana's Tempo data source expects by
-//!   default (`Accept: application/protobuf`).
+//!   protobuf message, the body served under `Accept: application/protobuf`.
+//! - [`encode_trace_response_v2_proto`] / [`build_trace_response_v2_json`] —
+//!   the same payload wrapped in the `TraceByIDResponse` envelope that
+//!   `GET /api/v2/traces/{traceID}` returns.
 //! - [`spansets_to_search_response`] — convert a planner output into
 //!   the Tempo search JSON shape (`{traces, metrics}`).
 
@@ -607,20 +609,21 @@ fn build_matched_span(
 }
 
 // =========================================================================
-// OTLP protobuf formatter (Grafana's default Content-Type)
+// OTLP protobuf formatter (`Accept: application/protobuf`)
 // =========================================================================
 
 /// Convert spans into OTLP `TracesData` protobuf bytes.
 ///
-/// Grafana's Tempo data source expects protobuf by default; returning JSON
-/// makes it fail with `proto: illegal wireType 6`. This encoder groups spans
+/// This is the whole body of `GET /api/traces/{traceID}` under
+/// `Accept: application/protobuf`; serving the JSON rendering there instead
+/// yields bytes no protobuf decoder can read. The encoder groups spans
 /// by `service_name` (our proxy for a resource) and by instrumentation scope
 /// (just "icegate" since the spans schema doesn't preserve scope metadata),
 /// matching what the JSON formatter emits structurally.
 ///
 /// Trace and span IDs are hex-decoded back to raw bytes for the proto
-/// `bytes` fields; invalid hex collapses to empty bytes (proto will then
-/// carry zero-length IDs, matching how Grafana renders orphaned rows).
+/// `bytes` fields; invalid hex collapses to empty bytes, so such a span
+/// carries zero-length IDs rather than failing the whole response.
 ///
 /// # Errors
 ///
@@ -629,6 +632,92 @@ fn build_matched_span(
 pub fn spans_to_otlp_proto(batches: &[RecordBatch]) -> crate::error::Result<Vec<u8>> {
     let data = spans_to_traces_data(batches)?;
     Ok(data.encode_to_vec())
+}
+
+// =========================================================================
+// Tempo v2 trace-by-id envelope (`TraceByIDResponse`)
+// =========================================================================
+
+/// `PartialStatus::PARTIAL`; `COMPLETE` is 0 and stays unencoded (proto3
+/// omits default-valued scalars).
+const V2_STATUS_PARTIAL: i32 = 1;
+
+/// Explanation carried by the `message` field of a partially returned trace.
+const V2_PARTIAL_MESSAGE: &str = "trace exceeded the server-side span cap and was truncated";
+
+/// Wire form of Tempo's `TraceByIDResponse` — the body of
+/// `GET /api/v2/traces/{traceID}`.
+///
+/// `trace` is `tempopb.Trace`, whose only field is
+/// `repeated ResourceSpans resourceSpans = 1`; that layout is byte-identical
+/// to an OTLP [`TracesData`], so the v1 payload type is reused here rather
+/// than restated. Field 2 (`metrics`, inspected-bytes counters) is not
+/// modelled: we have nothing to report there and proto3 leaves an unset
+/// message absent.
+#[derive(prost::Message)]
+struct TraceByIdResponse {
+    /// The trace payload. Always `Some` on the response path — an empty
+    /// trace is answered with 404 by the handler, never with an empty
+    /// envelope.
+    #[prost(message, optional, tag = "1")]
+    trace: Option<TracesData>,
+    /// `PartialStatus`: 0 (`COMPLETE`) or [`V2_STATUS_PARTIAL`].
+    #[prost(int32, tag = "3")]
+    status: i32,
+    /// Human-readable detail for a partial trace; empty when complete.
+    #[prost(string, tag = "4")]
+    message: String,
+}
+
+/// Encode spans as a Tempo `TraceByIDResponse` protobuf message.
+///
+/// `GET /api/v2/traces/{traceID}` returns this envelope; the bare OTLP
+/// payload of [`spans_to_otlp_proto`] is the v1 body and is not a valid
+/// `TraceByIDResponse`, so the two route versions are not interchangeable
+/// (test `v2_envelope_embeds_trace_as_field_one`).
+///
+/// `truncated` maps to `status = PARTIAL` plus a `message`; a complete trace
+/// leaves both unset, since proto3 does not encode default-valued fields.
+///
+/// # Errors
+///
+/// Returns [`crate::error::QueryError::Internal`] if a column has an
+/// unexpected type.
+pub fn encode_trace_response_v2_proto(batches: &[RecordBatch], truncated: bool) -> crate::error::Result<Vec<u8>> {
+    // Encoding the whole envelope in one pass writes the trace straight into
+    // the output buffer; encoding the trace on its own first would cost a
+    // second buffer and a full copy of a trace up to `MAX_TRACE_SPANS` spans.
+    let mut response = TraceByIdResponse {
+        trace: Some(spans_to_traces_data(batches)?),
+        ..Default::default()
+    };
+    if truncated {
+        response.status = V2_STATUS_PARTIAL;
+        response.message = V2_PARTIAL_MESSAGE.to_string();
+    }
+    Ok(response.encode_to_vec())
+}
+
+/// Build the JSON rendering of the same `TraceByIDResponse` envelope.
+///
+/// Serves `Accept: application/json` callers of the v2 route. Enum values
+/// follow protobuf JSON mapping and are emitted as their names.
+///
+/// # Errors
+///
+/// Returns [`crate::error::QueryError::Internal`] if a column has an
+/// unexpected type.
+pub fn build_trace_response_v2_json(batches: &[RecordBatch], truncated: bool) -> crate::error::Result<Value> {
+    let trace = spans_to_otlp_json(batches)?;
+    let mut response = Map::new();
+    response.insert("trace".to_string(), trace);
+    if truncated {
+        response.insert("status".to_string(), json!("PARTIAL"));
+        response.insert("message".to_string(), json!(V2_PARTIAL_MESSAGE));
+    } else {
+        response.insert("status".to_string(), json!("COMPLETE"));
+    }
+    Ok(Value::Object(response))
 }
 
 /// Group accumulator for proto `ResourceSpans` construction.
@@ -1482,6 +1571,84 @@ mod proto_tests {
 
         assert_eq!(span["droppedEventsCount"], 2);
         assert_eq!(span["droppedLinksCount"], 3);
+    }
+
+    /// The v2 body is a `TraceByIDResponse`, so a decoder following that
+    /// contract reads field 1 as an embedded message; a bare `TracesData`
+    /// there would be read as garbage. The envelope must carry the v1
+    /// payload verbatim as embedded field 1, and nothing else when the
+    /// trace is complete.
+    #[test]
+    fn v2_envelope_embeds_trace_as_field_one() {
+        let batches = vec![single_span_batch()];
+        let envelope = encode_trace_response_v2_proto(&batches, false).expect("v2 encode");
+        let bare = spans_to_otlp_proto(&batches).expect("proto encode");
+
+        let mut buf = envelope.as_slice();
+        let (tag, wire_type) = prost::encoding::decode_key(&mut buf).expect("envelope key");
+        assert_eq!(tag, 1, "trace must be field 1");
+        assert_eq!(wire_type, prost::encoding::WireType::LengthDelimited);
+        let len = prost::encoding::decode_varint(&mut buf).expect("trace length");
+        assert_eq!(len, u64::try_from(bare.len()).expect("length fits u64"));
+        assert_eq!(buf, bare.as_slice(), "embedded payload must equal the v1 body");
+        assert!(
+            TracesData::decode(buf).expect("embedded trace decode").resource_spans.len() == 1,
+            "tempopb.Trace and TracesData share the resourceSpans = 1 layout"
+        );
+    }
+
+    /// A truncated trace must additionally carry `status = PARTIAL` and the
+    /// message explaining the cap, so a consumer can tell a partial trace
+    /// from a complete one without counting spans.
+    #[test]
+    fn v2_envelope_marks_truncated_trace_partial() {
+        let batches = vec![single_span_batch()];
+        let envelope = encode_trace_response_v2_proto(&batches, true).expect("v2 encode");
+        let bare = spans_to_otlp_proto(&batches).expect("proto encode");
+
+        // Skip the embedded trace: key, length, payload.
+        let mut buf = envelope.as_slice();
+        let _ = prost::encoding::decode_key(&mut buf).expect("envelope key");
+        let _ = prost::encoding::decode_varint(&mut buf).expect("trace length");
+        buf = &buf[bare.len()..];
+
+        let (status_tag, status_wire) = prost::encoding::decode_key(&mut buf).expect("status key");
+        assert_eq!(status_tag, 3, "status must be field 3");
+        assert_eq!(status_wire, prost::encoding::WireType::Varint);
+        assert_eq!(
+            prost::encoding::decode_varint(&mut buf).expect("status value"),
+            1,
+            "PARTIAL is 1"
+        );
+
+        let (message_tag, message_wire) = prost::encoding::decode_key(&mut buf).expect("message key");
+        assert_eq!(message_tag, 4, "message must be field 4");
+        assert_eq!(message_wire, prost::encoding::WireType::LengthDelimited);
+        let message_len = prost::encoding::decode_varint(&mut buf).expect("message length");
+        assert_eq!(
+            message_len,
+            u64::try_from(V2_PARTIAL_MESSAGE.len()).expect("length fits u64")
+        );
+        assert_eq!(buf, V2_PARTIAL_MESSAGE.as_bytes());
+    }
+
+    /// The JSON rendering of the v2 route mirrors the protobuf envelope:
+    /// the OTLP payload nests under `trace`, with the status alongside it.
+    #[test]
+    fn v2_json_envelope_nests_trace_and_status() {
+        let batches = vec![single_span_batch()];
+
+        let complete = build_trace_response_v2_json(&batches, false).expect("v2 json");
+        assert_eq!(complete["status"], "COMPLETE");
+        assert!(complete.get("message").is_none(), "complete traces carry no message");
+        assert_eq!(
+            complete["trace"]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["name"],
+            "GET /api"
+        );
+
+        let partial = build_trace_response_v2_json(&batches, true).expect("v2 json");
+        assert_eq!(partial["status"], "PARTIAL");
+        assert_eq!(partial["message"], V2_PARTIAL_MESSAGE);
     }
 }
 

--- a/crates/icegate-query/src/tempo/handlers.rs
+++ b/crates/icegate-query/src/tempo/handlers.rs
@@ -19,14 +19,16 @@ use serde_json::json;
 use super::{
     error::{TempoError, TempoResult},
     executor,
-    formatters::{spans_to_otlp_json, spans_to_otlp_proto},
+    formatters::{
+        build_trace_response_v2_json, encode_trace_response_v2_proto, spans_to_otlp_json, spans_to_otlp_proto,
+    },
     metadata,
     models::{
         Scope, SearchParams, TagValuesQueryParams, TagValuesResponse, TagValuesV2Metrics, TagValuesV2Response,
         TagsQueryParams, TagsV1Response, TagsV2Response, TraceLookupParams,
     },
     server::TempoState,
-    trace_by_id::{default_window, fetch},
+    trace_by_id::{FetchResult, default_window, fetch},
     validation,
 };
 use crate::{error::QueryError, traceql::iceberg_predicate::translate_query_to_predicate_excluding};
@@ -125,10 +127,11 @@ fn wants_protobuf(headers: &HeaderMap) -> bool {
 // Trace-by-ID
 // ============================================================================
 
-/// Handle `GET /api/traces/{trace_id}` (and the `/api/v2/...` alias).
+/// Handle `GET /api/traces/{trace_id}` — the v1 trace lookup.
 ///
-/// Returns the matching spans encoded as OTLP `resourceSpans` JSON, or 404
-/// when no spans match the trace ID under the requesting tenant.
+/// Returns the matching spans as a bare OTLP payload (`TracesData` protobuf
+/// or its JSON rendering), or 404 when no spans match the trace ID under the
+/// requesting tenant.
 ///
 /// # Errors
 ///
@@ -141,41 +144,100 @@ pub async fn get_trace(
     Path(trace_id): Path<String>,
     Query(params): Query<TraceLookupParams>,
 ) -> TempoResult<Response> {
-    let tenant_id = extract_tenant_id(&headers);
+    let Some(result) = fetch_requested_trace(state, &headers, &trace_id, &params).await? else {
+        return Ok(build_trace_not_found_response());
+    };
+
+    let mut resp = if wants_protobuf(&headers) {
+        build_proto_response(spans_to_otlp_proto(&result.batches)?)
+    } else {
+        (StatusCode::OK, Json(spans_to_otlp_json(&result.batches)?)).into_response()
+    };
+    set_truncated_header(&mut resp, result.truncated);
+    Ok(resp)
+}
+
+/// Handle `GET /api/v2/traces/{trace_id}` — the v2 trace lookup.
+///
+/// Same data as [`get_trace`], wrapped in the `TraceByIDResponse` envelope.
+/// The envelope is not cosmetic: it is the v2 body contract, and a v1 body
+/// served here is not decodable as one (test
+/// `v2_wraps_trace_in_trace_by_id_response`).
+///
+/// Truncation is reported twice over: as `status = PARTIAL` inside the
+/// envelope and as the `x-icegate-truncated` header the v1 route also sets.
+///
+/// # Errors
+///
+/// Returns a [`super::error::TempoError`] (rendered as JSON) if the engine
+/// session cannot be created, the planner fails, or execution errors out.
+#[tracing::instrument(skip_all, fields(tenant_id, trace_id = %trace_id))]
+pub async fn get_trace_v2(
+    State(state): State<TempoState>,
+    headers: HeaderMap,
+    Path(trace_id): Path<String>,
+    Query(params): Query<TraceLookupParams>,
+) -> TempoResult<Response> {
+    let Some(result) = fetch_requested_trace(state, &headers, &trace_id, &params).await? else {
+        return Ok(build_trace_not_found_response());
+    };
+
+    let mut resp = if wants_protobuf(&headers) {
+        build_proto_response(encode_trace_response_v2_proto(&result.batches, result.truncated)?)
+    } else {
+        let body = build_trace_response_v2_json(&result.batches, result.truncated)?;
+        (StatusCode::OK, Json(body)).into_response()
+    };
+    set_truncated_header(&mut resp, result.truncated);
+    Ok(resp)
+}
+
+/// Resolve a trace-lookup request into the spans it matched.
+///
+/// Shared by both API versions: extracts the tenant, resolves the time
+/// window (falling back to [`default_window`]), validates the inputs, and
+/// runs the fetch. Returns `None` when the trace has no spans under the
+/// requesting tenant, which each caller renders as 404.
+async fn fetch_requested_trace(
+    state: TempoState,
+    headers: &HeaderMap,
+    trace_id: &str,
+    params: &TraceLookupParams,
+) -> TempoResult<Option<FetchResult>> {
+    let tenant_id = extract_tenant_id(headers);
     tracing::Span::current().record("tenant_id", tenant_id.as_str());
 
     let now = Utc::now();
     let (default_start, default_end) = default_window(now);
     let start = params.start.map(parse_epoch_seconds).transpose()?.unwrap_or(default_start);
     let end = params.end.map(parse_epoch_seconds).transpose()?.unwrap_or(default_end);
-    validation::validate_trace_id(&trace_id).map_err(TempoError::new)?;
+    validation::validate_trace_id(trace_id).map_err(TempoError::new)?;
     validation::validate_query_window(start, end).map_err(TempoError::new)?;
 
-    let result = fetch(state.engine, &tenant_id, &trace_id, start, end).await?;
-    if result.batches.iter().all(|b| b.num_rows() == 0) {
-        return Ok((StatusCode::NOT_FOUND, Json(json!({"error": "trace not found"}))).into_response());
-    }
+    let result = fetch(state.engine, &tenant_id, trace_id, start, end).await?;
+    let is_empty = result.batches.iter().all(|b| b.num_rows() == 0);
+    Ok((!is_empty).then_some(result))
+}
 
-    // Surface truncation to the caller via response header — the body
-    // payload itself stays valid OTLP so existing decoders keep working.
-    let truncated_header_value = axum::http::HeaderValue::from_static("true");
-    let truncated_pair = result.truncated.then_some(("x-icegate-truncated", truncated_header_value));
+/// Render protobuf bytes with the OTLP protobuf content type.
+fn build_proto_response(bytes: Vec<u8>) -> Response {
+    let content_type = axum::http::HeaderValue::from_static("application/protobuf");
+    ([(header::CONTENT_TYPE, content_type)], bytes).into_response()
+}
 
-    if wants_protobuf(&headers) {
-        let bytes = spans_to_otlp_proto(&result.batches)?;
-        let content_type = axum::http::HeaderValue::from_static("application/protobuf");
-        let mut resp = ([(header::CONTENT_TYPE, content_type)], bytes).into_response();
-        if let Some((name, value)) = truncated_pair {
-            resp.headers_mut().insert(name, value);
-        }
-        Ok(resp)
-    } else {
-        let body = spans_to_otlp_json(&result.batches)?;
-        let mut resp = (StatusCode::OK, Json(body)).into_response();
-        if let Some((name, value)) = truncated_pair {
-            resp.headers_mut().insert(name, value);
-        }
-        Ok(resp)
+/// Build the 404 body both trace-lookup routes return for an unknown trace.
+fn build_trace_not_found_response() -> Response {
+    (StatusCode::NOT_FOUND, Json(json!({"error": "trace not found"}))).into_response()
+}
+
+/// Flag a partial trace on the response.
+///
+/// The body payload itself stays a valid, decodable trace, so consumers that
+/// ignore the header keep working — they just see fewer spans.
+fn set_truncated_header(resp: &mut Response, truncated: bool) {
+    if truncated {
+        resp.headers_mut()
+            .insert("x-icegate-truncated", axum::http::HeaderValue::from_static("true"));
     }
 }
 
@@ -183,7 +245,7 @@ pub async fn get_trace(
 // TraceQL search
 // ============================================================================
 
-/// Handle `GET`/`POST /api/search` (and the `/api/v2/...` alias).
+/// Handle `GET`/`POST /api/search`.
 ///
 /// Parses the `TraceQL` query in `params.q`, plans it, executes against
 /// the spans table, and returns a Tempo `SearchResponse`.

--- a/crates/icegate-query/src/tempo/routes.rs
+++ b/crates/icegate-query/src/tempo/routes.rs
@@ -23,8 +23,8 @@ use super::{
 /// Build the Tempo HTTP router.
 ///
 /// Endpoint mapping:
-/// - `GET  /api/traces/{trace_id}`          — trace lookup by id.
-/// - `GET  /api/v2/traces/{trace_id}`       — v2 alias of trace lookup.
+/// - `GET  /api/traces/{trace_id}`          — trace lookup by id (bare OTLP).
+/// - `GET  /api/v2/traces/{trace_id}`       — same lookup in the `TraceByIDResponse` envelope.
 /// - `GET  / POST /api/search`              — `TraceQL` search.
 /// - `GET  /api/search/tags`                — v1 flat tag list.
 /// - `GET  /api/v2/search/tags`             — v2 scoped tag list (Grafana).
@@ -50,7 +50,7 @@ use super::{
 pub fn routes(state: TempoState, pressure: MemoryPressure) -> Router {
     Router::new()
         .route("/api/traces/{trace_id}", get(handlers::get_trace))
-        .route("/api/v2/traces/{trace_id}", get(handlers::get_trace))
+        .route("/api/v2/traces/{trace_id}", get(handlers::get_trace_v2))
         .route(
             "/api/search",
             get(handlers::search_traces).post(handlers::search_traces),

--- a/crates/icegate-query/tests/tempo/mod.rs
+++ b/crates/icegate-query/tests/tempo/mod.rs
@@ -3,3 +3,4 @@
 mod echo;
 mod harness;
 mod tags;
+mod trace_by_id;

--- a/crates/icegate-query/tests/tempo/trace_by_id.rs
+++ b/crates/icegate-query/tests/tempo/trace_by_id.rs
@@ -1,0 +1,184 @@
+//! Tests for the Tempo trace-lookup endpoints: `/api/traces/{traceID}`
+//! returns a bare OTLP payload, `/api/v2/traces/{traceID}` returns the same
+//! payload inside the `TraceByIDResponse` envelope. The two body shapes are
+//! not interchangeable — a decoder following one contract cannot read the
+//! other — so each route is pinned to its own shape here.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use icegate_common::{ICEGATE_NAMESPACE, SPANS_TABLE};
+use opentelemetry_proto::tonic::trace::v1::TracesData;
+use prost::Message;
+use serde_json::Value;
+
+use super::harness::{TestServer, write_test_spans};
+
+/// `trace_id` of the root span written by [`write_test_spans`].
+const FIXTURE_TRACE_ID: &str = "0102030405060708090a0b0c0d0e0f10";
+
+/// Unwrap a `TraceByIDResponse` body into the trace it embeds.
+///
+/// Walks the wire form by hand — envelope key, length, payload — instead of
+/// decoding the body as a `TracesData`, so a v2 route that regressed to the
+/// bare v1 payload fails here rather than silently decoding. Only valid for a
+/// complete trace: the length check assumes nothing follows the trace field,
+/// which is what `status`/`message` would add for a truncated one.
+fn decode_envelope_trace(body: &[u8]) -> TracesData {
+    let mut buf = body;
+    let (tag, wire_type) = prost::encoding::decode_key(&mut buf).expect("envelope key");
+    assert_eq!(tag, 1, "TraceByIDResponse.trace is field 1");
+    assert_eq!(wire_type, prost::encoding::WireType::LengthDelimited);
+    let len = prost::encoding::decode_varint(&mut buf).expect("trace length");
+    assert_eq!(len, u64::try_from(buf.len()).expect("length fits u64"));
+    TracesData::decode(buf).expect("embedded trace is a TracesData")
+}
+
+#[tokio::test]
+async fn v1_returns_bare_otlp_traces_data() -> Result<(), Box<dyn std::error::Error>> {
+    let (server, catalog) = TestServer::start().await?;
+    let table = catalog
+        .load_table(&iceberg::TableIdent::from_strs([ICEGATE_NAMESPACE, SPANS_TABLE])?)
+        .await?;
+    write_test_spans(&table, &catalog, "tempo-tenant").await?;
+
+    let resp = server
+        .client
+        .get(format!("{}/api/traces/{FIXTURE_TRACE_ID}", server.base_url))
+        .header("X-Scope-OrgID", "tempo-tenant")
+        .header("Accept", "application/protobuf")
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 200);
+    let body = resp.bytes().await?;
+
+    let traces = TracesData::decode(body).expect("v1 body is a TracesData");
+    let spans = &traces.resource_spans[0].scope_spans[0].spans;
+    assert_eq!(spans.len(), 1, "only the root span carries this trace id");
+    assert_eq!(spans[0].name, "GET /api/health");
+
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn v2_wraps_trace_in_trace_by_id_response() -> Result<(), Box<dyn std::error::Error>> {
+    let (server, catalog) = TestServer::start().await?;
+    let table = catalog
+        .load_table(&iceberg::TableIdent::from_strs([ICEGATE_NAMESPACE, SPANS_TABLE])?)
+        .await?;
+    write_test_spans(&table, &catalog, "tempo-tenant").await?;
+
+    let resp = server
+        .client
+        .get(format!("{}/api/v2/traces/{FIXTURE_TRACE_ID}", server.base_url))
+        .header("X-Scope-OrgID", "tempo-tenant")
+        .header("Accept", "application/protobuf")
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 200);
+    let body = resp.bytes().await?;
+
+    let traces = decode_envelope_trace(&body);
+    let spans = &traces.resource_spans[0].scope_spans[0].spans;
+    assert_eq!(spans.len(), 1);
+    assert_eq!(spans[0].name, "GET /api/health");
+
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn v2_json_nests_trace_under_envelope() -> Result<(), Box<dyn std::error::Error>> {
+    let (server, catalog) = TestServer::start().await?;
+    let table = catalog
+        .load_table(&iceberg::TableIdent::from_strs([ICEGATE_NAMESPACE, SPANS_TABLE])?)
+        .await?;
+    write_test_spans(&table, &catalog, "tempo-tenant").await?;
+
+    let resp = server
+        .client
+        .get(format!("{}/api/v2/traces/{FIXTURE_TRACE_ID}", server.base_url))
+        .header("X-Scope-OrgID", "tempo-tenant")
+        .header("Accept", "application/json")
+        .send()
+        .await?;
+    let status = resp.status();
+    let body: Value = resp.json().await?;
+    assert_eq!(status, 200, "Response body: {body}");
+
+    assert_eq!(body["status"], "COMPLETE");
+    assert_eq!(
+        body["trace"]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["name"],
+        "GET /api/health"
+    );
+
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn v2_returns_404_for_unknown_trace() -> Result<(), Box<dyn std::error::Error>> {
+    let (server, catalog) = TestServer::start().await?;
+    let table = catalog
+        .load_table(&iceberg::TableIdent::from_strs([ICEGATE_NAMESPACE, SPANS_TABLE])?)
+        .await?;
+    write_test_spans(&table, &catalog, "tempo-tenant").await?;
+
+    // An unknown trace is a 404, not a 200 carrying an empty envelope: the
+    // status code is the only signal a caller has before decoding the body.
+    let resp = server
+        .client
+        .get(format!(
+            "{}/api/v2/traces/ffffffffffffffffffffffffffffffff",
+            server.base_url
+        ))
+        .header("X-Scope-OrgID", "tempo-tenant")
+        .header("Accept", "application/protobuf")
+        .send()
+        .await?;
+    assert_eq!(resp.status(), 404);
+
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn v2_isolates_trace_lookup_by_tenant() -> Result<(), Box<dyn std::error::Error>> {
+    let (server, catalog) = TestServer::start().await?;
+    let table_ident = iceberg::TableIdent::from_strs([ICEGATE_NAMESPACE, SPANS_TABLE])?;
+    // The same trace id lives under both tenants, so a lookup that stopped
+    // filtering by tenant would return two root spans instead of one below,
+    // and 200 instead of 404 for a tenant that wrote nothing.
+    write_test_spans(&catalog.load_table(&table_ident).await?, &catalog, "tempo-tenant").await?;
+    // Reload between writes: the first commit advanced the table's snapshot,
+    // and the append is planned against the metadata it was handed.
+    write_test_spans(&catalog.load_table(&table_ident).await?, &catalog, "other-tenant").await?;
+
+    let owner = server
+        .client
+        .get(format!("{}/api/v2/traces/{FIXTURE_TRACE_ID}", server.base_url))
+        .header("X-Scope-OrgID", "tempo-tenant")
+        .header("Accept", "application/protobuf")
+        .send()
+        .await?;
+    assert_eq!(owner.status(), 200);
+    let traces = decode_envelope_trace(&owner.bytes().await?);
+    let span_count: usize = traces
+        .resource_spans
+        .iter()
+        .flat_map(|rs| rs.scope_spans.iter())
+        .map(|ss| ss.spans.len())
+        .sum();
+    assert_eq!(span_count, 1, "only the requesting tenant's root span");
+
+    let stranger = server
+        .client
+        .get(format!("{}/api/v2/traces/{FIXTURE_TRACE_ID}", server.base_url))
+        .header("X-Scope-OrgID", "third-tenant")
+        .header("Accept", "application/protobuf")
+        .send()
+        .await?;
+    assert_eq!(stranger.status(), 404, "a trace of another tenant must not be readable");
+
+    server.shutdown().await;
+    Ok(())
+}


### PR DESCRIPTION
/api/v2/traces/{id} aliased the v1 handler and returned bare OTLP, so a client decoding the v2 contract got a body it could not parse.
Split off get_trace_v2 with the envelope encoder; v1 keeps the bare payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a v2 trace lookup endpoint returning Tempo’s `TraceByIDResponse` envelope.
  * Added JSON and protobuf response formats, including complete and partial result statuses.
  * Added truncation details when trace results are incomplete.
  * Preserved v1 trace lookups with bare OTLP JSON or protobuf responses.

* **Bug Fixes**
  * Improved handling of unknown traces with appropriate not-found responses.
  * Added tenant-isolated trace lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->