### PR TITLE
Openinference indexed messages and convention enrich

### DIFF
--- a/crates/icegate-ingest/src/transform/attributes.rs
+++ b/crates/icegate-ingest/src/transform/attributes.rs
@@ -195,6 +195,136 @@ pub(crate) fn serialize_message_to_json_array(role: &str, content: &str) -> Opti
     serde_json::to_string(&serde_json::json!([{ "role": role, "content": content }])).ok()
 }
 
+/// One node of a rebuilt structure, before it is turned back into JSON.
+///
+/// Arrays are held index-keyed rather than as a `Vec` because the flattened
+/// attributes arrive in whatever order the map iterated: `...10.` sorts before
+/// `...2.` lexicographically, and an index may be missing entirely if the
+/// producer dropped an attribute. A `BTreeMap<usize, _>` restores numeric order
+/// and tolerates gaps, both of which a positional `Vec` would get wrong.
+enum RebuiltNode {
+    /// A terminal attribute value.
+    Leaf(serde_json::Value),
+    /// A nested object, keyed by field name.
+    Object(std::collections::BTreeMap<String, Self>),
+    /// A nested array, keyed by the index parsed out of the attribute key.
+    Array(std::collections::BTreeMap<usize, Self>),
+}
+
+impl RebuiltNode {
+    /// Convert the tree into JSON, collapsing index-keyed maps into arrays in
+    /// ascending index order.
+    fn into_json(self) -> serde_json::Value {
+        match self {
+            Self::Leaf(value) => value,
+            Self::Object(fields) => {
+                serde_json::Value::Object(fields.into_iter().map(|(key, node)| (key, node.into_json())).collect())
+            }
+            Self::Array(items) => serde_json::Value::Array(items.into_values().map(Self::into_json).collect()),
+        }
+    }
+
+    /// Insert `value` at `path`, creating intermediate nodes as needed.
+    ///
+    /// A numeric segment addresses an array element and, per the `OpenInference`
+    /// flattening rule, is always followed by a singular wrapper segment naming
+    /// the element's type (`message`, `tool_call`, `tool`, `document`). That
+    /// wrapper carries no information the position does not already give, so it
+    /// is skipped, which is what turns `...messages.0.message.role` back into
+    /// `[{"role": ...}]` rather than `[{"message": {"role": ...}}]`.
+    ///
+    /// A segment that collides with an already-built node of the other kind is
+    /// dropped rather than overwriting it: a producer that emits both
+    /// `x.0.a.b` and `x.0.a` has contradicted itself, and keeping the first
+    /// value is preferable to letting the later one silently win.
+    fn insert(&mut self, path: &[&str], value: serde_json::Value) {
+        let Some((head, rest)) = path.split_first() else {
+            return;
+        };
+        if let Ok(index) = head.parse::<usize>() {
+            let Self::Array(items) = self else { return };
+            // Skip the singular wrapper that always follows an index. A path
+            // ending on the index itself has no wrapper to skip.
+            let rest = rest.split_first().map_or(rest, |(_wrapper, tail)| tail);
+            if rest.is_empty() {
+                items.entry(index).or_insert(Self::Leaf(value));
+                return;
+            }
+            items.entry(index).or_insert_with(|| Self::child_for(rest)).insert(rest, value);
+            return;
+        }
+        let Self::Object(fields) = self else { return };
+        if rest.is_empty() {
+            fields.entry((*head).to_string()).or_insert(Self::Leaf(value));
+            return;
+        }
+        fields
+            .entry((*head).to_string())
+            .or_insert_with(|| Self::child_for(rest))
+            .insert(rest, value);
+    }
+
+    /// The empty container a path should descend into: an array when the next
+    /// segment is an index, an object otherwise.
+    fn child_for(path: &[&str]) -> Self {
+        if path.first().is_some_and(|segment| segment.parse::<usize>().is_ok()) {
+            Self::Array(std::collections::BTreeMap::new())
+        } else {
+            Self::Object(std::collections::BTreeMap::new())
+        }
+    }
+}
+
+/// Rebuild the JSON array that `OpenInference` flattened into indexed attribute
+/// keys under `prefix`, and serialize it.
+///
+/// `OpenInference` does not emit a structured messages array the way the OTEL
+/// `GenAI` convention does. It flattens one instead, as
+/// `<prefix>.<index>.<singular>.<field...>` — so a two-message prompt arrives as
+/// four separate span attributes:
+///
+/// ```text
+/// llm.input_messages.0.message.role     = "system"
+/// llm.input_messages.0.message.content  = "You are..."
+/// llm.input_messages.1.message.role     = "user"
+/// llm.input_messages.1.message.content  = "What is..."
+/// ```
+///
+/// This is the inverse of that flattening, so the pieces land in
+/// `input_messages` / `output_messages` as the same
+/// `[{"role": ..., "content": ...}]` array every other convention projects,
+/// rather than not landing at all. The rule is applied recursively, so a nested
+/// group such as `...0.message.tool_calls.0.tool_call.function.name` rebuilds
+/// into a `tool_calls` array inside its message.
+///
+/// Returns `None` when no attribute carries the prefix.
+pub(crate) fn serialize_indexed_attrs_to_json_array(attrs: &[KeyValue], prefix: &str) -> Option<String> {
+    let mut root = RebuiltNode::Array(std::collections::BTreeMap::new());
+    let mut found = false;
+    for kv in attrs {
+        // The trailing dot matters: without it, `llm.tools_count` would be read
+        // as a member of the `llm.tools` array.
+        let Some(remainder) = kv.key.strip_prefix(prefix).and_then(|rest| rest.strip_prefix('.')) else {
+            continue;
+        };
+        let Some(value) = kv.value.as_ref().and_then(any_value_to_json) else {
+            continue;
+        };
+        let path: Vec<&str> = remainder.split('.').collect();
+        // The first segment must be an index; anything else is a sibling
+        // attribute that merely shares the prefix, not an array element.
+        if path.first().is_none_or(|segment| segment.parse::<usize>().is_err()) {
+            continue;
+        }
+        root.insert(&path, value);
+        found = true;
+    }
+    if !found {
+        return None;
+    }
+    serde_json::to_string(&root.into_json()).ok()
+}
+
 /// Checks if a byte slice is all zeros.
 pub(crate) fn is_zero_bytes(bytes: &[u8]) -> bool {
     bytes.iter().all(|&b| b == 0)
@@ -994,5 +1124,141 @@ mod tests {
         assert!(parsed.is_array());
         assert_eq!(parsed[0]["role"], "user");
         assert_eq!(parsed[0]["content"], "hello \"world\"");
+    }
+
+    /// Build a string attribute, for the indexed-rebuild tests below.
+    fn indexed_kv(key: &str, value: &str) -> KeyValue {
+        KeyValue {
+            key_strindex: 0,
+            key: key.to_string(),
+            value: Some(AnyValue {
+                value: Some(Value::StringValue(value.to_string())),
+            }),
+        }
+    }
+
+    /// Parse a rebuilt array back out, so assertions read against structure
+    /// rather than against an exact serialization.
+    fn rebuild(attrs: &[KeyValue], prefix: &str) -> serde_json::Value {
+        let json = serialize_indexed_attrs_to_json_array(attrs, prefix).expect("prefix is present");
+        serde_json::from_str(&json).expect("valid json")
+    }
+
+    #[test]
+    fn rebuilds_indexed_messages_into_the_role_content_array_shape() {
+        let attrs = vec![
+            indexed_kv("llm.input_messages.0.message.role", "system"),
+            indexed_kv("llm.input_messages.0.message.content", "You are helpful"),
+            indexed_kv("llm.input_messages.1.message.role", "user"),
+            indexed_kv("llm.input_messages.1.message.content", "What is 2+2?"),
+        ];
+        let parsed = rebuild(&attrs, "llm.input_messages");
+        assert_eq!(parsed.as_array().expect("array").len(), 2);
+        assert_eq!(parsed[0]["role"], "system");
+        assert_eq!(parsed[0]["content"], "You are helpful");
+        assert_eq!(parsed[1]["role"], "user");
+        assert_eq!(parsed[1]["content"], "What is 2+2?");
+    }
+
+    #[test]
+    fn rebuilt_messages_drop_the_singular_wrapper_segment() {
+        let attrs = vec![indexed_kv("llm.input_messages.0.message.role", "user")];
+        let parsed = rebuild(&attrs, "llm.input_messages");
+        assert!(
+            parsed[0].get("message").is_none(),
+            "the `message` wrapper carries nothing the position does not, and would break the shared array shape"
+        );
+    }
+
+    #[test]
+    fn rebuilds_indices_in_numeric_not_lexicographic_order() {
+        // "10" sorts before "2" as text; a positional rebuild that trusted map
+        // order would emit this conversation scrambled.
+        let attrs = vec![
+            indexed_kv("llm.input_messages.10.message.content", "eleventh"),
+            indexed_kv("llm.input_messages.2.message.content", "third"),
+            indexed_kv("llm.input_messages.0.message.content", "first"),
+        ];
+        let parsed = rebuild(&attrs, "llm.input_messages");
+        let contents: Vec<&str> = parsed
+            .as_array()
+            .expect("array")
+            .iter()
+            .map(|item| item["content"].as_str().expect("string"))
+            .collect();
+        assert_eq!(contents, vec!["first", "third", "eleventh"]);
+    }
+
+    #[test]
+    fn rebuilds_nested_tool_calls_inside_a_message() {
+        let attrs = vec![
+            indexed_kv("llm.output_messages.0.message.role", "assistant"),
+            indexed_kv("llm.output_messages.0.message.tool_calls.0.tool_call.id", "call_abc"),
+            indexed_kv(
+                "llm.output_messages.0.message.tool_calls.0.tool_call.function.name",
+                "final_answer",
+            ),
+            indexed_kv(
+                "llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments",
+                r#"{"answer": 42}"#,
+            ),
+        ];
+        let parsed = rebuild(&attrs, "llm.output_messages");
+        assert_eq!(parsed[0]["role"], "assistant");
+        let calls = parsed[0]["tool_calls"].as_array().expect("tool_calls is an array");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["id"], "call_abc");
+        assert_eq!(calls[0]["function"]["name"], "final_answer");
+        assert_eq!(calls[0]["function"]["arguments"], r#"{"answer": 42}"#);
+    }
+
+    #[test]
+    fn rebuilds_a_gap_in_the_indices_without_inventing_an_element() {
+        // Index 1 is missing entirely; the result must be two elements, not
+        // three with a null in the middle.
+        let attrs = vec![
+            indexed_kv("llm.input_messages.0.message.content", "first"),
+            indexed_kv("llm.input_messages.2.message.content", "third"),
+        ];
+        let parsed = rebuild(&attrs, "llm.input_messages");
+        assert_eq!(parsed.as_array().expect("array").len(), 2);
+        assert_eq!(parsed[0]["content"], "first");
+        assert_eq!(parsed[1]["content"], "third");
+    }
+
+    #[test]
+    fn rebuild_ignores_a_sibling_attribute_sharing_the_prefix() {
+        let attrs = vec![
+            indexed_kv("llm.input_messages.0.message.content", "hello"),
+            indexed_kv("llm.input_messages_count", "1"),
+        ];
+        let parsed = rebuild(&attrs, "llm.input_messages");
+        assert_eq!(parsed.as_array().expect("array").len(), 1);
+        assert_eq!(parsed[0]["content"], "hello");
+    }
+
+    #[test]
+    fn rebuild_ignores_a_prefixed_attribute_that_is_not_indexed() {
+        // `llm.input_messages.summary` shares the prefix but names no element.
+        let attrs = vec![indexed_kv("llm.input_messages.summary", "two messages")];
+        assert!(serialize_indexed_attrs_to_json_array(&attrs, "llm.input_messages").is_none());
+    }
+
+    #[test]
+    fn rebuild_returns_none_when_the_prefix_is_absent() {
+        let attrs = vec![indexed_kv("gen_ai.input.messages", "[]")];
+        assert!(serialize_indexed_attrs_to_json_array(&attrs, "llm.input_messages").is_none());
+    }
+
+    #[test]
+    fn rebuilds_a_single_valued_element_such_as_a_tool_schema() {
+        let attrs = vec![
+            indexed_kv("llm.tools.0.tool.json_schema", r#"{"name":"web_search"}"#),
+            indexed_kv("llm.tools.1.tool.json_schema", r#"{"name":"final_answer"}"#),
+        ];
+        let parsed = rebuild(&attrs, "llm.tools");
+        assert_eq!(parsed.as_array().expect("array").len(), 2);
+        assert_eq!(parsed[0]["json_schema"], r#"{"name":"web_search"}"#);
+        assert_eq!(parsed[1]["json_schema"], r#"{"name":"final_answer"}"#);
     }
 }

--- a/crates/icegate-ingest/src/transform/operations/convention.rs
+++ b/crates/icegate-ingest/src/transform/operations/convention.rs
@@ -52,6 +52,19 @@ pub(crate) trait OperationConvention: Send + Sync {
         &[]
     }
 
+    /// Attribute-key prefixes under which this convention flattens a JSON array
+    /// into indexed keys (`<prefix>.<index>.<singular>.<field>`), to be rebuilt
+    /// into the array `field` expects. Used by SDKs that do not emit a
+    /// structured array attribute at all — `OpenInference` spreads a prompt
+    /// across one attribute per message field. Resolved after the scalar
+    /// [`Self::field_keys`] and before the object, message, and event modes,
+    /// since a convention that offers both a whole array and its flattened
+    /// pieces means the same thing by each and the whole array is cheaper.
+    /// Default: none.
+    fn indexed_field_prefixes(&self, _field: OperationField) -> &'static [&'static str] {
+        &[]
+    }
+
     /// `(attribute_key, role)` sources this convention wraps into a single-message
     /// JSON array `[{"role": role, "content": <value>}]` for a message content
     /// `field` — used when an SDK emits a bare prompt/response string rather than

--- a/crates/icegate-ingest/src/transform/operations/convention.rs
+++ b/crates/icegate-ingest/src/transform/operations/convention.rs
@@ -52,6 +52,37 @@ pub(crate) trait OperationConvention: Send + Sync {
         &[]
     }
 
+    /// `(attribute_key, json_field)` sources this convention reads a scalar
+    /// `field` out of, where the attribute holds an opaque JSON object rather
+    /// than the value itself.
+    ///
+    /// `OpenInference` declares no individual sampling attributes at all: an SDK
+    /// puts the whole request payload in `llm.invocation_parameters`, so
+    /// `temperature`, `top_p`, `max_tokens` and the rest are only reachable
+    /// through it. Candidates are ordered, because the JSON field name is the
+    /// provider's, not the convention's — `OpenAI` writes `max_tokens` on one API
+    /// and `max_completion_tokens` on another.
+    ///
+    /// Resolved only after every declared attribute key for the field is absent,
+    /// so a real typed attribute always wins over a value dug out of a blob.
+    /// Default: none.
+    fn json_blob_field_keys(&self, _field: OperationField) -> &'static [(&'static str, &'static str)] {
+        &[]
+    }
+
+    /// Attribute keys holding a single string that this convention contributes
+    /// as the sole element of a *list* `field`.
+    ///
+    /// Needed because the conventions disagree on cardinality for the same
+    /// concept: OTEL's `gen_ai.response.finish_reasons` is an array, while
+    /// `OpenInference`'s `llm.finish_reason` is one string. The list resolver
+    /// rejects a non-array outright — and a rejected value drops the whole row —
+    /// so a singular source has to be declared here rather than alongside the
+    /// array keys. Default: none.
+    fn singular_list_field_keys(&self, _field: OperationField) -> &'static [&'static str] {
+        &[]
+    }
+
     /// Attribute-key prefixes under which this convention flattens a JSON array
     /// into indexed keys (`<prefix>.<index>.<singular>.<field>`), to be rebuilt
     /// into the array `field` expects. Used by SDKs that do not emit a

--- a/crates/icegate-ingest/src/transform/operations/openinference.rs
+++ b/crates/icegate-ingest/src/transform/operations/openinference.rs
@@ -4,10 +4,29 @@ use super::convention::OperationConvention;
 use super::projection::{AttributeView, OperationField};
 use crate::transform::attributes::extract_string_value;
 
-/// `OpenInference` (Arize) semantic-convention adapter. Sources `llm.*` token
-/// counts, `llm.model_name`, `session.id`, and classifies via the
-/// `openinference.span.kind` normalization map (spec section 4). Second in the
-/// registry, so OTEL wins on any key `OpenInference` also offers.
+/// `OpenInference` (Arize) semantic-convention adapter. Second in the registry,
+/// so OTEL wins on any key `OpenInference` also offers.
+///
+/// Classifies via the `openinference.span.kind` normalization map (spec section
+/// 4), and sources the `llm.*` and `tool.*` families. Three of those need a
+/// resolution mode the OTEL convention never does, because `OpenInference`
+/// states the same facts in a different shape:
+///
+/// - **Sampling parameters have no attributes of their own.** An SDK puts the
+///   whole request payload in `llm.invocation_parameters`, so nine typed columns
+///   are reachable only by reading into that JSON — see
+///   [`OperationConvention::json_blob_field_keys`].
+/// - **Messages are flattened, not arrays.** `llm.input_messages`,
+///   `llm.output_messages`, `llm.tools`, and the completions-API
+///   `llm.prompts` / `llm.choices` arrive one attribute per field, rebuilt by
+///   [`OperationConvention::indexed_field_prefixes`].
+/// - **`llm.finish_reason` is one string** where OTEL's equivalent column is an
+///   array — see [`OperationConvention::singular_list_field_keys`].
+///
+/// Attribute families the spec defines that this adapter does *not* source,
+/// because `operations` has no column for them: `llm.cost.*`,
+/// `llm.prompt_template.*`, `llm.function_call`, and the
+/// `llm.token_count.*_details.audio` counts.
 pub(crate) struct OpenInference;
 
 impl OperationConvention for OpenInference {
@@ -17,7 +36,7 @@ impl OperationConvention for OpenInference {
 
     fn field_keys(&self, field: OperationField) -> &'static [&'static str] {
         match field {
-            OperationField::RequestModel => &["llm.model_name"],
+            OperationField::RequestModel => &["llm.model_name", "embedding.model_name", "reranker.model_name"],
             OperationField::InputTokens => &["llm.token_count.prompt"],
             OperationField::OutputTokens => &["llm.token_count.completion"],
             OperationField::TotalTokens => &["llm.token_count.total"],
@@ -25,14 +44,62 @@ impl OperationConvention for OpenInference {
             OperationField::CacheCreationInputTokens => &["llm.token_count.prompt_details.cache_write"],
             OperationField::CacheReadInputTokens => &["llm.token_count.prompt_details.cache_read"],
             OperationField::ConversationId => &["session.id"],
+            // The OTEL adapter already offers `llm.system` for this column and
+            // is ahead in the registry, so it wins when both are present. That
+            // ordering is deliberate: `llm.system` names the AI product
+            // ("openai"), which is what `provider_name` means elsewhere, while
+            // `llm.provider` names the host it runs on ("azure") and is the
+            // better answer only when no product is stated.
+            OperationField::ProviderName => &["llm.provider"],
+            OperationField::ToolName => &["tool.name"],
+            OperationField::ToolDescription => &["tool.description"],
+            OperationField::ToolCallId => &["tool.id"],
+            // A TOOL span states its own definition flatly, unlike an LLM span,
+            // which advertises every tool it may call through the indexed
+            // `llm.tools` list below. `json_schema` is the complete definition
+            // and `parameters` only the argument shape, so the fuller one wins.
+            OperationField::ToolDefinitions => &["tool.json_schema", "tool.parameters"],
+            _ => &[],
+        }
+    }
+
+    fn json_blob_field_keys(&self, field: OperationField) -> &'static [(&'static str, &'static str)] {
+        // Every sampling parameter lives inside `llm.invocation_parameters`;
+        // OpenInference declares no attribute for any of them individually.
+        const BLOB: &str = "llm.invocation_parameters";
+        match field {
+            OperationField::Temperature => &[(BLOB, "temperature")],
+            OperationField::TopP => &[(BLOB, "top_p")],
+            OperationField::TopK => &[(BLOB, "top_k")],
+            // Chat Completions spells it `max_tokens`; the Responses API and
+            // the reasoning models spell it `max_completion_tokens`.
+            OperationField::MaxTokens => &[(BLOB, "max_tokens"), (BLOB, "max_completion_tokens")],
+            OperationField::FrequencyPenalty => &[(BLOB, "frequency_penalty")],
+            OperationField::PresencePenalty => &[(BLOB, "presence_penalty")],
+            OperationField::Seed => &[(BLOB, "seed")],
+            OperationField::Stream => &[(BLOB, "stream")],
+            OperationField::ChoiceCount => &[(BLOB, "n")],
+            _ => &[],
+        }
+    }
+
+    fn singular_list_field_keys(&self, field: OperationField) -> &'static [&'static str] {
+        match field {
+            // One string, where OTEL's equivalent column is an array.
+            OperationField::FinishReasons => &["llm.finish_reason"],
             _ => &[],
         }
     }
 
     fn indexed_field_prefixes(&self, field: OperationField) -> &'static [&'static str] {
         match field {
-            OperationField::InputMessages => &["llm.input_messages"],
-            OperationField::OutputMessages => &["llm.output_messages"],
+            // `llm.prompts` / `llm.choices` are the completions-API counterparts
+            // of the chat messages lists. They rebuild to `[{"text": ...}]`
+            // rather than `[{"role": ..., "content": ...}]`, because a
+            // completions call has no roles to report — the chat prefixes are
+            // ordered first so a chat span is never affected.
+            OperationField::InputMessages => &["llm.input_messages", "llm.prompts"],
+            OperationField::OutputMessages => &["llm.output_messages", "llm.choices"],
             OperationField::ToolDefinitions => &["llm.tools"],
             _ => &[],
         }
@@ -90,8 +157,10 @@ mod tests {
 
     #[test]
     fn request_model_sources_llm_model_name() {
+        // Embedding and reranker spans name their model with their own key,
+        // so all three fill the same column.
         let keys = OpenInference.field_keys(OperationField::RequestModel);
-        assert_eq!(keys, &["llm.model_name"]);
+        assert_eq!(keys, &["llm.model_name", "embedding.model_name", "reranker.model_name"]);
     }
 
     #[test]
@@ -116,13 +185,15 @@ mod tests {
     fn message_columns_source_the_indexed_prefixes() {
         // OpenInference has no whole-array attribute for these; it flattens the
         // array across `<prefix>.<index>.message.<field>` keys.
+        // Chat first, then the completions-API counterparts, so a chat span is
+        // never resolved from `llm.prompts`.
         assert_eq!(
             OpenInference.indexed_field_prefixes(OperationField::InputMessages),
-            &["llm.input_messages"]
+            &["llm.input_messages", "llm.prompts"]
         );
         assert_eq!(
             OpenInference.indexed_field_prefixes(OperationField::OutputMessages),
-            &["llm.output_messages"]
+            &["llm.output_messages", "llm.choices"]
         );
         assert_eq!(
             OpenInference.indexed_field_prefixes(OperationField::ToolDefinitions),

--- a/crates/icegate-ingest/src/transform/operations/openinference.rs
+++ b/crates/icegate-ingest/src/transform/operations/openinference.rs
@@ -29,6 +29,15 @@ impl OperationConvention for OpenInference {
         }
     }
 
+    fn indexed_field_prefixes(&self, field: OperationField) -> &'static [&'static str] {
+        match field {
+            OperationField::InputMessages => &["llm.input_messages"],
+            OperationField::OutputMessages => &["llm.output_messages"],
+            OperationField::ToolDefinitions => &["llm.tools"],
+            _ => &[],
+        }
+    }
+
     fn classify_operation(&self, _span_name: &str, attrs: &AttributeView) -> Option<String> {
         let kind = extract_string_value(attrs.get("openinference.span.kind"))?;
         // Normalization map per spec section 4. PROMPT and any unrecognized kind
@@ -101,6 +110,40 @@ mod tests {
     fn conversation_id_sources_session_id() {
         let keys = OpenInference.field_keys(OperationField::ConversationId);
         assert_eq!(keys, &["session.id"]);
+    }
+
+    #[test]
+    fn message_columns_source_the_indexed_prefixes() {
+        // OpenInference has no whole-array attribute for these; it flattens the
+        // array across `<prefix>.<index>.message.<field>` keys.
+        assert_eq!(
+            OpenInference.indexed_field_prefixes(OperationField::InputMessages),
+            &["llm.input_messages"]
+        );
+        assert_eq!(
+            OpenInference.indexed_field_prefixes(OperationField::OutputMessages),
+            &["llm.output_messages"]
+        );
+        assert_eq!(
+            OpenInference.indexed_field_prefixes(OperationField::ToolDefinitions),
+            &["llm.tools"]
+        );
+    }
+
+    #[test]
+    fn message_columns_have_no_scalar_source() {
+        // The indexed prefixes are the only source; declaring a scalar key as
+        // well would claim an attribute this convention never emits.
+        assert_eq!(OpenInference.field_keys(OperationField::InputMessages), &[] as &[&str]);
+        assert_eq!(OpenInference.field_keys(OperationField::OutputMessages), &[] as &[&str]);
+    }
+
+    #[test]
+    fn fields_without_an_indexed_source_declare_none() {
+        assert_eq!(
+            OpenInference.indexed_field_prefixes(OperationField::RequestModel),
+            &[] as &[&str]
+        );
     }
 
     #[test]

--- a/crates/icegate-ingest/src/transform/operations/projection.rs
+++ b/crates/icegate-ingest/src/transform/operations/projection.rs
@@ -15,7 +15,7 @@ use crate::error::Result;
 use crate::transform::attributes::{
     extract_bool, extract_f64, extract_i64, extract_string_list, extract_string_value, is_zero_bytes, nanos_to_micros,
     serialize_all_attrs_to_json_object, serialize_any_value_to_json, serialize_attrs_to_json_object,
-    serialize_message_to_json_array, u32_count_to_i32,
+    serialize_indexed_attrs_to_json_array, serialize_message_to_json_array, u32_count_to_i32,
 };
 
 /// Borrowing view over a span's attribute list. Built once per span and shared
@@ -443,6 +443,20 @@ fn resolve_json_object_from_attrs(attrs: &[KeyValue], field: OperationField) -> 
     None
 }
 
+/// Resolve a content field by rebuilding the JSON array a convention flattened
+/// into indexed attribute keys. Returns `None` when no convention declares an
+/// indexed prefix for `field`, or no attribute carries one.
+fn resolve_indexed_array_from_attrs(attrs: &[KeyValue], field: OperationField) -> Option<String> {
+    for convention in CONVENTIONS {
+        for &prefix in convention.indexed_field_prefixes(field) {
+            if let Some(json) = serialize_indexed_attrs_to_json_array(attrs, prefix) {
+                return Some(json);
+            }
+        }
+    }
+    None
+}
+
 /// Resolve a message content field as a single-message JSON array
 /// `[{"role": role, "content": <value>}]` from the first present
 /// convention-declared `(attribute_key, role)` source. Returns `None` when no
@@ -465,7 +479,8 @@ fn resolve_message_array_from_attrs(attrs: &[KeyValue], field: OperationField) -
 }
 
 /// Resolve a content field through the modes in precedence order: a scalar
-/// attribute value ([`resolve_json`]), a JSON object of flat attributes
+/// attribute value ([`resolve_json`]), an array rebuilt from indexed attribute
+/// keys ([`resolve_indexed_array_from_attrs`]), a JSON object of flat attributes
 /// ([`resolve_json_object_from_attrs`]), a single-message JSON array
 /// ([`resolve_message_array_from_attrs`]), then a JSON object from a span event
 /// ([`resolve_json_from_events`]). The first mode to produce a value wins.
@@ -481,6 +496,9 @@ fn resolve_json_incl_events(
     field: OperationField,
 ) -> Result<Option<String>> {
     if let Some(json) = resolve_json(view, field)? {
+        return Ok(Some(json));
+    }
+    if let Some(json) = resolve_indexed_array_from_attrs(attrs, field) {
         return Ok(Some(json));
     }
     if let Some(json) = resolve_json_object_from_attrs(attrs, field) {
@@ -1303,6 +1321,90 @@ mod tests {
         assert!(messages.is_array(), "input_messages must be a JSON array");
         assert_eq!(messages[0]["role"], "user");
         assert_eq!(messages[0]["content"], "/code-review");
+    }
+
+    #[test]
+    fn openinference_indexed_messages_project_into_the_content_columns() {
+        // OpenInference SDKs (smolagents, LlamaIndex, LangChain) do not emit a
+        // messages array; they flatten one across indexed attributes. Before the
+        // indexed mode existed these spans projected an operations row with both
+        // message columns NULL, silently losing the whole conversation.
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("llm.model_name", "o3-mini"),
+            kv_str("llm.input_messages.0.message.role", "system"),
+            kv_str("llm.input_messages.0.message.content", "You are helpful"),
+            kv_str("llm.input_messages.1.message.role", "user"),
+            kv_str("llm.input_messages.1.message.content", "What is 2+2?"),
+            kv_str("llm.output_messages.0.message.role", "assistant"),
+            kv_str("llm.output_messages.0.message.content", "4"),
+        ]);
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("an OpenInference LLM span -> row");
+
+        assert_eq!(row.operation_name, "chat");
+        let input: serde_json::Value =
+            serde_json::from_str(row.input_messages.as_deref().expect("input_messages present")).expect("json");
+        assert_eq!(input.as_array().expect("array").len(), 2);
+        assert_eq!(input[0]["role"], "system");
+        assert_eq!(input[1]["content"], "What is 2+2?");
+
+        let output: serde_json::Value =
+            serde_json::from_str(row.output_messages.as_deref().expect("output_messages present")).expect("json");
+        assert_eq!(output[0]["role"], "assistant");
+        assert_eq!(output[0]["content"], "4");
+    }
+
+    #[test]
+    fn openinference_tool_schemas_project_into_tool_definitions() {
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("llm.tools.0.tool.json_schema", r#"{"name":"web_search"}"#),
+        ]);
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("row");
+
+        let tools: serde_json::Value =
+            serde_json::from_str(row.tool_definitions.as_deref().expect("tool_definitions present")).expect("json");
+        assert_eq!(tools[0]["json_schema"], r#"{"name":"web_search"}"#);
+    }
+
+    #[test]
+    fn a_whole_messages_array_wins_over_the_flattened_form() {
+        // A span carrying both means the same thing by each, so the scalar
+        // OTEL attribute is taken and the indexed rebuild is not run.
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("gen_ai.input.messages", r#"[{"role":"user","content":"whole"}]"#),
+            kv_str("llm.input_messages.0.message.role", "user"),
+            kv_str("llm.input_messages.0.message.content", "flattened"),
+        ]);
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("row");
+
+        let input: serde_json::Value =
+            serde_json::from_str(row.input_messages.as_deref().expect("present")).expect("json");
+        assert_eq!(input[0]["content"], "whole");
+    }
+
+    #[test]
+    fn openinference_session_id_projects_as_the_conversation_id() {
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("session.id", "conv-42"),
+        ]);
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("row");
+
+        assert_eq!(row.conversation_id.as_deref(), Some("conv-42"));
     }
 
     #[test]

--- a/crates/icegate-ingest/src/transform/operations/projection.rs
+++ b/crates/icegate-ingest/src/transform/operations/projection.rs
@@ -333,7 +333,46 @@ fn resolve_str(view: &AttributeView, field: OperationField) -> Result<Option<Str
     Ok(None)
 }
 
+/// Resolve `field` out of a convention-declared JSON blob attribute.
+///
+/// Returns the raw JSON value so each typed resolver can apply its own
+/// conversion. A blob that is absent, unparseable, or missing the named field
+/// yields `None`.
+///
+/// Deliberately non-fatal, unlike the typed attribute resolvers: a blob is an
+/// opaque vendor request payload that the convention makes no type promise
+/// about, so a surprise inside it is a value this projection cannot use, not
+/// evidence that the span is malformed. Dropping the whole operations row over
+/// an unexpected `temperature` in a passthrough payload would lose the span's
+/// tokens, model, and messages along with it.
+///
+/// The blob is re-parsed per field rather than parsed once per span. Nine
+/// sampling fields consult it, so a span pays up to nine parses of a small
+/// object — measurably cheaper than threading a cache through `AttributeView`,
+/// and exactly zero for the conventions that declare no blob sources at all.
+fn resolve_blob_value(view: &AttributeView, field: OperationField) -> Option<serde_json::Value> {
+    for convention in CONVENTIONS {
+        for &(blob_key, json_field) in convention.json_blob_field_keys(field) {
+            let Some(text) = extract_string_value(view.get(blob_key)) else {
+                continue;
+            };
+            let Ok(serde_json::Value::Object(fields)) = serde_json::from_str::<serde_json::Value>(&text) else {
+                continue;
+            };
+            if let Some(value) = fields.get(json_field) {
+                if !value.is_null() {
+                    return Some(value.clone());
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Resolve the first present `i64` for `field`; strict parse (D6).
+///
+/// Falls back to a JSON blob source ([`resolve_blob_value`]) only when no
+/// declared attribute key is present.
 ///
 /// # Errors
 ///
@@ -344,7 +383,7 @@ fn resolve_i64(view: &AttributeView, field: OperationField, context: &'static st
             return extract_i64(Some(value), context);
         }
     }
-    Ok(None)
+    Ok(resolve_blob_value(view, field).and_then(|value| value.as_i64()))
 }
 
 /// Resolve the first present `f64` for `field`; strict parse (D6).
@@ -358,7 +397,11 @@ fn resolve_f64(view: &AttributeView, field: OperationField, context: &'static st
             return extract_f64(Some(value), context);
         }
     }
-    Ok(None)
+    // A blob number arrives as JSON, where `1` and `1.0` are the same literal,
+    // so an integral value is accepted here rather than demanded as a float.
+    Ok(resolve_blob_value(view, field)
+        .and_then(|value| value.as_f64())
+        .filter(|number| number.is_finite()))
 }
 
 /// Resolve the first present `bool` for `field`; strict parse (D6).
@@ -372,7 +415,7 @@ fn resolve_bool(view: &AttributeView, field: OperationField, context: &'static s
             return extract_bool(Some(value), context);
         }
     }
-    Ok(None)
+    Ok(resolve_blob_value(view, field).and_then(|value| value.as_bool()))
 }
 
 /// Resolve the first present `Vec<String>` for `field`; strict parse (D6).
@@ -386,7 +429,26 @@ fn resolve_str_list(view: &AttributeView, field: OperationField, context: &'stat
             return extract_string_list(Some(value), context);
         }
     }
-    Ok(None)
+    Ok(resolve_singular_list(view, field))
+}
+
+/// Resolve a list `field` from a convention that states it as a single string,
+/// yielding a one-element list.
+///
+/// Kept out of [`resolve_str_list`]'s main loop because the two cardinalities
+/// cannot share a key list: `extract_string_list` rejects a non-array value,
+/// and that rejection drops the entire operations row. A singular key listed
+/// beside the array keys would therefore not merely fail to resolve — it would
+/// discard the span's whole projection.
+fn resolve_singular_list(view: &AttributeView, field: OperationField) -> Option<Vec<String>> {
+    for convention in CONVENTIONS {
+        for &key in convention.singular_list_field_keys(field) {
+            if let Some(value) = extract_string_value(view.get(key)) {
+                return Some(vec![value]);
+            }
+        }
+    }
+    None
 }
 
 /// Resolve the first present JSON-serialized content for `field`.
@@ -1391,6 +1453,221 @@ mod tests {
         let input: serde_json::Value =
             serde_json::from_str(row.input_messages.as_deref().expect("present")).expect("json");
         assert_eq!(input[0]["content"], "whole");
+    }
+
+    #[test]
+    fn openinference_sampling_params_come_out_of_the_invocation_parameters_blob() {
+        // OpenInference declares no individual sampling attributes; an SDK puts
+        // the whole request payload in one JSON attribute, so these nine typed
+        // columns are reachable only through it.
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str(
+                "llm.invocation_parameters",
+                r#"{"temperature":0.7,"top_p":0.95,"top_k":40,"max_tokens":512,
+                    "frequency_penalty":0.1,"presence_penalty":-0.2,"seed":7,"stream":true,"n":3}"#,
+            ),
+        ]);
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("row");
+
+        assert!((row.temperature.expect("temperature") - 0.7).abs() < f64::EPSILON);
+        assert!((row.top_p.expect("top_p") - 0.95).abs() < f64::EPSILON);
+        assert_eq!(row.top_k, Some(40));
+        assert_eq!(row.max_tokens, Some(512));
+        assert!((row.frequency_penalty.expect("frequency") - 0.1).abs() < f64::EPSILON);
+        assert!((row.presence_penalty.expect("presence") + 0.2).abs() < f64::EPSILON);
+        assert_eq!(row.seed, Some(7));
+        assert_eq!(row.stream, Some(true));
+        assert_eq!(row.choice_count, Some(3), "OpenAI spells choice count `n`");
+    }
+
+    #[test]
+    fn max_completion_tokens_is_accepted_as_max_tokens() {
+        // The Responses API and the reasoning models spell it this way; the
+        // published TRAIL dataset uses it on 1,508 spans.
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("llm.invocation_parameters", r#"{"max_completion_tokens":8192}"#),
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+        assert_eq!(row.max_tokens, Some(8192));
+    }
+
+    #[test]
+    fn a_typed_attribute_wins_over_the_same_field_inside_a_blob() {
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_dbl("gen_ai.request.temperature", 0.1),
+            kv_str("llm.invocation_parameters", r#"{"temperature":0.9}"#),
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+        assert!((row.temperature.expect("temperature") - 0.1).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn a_malformed_blob_leaves_the_column_null_without_dropping_the_row() {
+        // A blob is an opaque vendor payload, not a typed attribute the
+        // convention promises, so a surprise inside it must not cost the span
+        // its tokens, model, and messages.
+        for blob in [
+            "not json at all",
+            r#"{"temperature":"hot"}"#,
+            r#"["temperature", 0.7]"#,
+            r#"{"temperature":null}"#,
+        ] {
+            let span = span_with(vec![
+                kv_str("openinference.span.kind", "LLM"),
+                kv_int("llm.token_count.total", 42),
+                kv_str("llm.invocation_parameters", blob),
+            ]);
+            let row = project_operation_row(&span, None, "t", None, 1)
+                .expect("a bad blob must not fail the projection")
+                .expect("row survives");
+            assert_eq!(row.temperature, None, "blob {blob} must not populate temperature");
+            assert_eq!(row.total_tokens, Some(42), "the rest of the row survives blob {blob}");
+        }
+    }
+
+    #[test]
+    fn openinference_tool_attributes_project_onto_the_tool_columns() {
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "TOOL"),
+            kv_str("tool.name", "web_search"),
+            kv_str("tool.description", "Search the web"),
+            kv_str("tool.id", "call_62136355"),
+            kv_str("tool.parameters", r#"{"q":"string"}"#),
+        ]);
+
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("projection ok")
+            .expect("row");
+
+        assert_eq!(row.operation_name, "execute_tool");
+        assert_eq!(row.tool_name.as_deref(), Some("web_search"));
+        assert_eq!(row.tool_description.as_deref(), Some("Search the web"));
+        assert_eq!(row.tool_call_id.as_deref(), Some("call_62136355"));
+        assert_eq!(row.tool_definitions.as_deref(), Some(r#"{"q":"string"}"#));
+    }
+
+    #[test]
+    fn a_tool_json_schema_is_preferred_over_bare_parameters() {
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "TOOL"),
+            kv_str("tool.parameters", r#"{"q":"string"}"#),
+            kv_str("tool.json_schema", r#"{"type":"function"}"#),
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+        assert_eq!(
+            row.tool_definitions.as_deref(),
+            Some(r#"{"type":"function"}"#),
+            "the complete definition wins over the argument shape alone"
+        );
+    }
+
+    #[test]
+    fn a_singular_finish_reason_becomes_a_one_element_list() {
+        // OTEL's equivalent is an array and OpenInference's is one string. The
+        // array resolver rejects a non-array and a rejection drops the row, so
+        // this guards that the singular source is handled separately.
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("llm.finish_reason", "stop"),
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1)
+            .expect("a singular finish reason must not drop the row")
+            .expect("row");
+        assert_eq!(row.finish_reasons, Some(vec!["stop".to_string()]));
+    }
+
+    #[test]
+    fn an_array_finish_reason_still_wins_over_the_singular_one() {
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("llm.finish_reason", "stop"),
+            KeyValue {
+                key_strindex: 0,
+                key: "gen_ai.response.finish_reasons".to_string(),
+                value: Some(AnyValue {
+                    value: Some(Value::ArrayValue(ArrayValue {
+                        values: vec![AnyValue {
+                            value: Some(Value::StringValue("length".to_string())),
+                        }],
+                    })),
+                }),
+            },
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+        assert_eq!(row.finish_reasons, Some(vec!["length".to_string()]));
+    }
+
+    #[test]
+    fn llm_provider_fills_provider_name_when_no_system_is_stated() {
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("llm.provider", "azure"),
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+        assert_eq!(row.provider_name.as_deref(), Some("azure"));
+    }
+
+    #[test]
+    fn llm_system_outranks_llm_provider_for_provider_name() {
+        // `llm.system` names the AI product, which is what this column means
+        // elsewhere; `llm.provider` names the host it runs on.
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("llm.provider", "azure"),
+            kv_str("llm.system", "openai"),
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+        assert_eq!(row.provider_name.as_deref(), Some("openai"));
+    }
+
+    #[test]
+    fn embedding_and_reranker_model_names_fill_request_model() {
+        for key in ["embedding.model_name", "reranker.model_name"] {
+            let span = span_with(vec![kv_str("openinference.span.kind", "LLM"), kv_str(key, "model-x")]);
+            let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+            assert_eq!(
+                row.request_model.as_deref(),
+                Some("model-x"),
+                "{key} must fill the column"
+            );
+        }
+    }
+
+    #[test]
+    fn completions_prompts_and_choices_project_into_the_message_columns() {
+        // A completions API has no roles, so these rebuild to [{"text": ...}].
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("llm.prompts.0.prompt.text", "def fib(n):"),
+            kv_str("llm.choices.0.completion.text", " return n"),
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+        let input: serde_json::Value =
+            serde_json::from_str(row.input_messages.as_deref().expect("present")).expect("json");
+        assert_eq!(input[0]["text"], "def fib(n):");
+        let output: serde_json::Value =
+            serde_json::from_str(row.output_messages.as_deref().expect("present")).expect("json");
+        assert_eq!(output[0]["text"], " return n");
+    }
+
+    #[test]
+    fn chat_messages_outrank_completions_prompts() {
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str("llm.prompts.0.prompt.text", "completions"),
+            kv_str("llm.input_messages.0.message.role", "user"),
+            kv_str("llm.input_messages.0.message.content", "chat"),
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+        let input: serde_json::Value =
+            serde_json::from_str(row.input_messages.as_deref().expect("present")).expect("json");
+        assert_eq!(input[0]["content"], "chat");
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved OpenInference data ingestion for chat messages, tool calls, tool definitions, provider details, model names, embedding and reranker models, sampling parameters, and finish reasons.
  - Reconstructed nested messages and tool data from indexed attributes, preserving ordering and supporting gaps, arrays, and nested objects.
  - Added support for JSON-valued fields and conversion of single values into one-item lists.

- **Bug Fixes**
  - Malformed or incompatible JSON values are safely ignored without discarding otherwise valid records.
  - Improved field precedence and mapping consistency across supported message and event formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->