### PR TITLE
Tenant id colon support

### DIFF
--- a/config/helm/icegate/README.md
+++ b/config/helm/icegate/README.md
@@ -1,7 +1,5 @@
 # icegate
 
-IceGate is an observability data lake engine that stores logs, traces, metrics, and events in Apache Iceberg tables with DataFusion as the query engine. Data is ingested via OpenTelemetry protocol and queried via Loki- and Tempo-compatible APIs plus Arrow Flight SQL.
-
 ![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 IceGate is an observability data lake engine. This chart deploys it on Kubernetes:

--- a/crates/icegate-common/src/lib.rs
+++ b/crates/icegate-common/src/lib.rs
@@ -70,10 +70,22 @@ pub const TENANT_ID_HEADER: &str = "x-scope-orgid";
 
 /// Validate a tenant ID value.
 ///
-/// Returns `true` if `value` is non-empty and contains only ASCII
-/// alphanumeric characters, hyphens, or underscores.
+/// Returns `true` if `value` is non-empty and contains only ASCII alphanumeric
+/// characters, hyphens, underscores, or colons.
+///
+/// The colon is admitted because the control plane's tenant id is
+/// `{org_id}:{workspace_id}` — the separator is part of the format, not a
+/// character that happens to appear in one. Refusing it does not reject a
+/// request: ingest and `resolve_tenant_id` both fall back to
+/// [`DEFAULT_TENANT_ID`], so a refused id merges every workspace into one
+/// tenant instead of failing. The class stays otherwise closed — no `/`, no
+/// `.`, no quote, no whitespace — so an id can neither traverse a storage path
+/// nor break out of a SQL literal.
 pub fn is_valid_tenant_id(value: &str) -> bool {
-    !value.is_empty() && value.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b':')
 }
 
 /// Resolve a tenant identifier from an optional raw header value.
@@ -223,5 +235,27 @@ mod tests {
         assert_eq!(resolve_tenant_id(None), DEFAULT_TENANT_ID);
         assert_eq!(resolve_tenant_id(Some("has space")), DEFAULT_TENANT_ID);
         assert_eq!(resolve_tenant_id(Some("")), DEFAULT_TENANT_ID);
+    }
+
+    /// The control plane's tenant id is `{org_id}:{workspace_id}`, so the colon is
+    /// part of the format rather than an edge case. Refusing it does not reject the
+    /// request: ingest and query both fall back to the default tenant, which
+    /// silently merges every workspace into one.
+    #[test]
+    fn a_tenant_id_may_carry_the_colon_that_separates_org_from_workspace() {
+        assert!(is_valid_tenant_id("2q4mHrPd9kL:7xZa1vB3nQe"));
+        assert_eq!(
+            resolve_tenant_id(Some("2q4mHrPd9kL:7xZa1vB3nQe")),
+            "2q4mHrPd9kL:7xZa1vB3nQe"
+        );
+    }
+
+    /// Widening to `:` must not widen to anything else: path traversal, quotes and
+    /// whitespace stay refused, and an empty id is still not an id.
+    #[test]
+    fn widening_to_the_colon_admits_nothing_else() {
+        for refused in ["", "../etc", "a/b", "a'b", "a b", "a.b", "a\\b", "a\"b"] {
+            assert!(!is_valid_tenant_id(refused), "must refuse {refused:?}");
+        }
     }
 }

--- a/crates/icegate-ingest/src/otlp_grpc/services.rs
+++ b/crates/icegate-ingest/src/otlp_grpc/services.rs
@@ -40,7 +40,7 @@ const STATUS_OK: &str = "ok";
 /// Extract tenant ID from gRPC request metadata.
 ///
 /// Returns `Some(tenant_id)` if the `x-scope-orgid` metadata key is present and
-/// contains a valid value (non-empty, ASCII alphanumeric/hyphens/underscores).
+/// contains a valid value (non-empty, ASCII alphanumeric/hyphens/underscores/colons).
 /// Returns `None` otherwise, which falls back to `DEFAULT_TENANT_ID` downstream.
 fn extract_tenant_id<T>(request: &Request<T>) -> Option<String> {
     request

--- a/crates/icegate-ingest/src/otlp_http/handlers.rs
+++ b/crates/icegate-ingest/src/otlp_http/handlers.rs
@@ -46,7 +46,7 @@ const STATUS_OK: &str = "ok";
 /// Extract tenant ID from HTTP headers.
 ///
 /// Returns `Some(tenant_id)` if the `x-scope-orgid` header is present and
-/// contains a valid value (non-empty, ASCII alphanumeric/hyphens/underscores).
+/// contains a valid value (non-empty, ASCII alphanumeric/hyphens/underscores/colons).
 /// Returns `None` otherwise, which falls back to `DEFAULT_TENANT_ID` downstream.
 fn extract_tenant_id(headers: &HeaderMap) -> Option<String> {
     headers

--- a/crates/icegate-query/src/loki/handlers.rs
+++ b/crates/icegate-query/src/loki/handlers.rs
@@ -27,8 +27,8 @@ use crate::{error::QueryError, infra::metrics::QueryRequestRecorder};
 
 /// Extract tenant ID from HTTP headers.
 ///
-/// Returns the header value if present and valid (ASCII alphanumeric, hyphens,
-/// underscores). Falls back to `DEFAULT_TENANT_ID` otherwise — matching the
+/// Returns the header value if present and valid (non-empty, ASCII alphanumeric/hyphens/underscores/colons).
+/// Falls back to `DEFAULT_TENANT_ID` otherwise — matching the
 /// ingest-path behaviour so that data is always queryable under the same
 /// tenant that was used during ingestion.
 fn extract_tenant_id(headers: &HeaderMap) -> String {

--- a/crates/icegate-query/src/tempo/handlers.rs
+++ b/crates/icegate-query/src/tempo/handlers.rs
@@ -39,8 +39,8 @@ use crate::{error::QueryError, traceql::iceberg_predicate::translate_query_to_pr
 
 /// Extract tenant ID from HTTP headers.
 ///
-/// Returns the header value if present and valid (ASCII alphanumeric, hyphens,
-/// underscores). Falls back to `DEFAULT_TENANT_ID` otherwise — matching the
+/// Returns the header value if present and valid (non-empty, ASCII alphanumeric/hyphens/underscores/colons).
+/// Falls back to `DEFAULT_TENANT_ID` otherwise — matching the
 /// ingest-path behaviour so that data is always queryable under the same
 /// tenant that was used during ingestion.
 fn extract_tenant_id(headers: &HeaderMap) -> String {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tenant IDs can now include colons, supporting organization-and-workspace formats such as `org_id:workspace_id`.
  - Colon-containing tenant IDs are preserved and validated without allowing other unsafe characters.

- **Documentation**
  - Updated tenant ID documentation across ingestion and query interfaces.
  - Removed an introductory observability overview from the IceGate configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->