### PR TITLE
feat(gc): ensure sweep retains live files with escaped tenant id in partition key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5255,7 +5255,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
- "url",
  "uuid",
 ]
 

--- a/crates/icegate-maintain/Cargo.toml
+++ b/crates/icegate-maintain/Cargo.toml
@@ -34,9 +34,6 @@ arrow = { workspace = true }
 parquet = { workspace = true }
 object_store = { workspace = true }
 
-# URL parsing: reduce Iceberg's absolute file URIs to bucket-relative object keys
-url = { workspace = true }
-
 # HTTP: the pricing crawler fetches rate cards from upstream JSON endpoints.
 # `stream` enables `bytes_stream()`, used to enforce the response size cap
 # before buffering rather than after.

--- a/crates/icegate-maintain/src/gc/decide.rs
+++ b/crates/icegate-maintain/src/gc/decide.rs
@@ -24,21 +24,47 @@ use crate::error::MaintainError;
 /// three characters of the object's name. Decoding it invents a key that no
 /// object has, and the miss reads as "unreferenced".
 ///
+/// Every component is required and must be non-empty: a URI missing one is a
+/// URI whose object key cannot be derived, and guessing one is what drops a live
+/// file. Rejecting an empty authority also refuses `file://` URIs, which is the
+/// wanted answer — a local store is rooted at the table directory, so its listed
+/// keys are relative to that root and could not be compared against these
+/// bucket-relative ones anyway.
+///
 /// # Errors
 ///
-/// Returns [`MaintainError::Storage`] if `uri` carries no `scheme://` or names no
-/// object under its authority. Callers MUST treat this as fail-closed (delete
-/// nothing): an unparseable referenced path could otherwise drop a live file.
+/// Returns [`MaintainError::Storage`] if `uri` carries no `scheme://`, or if its
+/// scheme, authority, or object key is empty. Callers MUST treat this as
+/// fail-closed (delete nothing): an unparseable referenced path could otherwise
+/// drop a live file.
 pub(crate) fn parse_object_key(uri: &str) -> Result<ObjectPath, MaintainError> {
-    let authority_and_key = uri
-        .split_once("://")
-        .map(|(_scheme, rest)| rest)
-        .ok_or_else(|| MaintainError::Storage(format!("gc: malformed referenced URI '{uri}': no scheme")))?;
-    let key = authority_and_key
+    let (scheme, authority_and_key) = uri.split_once("://").ok_or_else(|| refuse_uri(uri, "no scheme"))?;
+    if scheme.is_empty() {
+        return Err(refuse_uri(uri, "empty scheme"));
+    }
+    let (authority, key) = authority_and_key
         .split_once('/')
-        .map(|(_authority, key)| key)
-        .ok_or_else(|| MaintainError::Storage(format!("gc: referenced URI '{uri}' names no object")))?;
-    Ok(ObjectPath::from(key))
+        .ok_or_else(|| refuse_uri(uri, "names no object"))?;
+    if authority.is_empty() {
+        return Err(refuse_uri(uri, "empty authority"));
+    }
+    let key = ObjectPath::from(key);
+    // Emptiness of the RESULT is the invariant, not of the input: `ObjectPath::from`
+    // drops empty segments, so `/` and `//` survive a non-empty string check and
+    // still normalise away to a key that names nothing.
+    if key.as_ref().is_empty() {
+        return Err(refuse_uri(uri, "empty object key"));
+    }
+    Ok(key)
+}
+
+/// Refuse `uri` as unusable, naming the component at fault.
+///
+/// The component is named because the sweep stops on this error, and an operator
+/// reading the log has to tell a malformed manifest from a URI shape the parser
+/// does not yet admit.
+fn refuse_uri(uri: &str, reason: &str) -> MaintainError {
+    MaintainError::Storage(format!("gc: malformed referenced URI '{uri}': {reason}"))
 }
 
 /// Whether a swept object is a data file or an Iceberg metadata file.
@@ -167,14 +193,41 @@ mod tests {
         assert_eq!(decision, Decision::Referenced);
     }
 
+    /// Every shape whose object key cannot be derived, one rule: refuse it.
+    ///
+    /// The sweep must fail closed rather than silently mis-key a referenced file
+    /// — a key guessed from an incomplete URI names an object that may not be the
+    /// referenced one, and a referenced file missing from the set is a deleted
+    /// file. The last two cases are why the check is on the parsed key rather
+    /// than the input string: both are non-empty strings that normalise to no key.
     #[test]
-    fn parse_object_key_rejects_a_scheme_less_path() {
-        // A bare, scheme-less path is not a valid absolute URI; the sweep must
-        // fail closed rather than silently mis-key a referenced file.
-        assert!(matches!(
-            parse_object_key("icegate/logs/data/f.parquet"),
-            Err(MaintainError::Storage(_))
-        ));
+    fn a_uri_missing_any_component_is_refused() {
+        for uri in [
+            "icegate/logs/data/f.parquet", // no scheme at all
+            "://warehouse/key",            // empty scheme
+            "s3://warehouse",              // no object under the authority
+            "s3:///key",                   // empty authority (a `file://` URI lands here too)
+            "s3://warehouse/",             // empty object key
+            "s3://warehouse//",            // object key of separators only
+        ] {
+            assert!(
+                matches!(parse_object_key(uri), Err(MaintainError::Storage(_))),
+                "must refuse {uri:?}"
+            );
+        }
+    }
+
+    /// The refusal names the component at fault, not just the URI: the sweep
+    /// stops here, and "malformed" alone does not tell an operator whether the
+    /// manifest is corrupt or the parser is too narrow.
+    #[test]
+    fn a_refusal_names_the_component_at_fault() {
+        let error = parse_object_key("s3://warehouse/").expect_err("an empty object key is refused");
+
+        assert!(
+            error.to_string().contains("empty object key"),
+            "the faulting component is not named: {error}"
+        );
     }
 
     fn referenced(keys: &[&str]) -> HashSet<ObjectPath> {

--- a/crates/icegate-maintain/src/gc/decide.rs
+++ b/crates/icegate-maintain/src/gc/decide.rs
@@ -4,7 +4,6 @@ use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
 use object_store::path::Path as ObjectPath;
-use url::Url;
 
 use crate::error::MaintainError;
 
@@ -12,23 +11,34 @@ use crate::error::MaintainError;
 ///
 /// Iceberg metadata records absolute URIs (`s3://bucket/icegate/logs/data/f.parquet`),
 /// while an object-store `list` yields bucket-relative keys
-/// (`icegate/logs/data/f.parquet`). Parsing the URI and taking its path component
-/// places both in the same key space, so the sweep can compare them directly
-/// (both as [`ObjectPath`], the type `list` already returns).
+/// (`icegate/logs/data/f.parquet`). Dropping the scheme and authority places both
+/// in the same key space, so the sweep can compare them directly (both as
+/// [`ObjectPath`], the type `list` already returns).
+///
+/// The strip is textual, and the remainder is keyed through [`ObjectPath::from`]
+/// — the same constructor a listed key arrives through — because the two must
+/// normalise one object identically or the sweep deletes a live file. What
+/// forbids percent-decoding here is that the escapes are not transport encoding:
+/// Iceberg escapes a partition value into the path it then writes to, so a
+/// `tenant_id` of `a:b` becomes the literal key `tenant_id=a%3Ab` and `%3A` is
+/// three characters of the object's name. Decoding it invents a key that no
+/// object has, and the miss reads as "unreferenced".
 ///
 /// # Errors
 ///
-/// Returns [`MaintainError::Storage`] if `uri` is not a valid absolute URL or its
-/// path is not a valid object key. Callers MUST treat this as fail-closed (delete
+/// Returns [`MaintainError::Storage`] if `uri` carries no `scheme://` or names no
+/// object under its authority. Callers MUST treat this as fail-closed (delete
 /// nothing): an unparseable referenced path could otherwise drop a live file.
 pub(crate) fn parse_object_key(uri: &str) -> Result<ObjectPath, MaintainError> {
-    let url =
-        Url::parse(uri).map_err(|e| MaintainError::Storage(format!("gc: malformed referenced URI '{uri}': {e}")))?;
-    // `url.path()` is the bucket-relative path with the scheme and authority
-    // (`s3://bucket`) already removed; `from_url_path` percent-decodes and
-    // validates it into an object key.
-    ObjectPath::from_url_path(url.path())
-        .map_err(|e| MaintainError::Storage(format!("gc: malformed referenced key '{uri}': {e}")))
+    let authority_and_key = uri
+        .split_once("://")
+        .map(|(_scheme, rest)| rest)
+        .ok_or_else(|| MaintainError::Storage(format!("gc: malformed referenced URI '{uri}': no scheme")))?;
+    let key = authority_and_key
+        .split_once('/')
+        .map(|(_authority, key)| key)
+        .ok_or_else(|| MaintainError::Storage(format!("gc: referenced URI '{uri}' names no object")))?;
+    Ok(ObjectPath::from(key))
 }
 
 /// Whether a swept object is a data file or an Iceberg metadata file.
@@ -117,6 +127,44 @@ mod tests {
             parse_object_key("s3://warehouse/icegate/logs/data/f.parquet").unwrap().as_ref(),
             "icegate/logs/data/f.parquet"
         );
+    }
+
+    /// The referenced set and the object listing MUST agree on the key of one
+    /// object. Iceberg percent-escapes partition values into the data-file path
+    /// (`form_urlencoded`, so a tenant id's `:` becomes `%3A`), while a listed
+    /// key reaches the sweep through `object_store`'s `Path`, whose encode set
+    /// contains `%`. The two therefore normalise the same object differently
+    /// unless the sweep keys both sides the same way -- and a disagreement here
+    /// deletes a live file, because the delete path decodes back to the real key.
+    #[test]
+    fn an_escaped_partition_value_keys_the_same_on_both_sides() {
+        // What Iceberg records in the manifest for a tenant id holding a colon.
+        let uri = "s3://warehouse/icegate/logs/data/tenant_id=a%3Ab/timestamp_day=2026-09-09/f.parquet";
+        // What `list` yields for that same object: the raw key, keyed through
+        // `Path::from` exactly as `object_store_opendal` does.
+        let listed = ObjectPath::from("icegate/logs/data/tenant_id=a%3Ab/timestamp_day=2026-09-09/f.parquet");
+
+        assert_eq!(
+            parse_object_key(uri).unwrap(),
+            listed,
+            "the referenced key and the listed key name the same object"
+        );
+    }
+
+    /// The consequence of the disagreement above, at the boundary that acts on
+    /// it: a live file of a colon-carrying tenant, old enough to be past the
+    /// grace period, must be kept.
+    #[test]
+    fn a_referenced_file_under_an_escaped_partition_is_kept() {
+        let uri = "s3://warehouse/icegate/logs/data/tenant_id=a%3Ab/timestamp_day=2026-09-09/f.parquet";
+        let set: HashSet<ObjectPath> = std::iter::once(parse_object_key(uri).unwrap()).collect();
+        let listed = ObjectPath::from("icegate/logs/data/tenant_id=a%3Ab/timestamp_day=2026-09-09/f.parquet");
+        let modified = Utc.timestamp_opt(1_000, 0).unwrap();
+        let cutoff = Utc.timestamp_opt(2_000, 0).unwrap();
+
+        let decision = Decision::classify(&listed, "icegate/logs", &set, modified, cutoff, true);
+
+        assert_eq!(decision, Decision::Referenced);
     }
 
     #[test]

--- a/crates/icegate-maintain/tests/common/mod.rs
+++ b/crates/icegate-maintain/tests/common/mod.rs
@@ -138,11 +138,20 @@ pub async fn list_all_object_keys(conn: &StorageConn) -> Vec<String> {
 /// laid out in the caller's order. The `body` column is `msg-<unique>` so every
 /// row is globally distinguishable.
 pub fn logs_batch(rows: &[(&str, i64)], unique_offset: usize) -> RecordBatch {
+    logs_batch_for_tenant(TENANT, rows, unique_offset)
+}
+
+/// [`logs_batch`] for a caller-chosen tenant.
+///
+/// `tenant_id` is an identity partition column, so it decides the partition
+/// directory Iceberg writes the file under — which is what a caller testing
+/// path escaping needs to vary.
+pub fn logs_batch_for_tenant(tenant_id: &str, rows: &[(&str, i64)], unique_offset: usize) -> RecordBatch {
     let iceberg_schema = logs_schema().unwrap();
     let arrow_schema = Arc::new(iceberg::arrow::schema_to_arrow_schema(&iceberg_schema).unwrap());
     let n = rows.len();
 
-    let tenant = StringArray::from(vec![TENANT; n]);
+    let tenant = StringArray::from(vec![tenant_id; n]);
     let service_name = StringArray::from(rows.iter().map(|(s, _)| Some(*s)).collect::<Vec<_>>());
     let ts: Vec<i64> = rows.iter().map(|(_, t)| *t).collect();
     let trace_vals: Vec<[u8; 16]> = (0..n).map(|i| [u8::try_from((unique_offset + i) % 256).unwrap(); 16]).collect();

--- a/crates/icegate-maintain/tests/gc_sweep_it.rs
+++ b/crates/icegate-maintain/tests/gc_sweep_it.rs
@@ -21,7 +21,7 @@ use arrow::record_batch::RecordBatch;
 use chrono::Utc;
 use common::{
     BUCKET_NAME, DAY_MICROS, StorageConn, build_operator_registry, build_s3_catalog, list_all_object_keys, logs_batch,
-    setup_object_store, write_one_file,
+    logs_batch_for_tenant, setup_object_store, write_one_file,
 };
 use futures::TryStreamExt;
 use iceberg::arrow::ArrowFileReader;
@@ -242,6 +242,74 @@ async fn gc_reclaims_unreferenced_files_and_keeps_live_ones() {
     let descriptor = icegate_common::merge::sort_key::SortColumnsDescriptor::logs().expect("logs descriptor");
     let rows = read_all_rows(&live_table, descriptor).await;
     assert!(!rows.is_empty(), "live rows must be intact");
+}
+
+/// The production incident this pins: a tenant id may hold a colon
+/// (`icegate_common::is_valid_tenant_id` admits one), and `tenant_id` is an
+/// identity partition value, so Iceberg escapes it into the data file's path and
+/// the object's real key holds `%3A`. The sweep must still recognise
+/// that file as referenced — it reaches the referenced set as a manifest URI and
+/// the listing as a raw key, and the two normalise identically only if neither
+/// side percent-decodes. When they disagreed, the sweep read a live file as an
+/// orphan and the delete path decoded back to the real key, so the file went.
+///
+/// The grace period is zero here on purpose: a live file must be kept because it
+/// is referenced, never because it is young.
+#[tokio::test]
+async fn gc_keeps_a_referenced_file_whose_partition_value_is_escaped() {
+    const COLON_TENANT: &str = "2q4mHrPd9kL:7xZa1vB3nQe";
+
+    let (_store, conn) = setup_object_store().await;
+    let catalog = Arc::new(build_s3_catalog(&conn));
+    let ident = create_logs_table(&catalog).await;
+
+    let live = write_one_file(
+        &catalog.load_table(&ident).await.unwrap(),
+        logs_batch_for_tenant(COLON_TENANT, &[("svc", DAY_MICROS)], 0),
+    )
+    .await;
+    fast_append_one(&catalog, &ident, live.clone()).await;
+
+    // Assert the premise rather than trusting it: the escape has to be in the
+    // key, or the test would pass without exercising the defect at all.
+    let keys = list_all_object_keys(&conn).await;
+    assert!(
+        keys.iter().any(|k| k.contains("tenant_id=2q4mHrPd9kL%3A7xZa1vB3nQe")),
+        "Iceberg must escape the colon into the object key: {keys:?}"
+    );
+    assert_eq!(count_under_segment(&keys, "data"), 1, "one live data file before sweep");
+
+    let dyn_catalog: Arc<dyn Catalog> = catalog.clone();
+    let operator_registry = build_operator_registry(&conn).await;
+    let summary = run_sweep(
+        &dyn_catalog,
+        &operator_registry,
+        TABLE,
+        &orphans_config(0, false, true),
+        Utc::now(),
+        &GcMetrics::new(),
+        &CancellationToken::new(),
+    )
+    .await
+    .expect("sweep succeeds");
+
+    assert_eq!(
+        summary.found_data, 0,
+        "the referenced file must not be classified as an orphan: {summary:?}"
+    );
+    assert_eq!(
+        count_under_segment(&list_all_object_keys(&conn).await, "data"),
+        1,
+        "the referenced data file must survive the sweep"
+    );
+
+    // And it is still readable through the table, not merely present.
+    let live_table = catalog.load_table(&ident).await.unwrap();
+    let descriptor = SortColumnsDescriptor::logs().expect("logs descriptor");
+    assert!(
+        !read_all_rows(&live_table, descriptor).await.is_empty(),
+        "live rows must be intact"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Normalize URI handling in garbage collection to prevent premature deletion of files with partition keys containing escaped characters (e.g., `%3A` for `:`). Added tests to confirm correctness. Removed redundant `url` crate dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cleanup handling for object paths containing escaped characters, such as colons in tenant or partition values.
  * Referenced data files with escaped path values are now correctly recognized, preserved, and remain readable during orphan cleanup.
  * Improved validation for storage paths that lack required URI or object-path information, preventing incorrect cleanup decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->