### PR TITLE
(refactor) Optimize JSON blob attribute parsing

### DIFF
--- a/crates/icegate-ingest/src/transform/attributes.rs
+++ b/crates/icegate-ingest/src/transform/attributes.rs
@@ -275,6 +275,20 @@ impl RebuiltNode {
     }
 }
 
+/// Longest dotted path, in segments after the prefix, that the indexed rebuild
+/// will follow.
+///
+/// [`RebuiltNode::insert`] recurses once per segment and
+/// [`RebuiltNode::into_json`] once per nesting level, while the segment count
+/// comes from an OTLP attribute key, which the client controls. Without a cap, a
+/// single key carrying enough dots would recurse the ingest thread into a stack
+/// overflow, which aborts the process rather than failing the request. The
+/// deepest path the convention defines is a multimodal image
+/// (`<index>.message.contents.<index>.message_content.image.image.url`, eight
+/// segments), so this leaves room for a longer variant while still bounding the
+/// recursion.
+const MAX_INDEXED_KEY_SEGMENTS: usize = 16;
+
 /// Rebuild the JSON array that `OpenInference` flattened into indexed attribute
 /// keys under `prefix`, and serialize it.
 ///
@@ -297,6 +311,9 @@ impl RebuiltNode {
 /// group such as `...0.message.tool_calls.0.tool_call.function.name` rebuilds
 /// into a `tool_calls` array inside its message.
 ///
+/// An over-deep key is skipped rather than rebuilt: see
+/// [`MAX_INDEXED_KEY_SEGMENTS`].
+///
 /// Returns `None` when no attribute carries the prefix.
 pub(crate) fn serialize_indexed_attrs_to_json_array(attrs: &[KeyValue], prefix: &str) -> Option<String> {
     let mut root = RebuiltNode::Array(std::collections::BTreeMap::new());
@@ -314,6 +331,9 @@ pub(crate) fn serialize_indexed_attrs_to_json_array(attrs: &[KeyValue], prefix: 
         // The first segment must be an index; anything else is a sibling
         // attribute that merely shares the prefix, not an array element.
         if path.first().is_none_or(|segment| segment.parse::<usize>().is_err()) {
+            continue;
+        }
+        if path.len() > MAX_INDEXED_KEY_SEGMENTS {
             continue;
         }
         root.insert(&path, value);
@@ -1260,5 +1280,90 @@ mod tests {
         assert_eq!(parsed.as_array().expect("array").len(), 2);
         assert_eq!(parsed[0]["json_schema"], r#"{"name":"web_search"}"#);
         assert_eq!(parsed[1]["json_schema"], r#"{"name":"final_answer"}"#);
+    }
+    #[test]
+    fn rebuilds_multimodal_message_contents_without_their_wrapper() {
+        // The wrapper skipped after an index is positional, not a known name:
+        // the multimodal list nests `message_content` under `contents`, and the
+        // content columns expect the same unwrapped shape there as anywhere
+        // else. Recognizing only a fixed set of wrapper names would rebuild
+        // this as `[{"message_content": {...}}]`.
+        let attrs = vec![
+            indexed_kv("llm.input_messages.0.message.role", "user"),
+            indexed_kv("llm.input_messages.0.message.contents.0.message_content.type", "text"),
+            indexed_kv(
+                "llm.input_messages.0.message.contents.0.message_content.text",
+                "what is this",
+            ),
+            indexed_kv("llm.input_messages.0.message.contents.1.message_content.type", "image"),
+            indexed_kv(
+                "llm.input_messages.0.message.contents.1.message_content.image.image.url",
+                "https://example.test/photo.jpg",
+            ),
+        ];
+        let parsed = rebuild(&attrs, "llm.input_messages");
+        assert_eq!(parsed[0]["role"], "user");
+        let contents = parsed[0]["contents"].as_array().expect("contents is an array");
+        assert_eq!(contents.len(), 2);
+        assert_eq!(contents[0]["type"], "text");
+        assert_eq!(contents[0]["text"], "what is this");
+        assert_eq!(contents[1]["type"], "image");
+        assert_eq!(contents[1]["image"]["image"]["url"], "https://example.test/photo.jpg");
+    }
+
+    #[test]
+    fn rebuild_keeps_the_first_value_when_a_segment_collides_with_the_other_shape() {
+        // The producer contradicts itself: `...tool.a` is a leaf in one
+        // attribute and an object in the next. The first value stands and the
+        // colliding segment is dropped, rather than the later key silently
+        // replacing what is already built.
+        let attrs = vec![
+            indexed_kv("llm.tools.0.tool.a", "scalar"),
+            indexed_kv("llm.tools.0.tool.a.b", "nested"),
+        ];
+        let parsed = rebuild(&attrs, "llm.tools");
+        assert_eq!(parsed[0]["a"], "scalar");
+
+        // ... and in the other order: the object is built first, so the later
+        // leaf cannot overwrite it.
+        let attrs = vec![
+            indexed_kv("llm.tools.0.tool.a.b", "nested"),
+            indexed_kv("llm.tools.0.tool.a", "scalar"),
+        ];
+        let parsed = rebuild(&attrs, "llm.tools");
+        assert_eq!(parsed[0]["a"]["b"], "nested");
+    }
+
+    #[test]
+    fn rebuild_skips_a_key_deeper_than_the_recursion_cap() {
+        // A client-supplied key with one segment too many is dropped whole,
+        // rather than recursed into. The well-formed sibling still rebuilds.
+        // `0` + the repeated segments + `leaf` is one segment over the cap.
+        let deep = format!("llm.tools.0.{}leaf", "a.".repeat(MAX_INDEXED_KEY_SEGMENTS - 1));
+        let attrs = vec![
+            indexed_kv(&deep, "dropped"),
+            indexed_kv("llm.tools.1.tool.json_schema", "kept"),
+        ];
+        let parsed = rebuild(&attrs, "llm.tools");
+        assert_eq!(parsed.as_array().expect("array").len(), 1);
+        assert_eq!(parsed[0]["json_schema"], "kept");
+    }
+
+    #[test]
+    fn rebuild_accepts_a_key_at_the_recursion_cap() {
+        // One segment shallower than the case above, so the cap is a boundary
+        // and not a blanket rejection of nested keys.
+        // `0` + `tool` + the repeated segments + `leaf` is exactly the cap.
+        const NESTING: usize = MAX_INDEXED_KEY_SEGMENTS - 3;
+        let attrs = vec![indexed_kv(
+            &format!("llm.tools.0.tool.{}leaf", "a.".repeat(NESTING)),
+            "kept",
+        )];
+        let parsed = rebuild(&attrs, "llm.tools");
+        let mut node = &parsed[0];
+        for _ in 0..NESTING {
+            node = &node["a"];
+        }
+        assert_eq!(node["leaf"], "kept");
     }
 }

--- a/crates/icegate-ingest/src/transform/operations/projection.rs
+++ b/crates/icegate-ingest/src/transform/operations/projection.rs
@@ -418,17 +418,28 @@ fn resolve_i64(view: &AttributeView, field: OperationField, context: &'static st
 }
 
 /// Convert an integral JSON float to `i64`, or `None` when it has a fractional
-/// part or falls outside the range `i64` can hold exactly.
+/// part or a magnitude no longer pinned to a single integer by `f64`.
 fn blob_number_as_i64(value: &serde_json::Value) -> Option<i64> {
-    // 2^63 as f64. The upper bound is exclusive because `i64::MAX` is not
-    // representable as an `f64`, so anything at or above this bound would
-    // saturate rather than convert.
-    const UPPER_BOUND: f64 = 9_223_372_036_854_775_808.0;
+    // 2^53, the first magnitude at which the representable integers stop being
+    // consecutive: from here up, a whole `f64` no longer names one integer, so
+    // casting it would store a number nothing necessarily sent. The bound is
+    // exclusive because 2^53 is itself where its unrepresentable neighbour
+    // lands. It sits far under `i64::MAX`, so nothing reaching the cast can
+    // saturate.
+    //
+    // This bounds only the cast. serde_json is built without
+    // `arbitrary_precision`, and its parser is already off by an ulp for some
+    // literals just under the bound, which no check here can undo: the text is
+    // gone by the time a `Value` arrives.
+    const EXACT_INTEGER_BOUND: f64 = 9_007_199_254_740_992.0;
     let number = value.as_f64()?;
-    if number.fract() != 0.0 || number < -UPPER_BOUND || number >= UPPER_BOUND {
+    if number.fract() != 0.0 || number.abs() >= EXACT_INTEGER_BOUND {
         return None;
     }
-    #[expect(clippy::cast_possible_truncation, reason = "checked integral and in range above")]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "checked integral and exactly representable above"
+    )]
     Some(number as i64)
 }
 
@@ -1561,14 +1572,37 @@ mod tests {
     }
 
     #[test]
+    fn the_integral_float_cast_is_bounded_at_the_last_exact_integer() {
+        // Driven through the values rather than through JSON text: serde_json's
+        // own parser is off by an ulp for some literals immediately under the
+        // bound, which would hide where this rule actually cuts.
+        for (number, expected) in [
+            (9_007_199_254_740_991.0_f64, Some(9_007_199_254_740_991)),
+            (-9_007_199_254_740_991.0_f64, Some(-9_007_199_254_740_991)),
+            (9_007_199_254_740_992.0_f64, None),
+            (-9_007_199_254_740_992.0_f64, None),
+        ] {
+            let value = serde_json::Value::from(number);
+            assert_eq!(
+                blob_number_as_i64(&value),
+                expected,
+                "{number} at the exact-integer bound"
+            );
+        }
+    }
+
+    #[test]
     fn a_fractional_or_out_of_range_number_leaves_the_integer_column_null() {
-        // A fraction is not the integer the column holds, and a magnitude past
-        // i64 would saturate into a value the payload never stated. Both stay
-        // NULL rather than storing something invented.
+        // A fraction is not the integer the column holds, and past 2^53 a whole
+        // float no longer names one integer: `9007199254740993.0` reaches this
+        // code already rounded onto a neighbour. Both stay NULL rather than
+        // storing a number the payload never stated.
         for blob in [
             r#"{"max_tokens":512.5}"#,
             r#"{"max_tokens":1e30}"#,
             r#"{"max_tokens":-1e30}"#,
+            r#"{"max_tokens":9007199254740993.0}"#,
+            r#"{"max_tokens":-9007199254740993.0}"#,
         ] {
             let span = span_with(vec![
                 kv_str("openinference.span.kind", "LLM"),

--- a/crates/icegate-ingest/src/transform/operations/projection.rs
+++ b/crates/icegate-ingest/src/transform/operations/projection.rs
@@ -5,6 +5,7 @@
 //! a span's attributes, and the `project_operation_row` driver with its strict
 //! typed resolvers.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 
 use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope, KeyValue};
@@ -28,6 +29,14 @@ use crate::transform::attributes::{
 /// skipped, so `has`/`get` only report attributes that carry an actual value.
 pub(crate) struct AttributeView<'a> {
     by_key: HashMap<&'a str, &'a AnyValue>,
+    /// Memoized parse of each convention-declared JSON blob attribute read so
+    /// far, keyed by attribute name. `None` records a blob that is absent or
+    /// not a JSON object, so a failed parse is not retried either.
+    ///
+    /// Interior mutability because the resolvers hold the view by shared
+    /// reference; the view is built and dropped inside one span's projection,
+    /// so the cell is never shared across threads.
+    parsed_blobs: RefCell<HashMap<&'static str, Option<serde_json::Map<String, serde_json::Value>>>>,
 }
 
 impl<'a> AttributeView<'a> {
@@ -40,7 +49,10 @@ impl<'a> AttributeView<'a> {
                 by_key.insert(kv.key.as_str(), value);
             }
         }
-        Self { by_key }
+        Self {
+            by_key,
+            parsed_blobs: RefCell::new(HashMap::new()),
+        }
     }
 
     /// Returns the borrowed [`AnyValue`] for `key`, or `None` when the key is
@@ -54,6 +66,31 @@ impl<'a> AttributeView<'a> {
     /// key is present).
     pub(crate) fn has(&self, key: &str) -> bool {
         self.by_key.contains_key(key)
+    }
+
+    /// Returns `json_field` out of the JSON object held in the `blob_key`
+    /// attribute, parsing that attribute at most once per span.
+    ///
+    /// A blob that is absent, unparseable, or not a JSON object yields `None`,
+    /// as does a field that is missing or JSON `null`. The parse is memoized
+    /// because one blob backs many columns — every `OpenInference` sampling
+    /// parameter is read out of `llm.invocation_parameters` — and the blob is a
+    /// whole vendor request payload, so its parse cost scales with the payload,
+    /// not with the one number being read.
+    fn blob_field(&self, blob_key: &'static str, json_field: &str) -> Option<serde_json::Value> {
+        let mut parsed_blobs = self.parsed_blobs.borrow_mut();
+        let fields = parsed_blobs.entry(blob_key).or_insert_with(|| {
+            let text = extract_string_value(self.get(blob_key))?;
+            match serde_json::from_str::<serde_json::Value>(&text) {
+                Ok(serde_json::Value::Object(fields)) => Some(fields),
+                _ => None,
+            }
+        });
+        fields
+            .as_ref()
+            .and_then(|fields| fields.get(json_field))
+            .filter(|value| !value.is_null())
+            .cloned()
     }
 }
 
@@ -346,27 +383,16 @@ fn resolve_str(view: &AttributeView, field: OperationField) -> Result<Option<Str
 /// an unexpected `temperature` in a passthrough payload would lose the span's
 /// tokens, model, and messages along with it.
 ///
-/// The blob is re-parsed per field rather than parsed once per span. Nine
-/// sampling fields consult it, so a span pays up to nine parses of a small
-/// object — measurably cheaper than threading a cache through `AttributeView`,
-/// and exactly zero for the conventions that declare no blob sources at all.
+/// Each declared blob is parsed at most once per span by
+/// [`AttributeView::blob_field`], however many columns read out of it, and not
+/// at all for the conventions that declare no blob sources.
 fn resolve_blob_value(view: &AttributeView, field: OperationField) -> Option<serde_json::Value> {
-    for convention in CONVENTIONS {
-        for &(blob_key, json_field) in convention.json_blob_field_keys(field) {
-            let Some(text) = extract_string_value(view.get(blob_key)) else {
-                continue;
-            };
-            let Ok(serde_json::Value::Object(fields)) = serde_json::from_str::<serde_json::Value>(&text) else {
-                continue;
-            };
-            if let Some(value) = fields.get(json_field) {
-                if !value.is_null() {
-                    return Some(value.clone());
-                }
-            }
-        }
-    }
-    None
+    CONVENTIONS.iter().find_map(|convention| {
+        convention
+            .json_blob_field_keys(field)
+            .iter()
+            .find_map(|&(blob_key, json_field)| view.blob_field(blob_key, json_field))
+    })
 }
 
 /// Resolve the first present `i64` for `field`; strict parse (D6).
@@ -383,7 +409,27 @@ fn resolve_i64(view: &AttributeView, field: OperationField, context: &'static st
             return extract_i64(Some(value), context);
         }
     }
-    Ok(resolve_blob_value(view, field).and_then(|value| value.as_i64()))
+    // JSON has a single number type, so an SDK that holds `max_tokens` as a
+    // float serializes it as `40.0`, which `as_i64` rejects. Accept an integral
+    // number in range rather than leaving the column NULL; a real fraction is
+    // still not an integer and stays NULL. This mirrors `resolve_f64`, which
+    // accepts an integral number for the same reason.
+    Ok(resolve_blob_value(view, field).and_then(|value| value.as_i64().or_else(|| blob_number_as_i64(&value))))
+}
+
+/// Convert an integral JSON float to `i64`, or `None` when it has a fractional
+/// part or falls outside the range `i64` can hold exactly.
+fn blob_number_as_i64(value: &serde_json::Value) -> Option<i64> {
+    // 2^63 as f64. The upper bound is exclusive because `i64::MAX` is not
+    // representable as an `f64`, so anything at or above this bound would
+    // saturate rather than convert.
+    const UPPER_BOUND: f64 = 9_223_372_036_854_775_808.0;
+    let number = value.as_f64()?;
+    if number.fract() != 0.0 || number < -UPPER_BOUND || number >= UPPER_BOUND {
+        return None;
+    }
+    #[expect(clippy::cast_possible_truncation, reason = "checked integral and in range above")]
+    Some(number as i64)
 }
 
 /// Resolve the first present `f64` for `field`; strict parse (D6).
@@ -1494,6 +1540,45 @@ mod tests {
         ]);
         let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
         assert_eq!(row.max_tokens, Some(8192));
+    }
+
+    #[test]
+    fn an_integral_float_in_the_blob_fills_the_integer_column() {
+        // An SDK that keeps these as floats serializes `40.0`, which is the
+        // same JSON number as `40`. Reading it as NULL would lose the value.
+        let span = span_with(vec![
+            kv_str("openinference.span.kind", "LLM"),
+            kv_str(
+                "llm.invocation_parameters",
+                r#"{"top_k":40.0,"max_tokens":512.0,"seed":7.0,"n":3.0}"#,
+            ),
+        ]);
+        let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+        assert_eq!(row.top_k, Some(40));
+        assert_eq!(row.max_tokens, Some(512));
+        assert_eq!(row.seed, Some(7));
+        assert_eq!(row.choice_count, Some(3));
+    }
+
+    #[test]
+    fn a_fractional_or_out_of_range_number_leaves_the_integer_column_null() {
+        // A fraction is not the integer the column holds, and a magnitude past
+        // i64 would saturate into a value the payload never stated. Both stay
+        // NULL rather than storing something invented.
+        for blob in [
+            r#"{"max_tokens":512.5}"#,
+            r#"{"max_tokens":1e30}"#,
+            r#"{"max_tokens":-1e30}"#,
+        ] {
+            let span = span_with(vec![
+                kv_str("openinference.span.kind", "LLM"),
+                kv_int("llm.token_count.total", 42),
+                kv_str("llm.invocation_parameters", blob),
+            ]);
+            let row = project_operation_row(&span, None, "t", None, 1).expect("ok").expect("row");
+            assert_eq!(row.max_tokens, None, "blob {blob} must not populate max_tokens");
+            assert_eq!(row.total_tokens, Some(42), "the rest of the row survives blob {blob}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
With memoization in `AttributeView`; cap recursion depth in `serialize_indexed_attrs_to_json_array` to prevent stack overflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconstruction of indexed attributes, including safer handling of deeply nested keys.
  * Preserved support for keys at the supported nesting limit while skipping overly deep keys.
  * Improved JSON attribute conversion, including valid integral floating-point values.
  * Continued graceful handling of missing, malformed, null, and unsupported JSON values.
  * Improved consistency when the same JSON attribute is referenced multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->